### PR TITLE
ci: add minimal permissions block to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds an explicit workflow-level `permissions: contents: read` block to `.github/workflows/ci.yml` (principle of least privilege).
- `.github/workflows/release.yml` already declares `contents: write` + `packages: write`; verified and left unchanged.

## Context
Fixes CodeQL alert #1 (rule `actions/missing-workflow-permissions`, CWE-275). Refs POM-176.

## Test plan
- [x] YAML validates: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); yaml.safe_load(open('.github/workflows/release.yml'))"`
- [ ] CI passes on this PR
- [ ] CodeQL alert #1 auto-closes after merge