### PR TITLE
fix(security): sanitize user-controlled path in tenant validation logs

### DIFF
--- a/src/Adapters/Compendium.Adapters.AspNetCore/Security/TenantValidationMiddleware.cs
+++ b/src/Adapters/Compendium.Adapters.AspNetCore/Security/TenantValidationMiddleware.cs
@@ -49,7 +49,7 @@ public sealed class TenantValidationMiddleware
         // Check if path is excluded
         if (IsExcludedPath(context.Request.Path))
         {
-            _logger.LogDebug("Path {Path} is excluded from tenant validation", context.Request.Path);
+            _logger.LogDebug("Path {Path} is excluded from tenant validation", SanitizeForLog(context.Request.Path.Value));
             await _next(context);
             return;
         }
@@ -65,7 +65,7 @@ public sealed class TenantValidationMiddleware
             _logger.LogWarning(
                 "Tenant validation failed: {Error}. Path: {Path}",
                 validationResult.Error.Message,
-                context.Request.Path);
+                SanitizeForLog(context.Request.Path.Value));
 
             await WriteErrorResponse(context, validationResult.Error.Message, StatusCodes.Status403Forbidden);
             return;
@@ -80,7 +80,7 @@ public sealed class TenantValidationMiddleware
 
             if (tenantResult.IsFailure || tenantResult.Value is null)
             {
-                _logger.LogWarning("Tenant {TenantId} not found or inactive", tenantId);
+                _logger.LogWarning("Tenant {TenantId} not found or inactive", SanitizeForLog(tenantId));
                 await WriteErrorResponse(
                     context,
                     TenantErrors.TenantNotFound(tenantId).Message,
@@ -90,7 +90,7 @@ public sealed class TenantValidationMiddleware
 
             if (!tenantResult.Value.IsActive)
             {
-                _logger.LogWarning("Tenant {TenantId} is not active", tenantId);
+                _logger.LogWarning("Tenant {TenantId} is not active", SanitizeForLog(tenantId));
                 await WriteErrorResponse(
                     context,
                     TenantErrors.TenantAccessDenied(tenantId).Message,
@@ -203,6 +203,13 @@ public sealed class TenantValidationMiddleware
 
         return _options.ExcludedPaths.Any(excluded =>
             pathValue.StartsWith(excluded, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+        return value.Replace("\r", "_").Replace("\n", "_").Replace("\t", "_");
     }
 
     private static async Task WriteErrorResponse(HttpContext context, string message, int statusCode)


### PR DESCRIPTION
## Summary
- Adds `SanitizeForLog` helper in `TenantValidationMiddleware` that strips CR/LF/tab from untrusted strings before they reach the logger.
- Wraps `context.Request.Path.Value` at the excluded-path debug log and the tenant-validation-failed warning.
- Also sanitizes `tenantId` in the two "tenant not found / not active" warnings, since that value originates from header / subdomain / JWT claim.

Fixes CodeQL `cs/log-forging` (CWE-117) alerts #2 and #3.

Refs POM-175.

## Test plan
- [x] `dotnet build Compendium.sln -c Release` — 0 errors, no new warnings.
- [ ] CodeQL rerun on this branch clears alerts #2 and #3.