### PR TITLE
docs: 4 concept pages (event sourcing, hexagonal, Result, multi-tenancy)

### DIFF
--- a/docs/concepts/event-sourcing.md
+++ b/docs/concepts/event-sourcing.md
@@ -1,5 +1,166 @@
 # Event Sourcing
 
-> Coming soon — tracked in [POM-183](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-183).
+Compendium treats the **event log as the source of truth**. Aggregates do not persist their *current state* — they persist the sequence of facts (events) that produced it, and any state you observe is a derived projection over that log.
 
-Why event sourcing, append-only stores, aggregates vs projections, and snapshots in Compendium. See also [ADR 0005](../adr/0005-event-sourcing-vs-state.md).
+This page explains why we made that call, the moving parts you will encounter, and the small set of rules that keep the model honest. For the decision and trade-offs, see [ADR 0005 — Event sourcing over state-stored persistence](../adr/0005-event-sourcing-vs-state.md).
+
+## Why event sourcing
+
+The domains Compendium targets — multi-tenant SaaS, billing-aware workflows, platform engineering — share three pressures that bias us away from CRUD:
+
+- **Audit is not optional.** Compliance, ops, and customer support need to know *who* did *what*, *when*, and *in what order*. With CRUD, the previous value is overwritten on every save and you end up bolting on history tables that duplicate the schema badly. With an event log, the audit trail *is* the database — there is no separate "history" because there is no other history.
+- **Many read shapes per write.** A `Subscription` aggregate feeds a billing dashboard, a usage report, an admin audit view, and a tenant-facing activity feed — each with a different shape and different freshness tolerance. Event sourcing lets you build each as an independent projection, without coupling write-side schema changes to read-side queries.
+- **Time-travel and replay are routine.** Reproducing a bug ("what did this customer's account look like on April 3?"), backfilling a new feature into history, or recovering a corrupted read model is one `replay-from-position` away — not a database forensic exercise.
+- **Multi-tenancy fits naturally.** Streams are partitioned per aggregate, and aggregate IDs are tenant-scoped, so isolation is structural rather than enforced by every query.
+
+The cost — schema evolution, idempotent projections, eventual consistency on the read side — is real. But in CRUD systems we pay it anyway, piecemeal: audit tables, change-data-capture, ad-hoc history queries. Event sourcing pays it once, deliberately, with a single coherent model.
+
+## The model
+
+```mermaid
+flowchart LR
+    Cmd[Command] --> Agg[AggregateRoot&lt;TId&gt;]
+    Agg -- raises --> Ev[IDomainEvent]
+    Ev --> Store[(Event Store<br/>append-only)]
+    Store -- replays --> Proj1[Projection A<br/>read model]
+    Store -- replays --> Proj2[Projection B<br/>read model]
+    Store -- rehydrates --> Agg
+    Proj1 --> Q1[Query: dashboard]
+    Proj2 --> Q2[Query: report]
+```
+
+The flow is one-directional: **commands** mutate aggregates, aggregates emit **events**, events go to the **event store**, and **projections** asynchronously derive read models from the event stream. Aggregates are rehydrated for the next command by replaying their stream (with optional snapshots as a performance optimisation, never as the source of truth).
+
+## Concepts
+
+### `IDomainEvent`
+
+A domain event is an immutable record of something that happened. The interface is small on purpose — five fields the framework needs in order to position, version, and correlate events:
+
+```csharp
+public interface IDomainEvent
+{
+    Guid EventId { get; }
+    string AggregateId { get; }
+    string AggregateType { get; }
+    DateTimeOffset OccurredOn { get; }
+    long AggregateVersion { get; }
+    int EventVersion { get; }
+}
+```
+
+Source: [`src/Core/Compendium.Core/Domain/Events/IDomainEvent.cs#L14-L47`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Core/Compendium.Core/Domain/Events/IDomainEvent.cs#L14-L47).
+
+`EventVersion` is what makes schema evolution survivable: when the shape of an event changes, you bump the version and register an upcaster in `Compendium.Core.EventSourcing` so old streams keep replaying cleanly.
+
+### `AggregateRoot<TId>`
+
+Aggregates are the only place commands turn into events. The base class enforces three invariants: events are deduplicated by `EventId`, mutations bump the version (for optimistic concurrency), and the uncommitted-event buffer is drained atomically when the repository persists:
+
+```csharp
+protected void AddDomainEvent(IDomainEvent domainEvent)
+{
+    if (_disposed)
+    {
+        throw new ObjectDisposedException(nameof(AggregateRoot<TId>));
+    }
+
+    ArgumentNullException.ThrowIfNull(domainEvent);
+
+    var eventHash = ComputeEventHash(domainEvent);
+
+    _lockingStrategy.ExecuteWrite(() =>
+    {
+        if (_eventHashes.Add(eventHash))
+        {
+            _domainEvents.Add(domainEvent);
+        }
+    });
+}
+```
+
+Source: [`src/Core/Compendium.Core/Domain/Primitives/AggregateRoot.cs#L65-L83`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Core/Compendium.Core/Domain/Primitives/AggregateRoot.cs#L65-L83).
+
+A typical command-handling method looks like this — check invariants, mutate, raise the event, bump the version:
+
+```csharp
+public class Order : AggregateRoot<OrderId>
+{
+    public void PlaceOrder()
+    {
+        CheckRule(new OrderMustHaveItemsRule(Items));
+
+        Status = OrderStatus.Placed;
+        AddDomainEvent(new OrderPlacedEvent(Id, CustomerId, TotalAmount));
+        IncrementVersion();
+    }
+}
+```
+
+The aggregate never writes to the store directly. The repository drains uncommitted events (`GetUncommittedEvents`) and appends them to the `IEventStore` with the `expectedVersion` it loaded at, which is how optimistic concurrency is enforced.
+
+### Idempotent projections
+
+Projections are read models built by folding events into a derived shape. They must be **idempotent** — replayed from position 0 they reproduce the same state, and re-applying an event already seen is a no-op or a deterministic overwrite. The `IProjection<TEvent>` interface keeps that contract small:
+
+```csharp
+public interface IProjection<in TEvent> : IProjection
+    where TEvent : IDomainEvent
+{
+    Task ApplyAsync(TEvent @event, EventMetadata metadata, CancellationToken cancellationToken = default);
+}
+```
+
+Source: [`src/Infrastructure/Compendium.Infrastructure/Projections/IProjection.cs#L37-L48`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Infrastructure/Compendium.Infrastructure/Projections/IProjection.cs#L37-L48).
+
+The example `OrderSummaryProjection` ships in `Compendium.Infrastructure.Projections.Examples` and shows the typical pattern: maintain a dictionary keyed by aggregate id, overwrite-on-create, mutate-on-subsequent-events:
+
+```csharp
+public Task ApplyAsync(OrderPlacedEvent @event, EventMetadata metadata, CancellationToken cancellationToken = default)
+{
+    _summaries[@event.OrderId] = new OrderSummary
+    {
+        OrderId = @event.OrderId,
+        CustomerId = @event.CustomerId,
+        Total = @event.Total,
+        Status = OrderStatus.Placed,
+        PlacedAt = @event.OccurredOn.DateTime,
+        TenantId = metadata.TenantId,
+        ItemCount = @event.Items?.Count ?? 0
+    };
+
+    return Task.CompletedTask;
+}
+```
+
+Source: [`src/Infrastructure/Compendium.Infrastructure/Projections/Examples/OrderProjections.cs#L29-L43`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Infrastructure/Compendium.Infrastructure/Projections/Examples/OrderProjections.cs#L29-L43).
+
+The projection manager (`EnhancedProjectionManager`) tracks a checkpoint per projection so live processing resumes where it left off, and rebuilds run from position 0 against a fresh state.
+
+### Snapshots
+
+Snapshots are a cache, not a checkpoint. For long-lived aggregates (thousands of events) we periodically capture state to avoid replaying from scratch on rehydration. The contract: an aggregate must always be reconstructible from events alone. If a snapshot is corrupted or missing, the framework replays from the log — never refuses to load.
+
+## Rules of the model
+
+A few invariants are easy to drift from and worth naming explicitly:
+
+1. **Events are immutable, past-tense facts.** `OrderPlaced`, not `PlaceOrder`. Once written, an event is never edited; corrections are *new* events (`OrderCancelled`, `OrderAmountCorrected`).
+2. **Only aggregates emit events.** Services and adapters call into aggregates; they don't fabricate events on the side. This keeps the audit trail honest.
+3. **Projections derive, never mutate the log.** A projection that needs to "fix history" is a sign the wrong layer is doing the work — emit a corrective event from the aggregate instead.
+4. **`expectedVersion` is non-optional.** Append calls assert the version they read at; concurrency conflicts surface as errors, not silent overwrites.
+
+## Where to look in the code
+
+- Aggregate base class: [`src/Core/Compendium.Core/Domain/Primitives/AggregateRoot.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Core/Compendium.Core/Domain/Primitives/AggregateRoot.cs)
+- Event interface and base: `src/Core/Compendium.Core/Domain/Events/`
+- Event store contract: [`src/Abstractions/Compendium.Abstractions/EventSourcing/IEventStore.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Abstractions/Compendium.Abstractions/EventSourcing/IEventStore.cs)
+- Projection plumbing: [`src/Infrastructure/Compendium.Infrastructure/Projections/`](https://github.com/sassy-solutions/compendium/tree/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Infrastructure/Compendium.Infrastructure/Projections)
+- PostgreSQL event store adapter: `src/Adapters/Compendium.Adapters.PostgreSQL/EventStore/`
+
+## Related
+
+- [ADR 0005 — Event sourcing over state-stored persistence](../adr/0005-event-sourcing-vs-state.md) — the decision and the trade-offs
+- [Result Pattern](result-pattern.md) — every event-store operation returns `Result<T>`; failures are values, not exceptions
+- [Hexagonal Architecture](hexagonal-architecture.md) — why the event store is a port, with PostgreSQL as one adapter
+- [Multi-tenancy](multi-tenancy.md) — how tenant context flows through events and projections

--- a/docs/concepts/hexagonal-architecture.md
+++ b/docs/concepts/hexagonal-architecture.md
@@ -1,5 +1,188 @@
 # Hexagonal Architecture
 
-> Coming soon — tracked in [POM-183](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-183).
+Compendium is organised as a hexagon: a **dependency-free domain Core** at the centre, an **Application** layer that orchestrates use cases, and **Adapters** at the edges that translate between the outside world and the Core's contracts. Adapters depend on the Core; the Core depends on nothing.
 
-Core / Application / Adapters, ports vs adapters, why Compendium keeps Core dependency-free. See also [ADR 0002](../adr/0002-hexagonal-architecture.md) and [ADR 0003](../adr/0003-zero-dep-core.md).
+This shape — Alistair Cockburn's "ports and adapters" — is the structural commitment that makes the rest of the framework's choices viable. Without it, "swappable adapters" and "testable in isolation" become aspirations rather than properties of the code.
+
+For the rationale, see [ADR 0002 — Hexagonal architecture](../adr/0002-hexagonal-architecture.md) and [ADR 0003 — Zero-dependency Core](../adr/0003-zero-dep-core.md).
+
+## Why hexagonal
+
+Three forces drive the choice:
+
+- **The Core has to outlive its infrastructure.** Database engines, identity providers, billing platforms, and message brokers all change on different cycles. If business rules live in the same project as a Postgres driver, every infra change drags the domain through compilation, code review, and regression testing. Ports keep the domain stable while adapters churn.
+- **Tests are only fast and trustworthy if they can avoid I/O.** A pure-domain test boots in milliseconds, has no flakiness, and survives infra outages. That is only possible when the domain has *zero* infrastructure references — not "mocked" infrastructure, *no* infrastructure.
+- **Adapter swaps must be a packaging decision, not a rewrite.** Today Stripe, tomorrow LemonSqueezy, the day after Paddle. The Core sees `IBillingService`; the application picks the adapter at composition time. No `if (provider == "stripe")` switches in domain code.
+
+## The shape
+
+```mermaid
+flowchart LR
+    subgraph Outside[" "]
+      direction LR
+      HTTP[HTTP / ASP.NET Core]
+      DB[(PostgreSQL)]
+      Stripe[Stripe API]
+      Zitadel[Zitadel]
+    end
+
+    subgraph Adapters["Adapters (implementations)"]
+      AspNet[Compendium.Adapters.AspNetCore]
+      Pg[Compendium.Adapters.PostgreSQL]
+      StripeAdapter[Compendium.Adapters.Stripe]
+      Identity[Compendium.Adapters.Zitadel]
+    end
+
+    subgraph App["Application (use cases / handlers)"]
+      Handlers[Command &amp; Query Handlers]
+    end
+
+    subgraph Ports["Ports (interfaces in Abstractions)"]
+      IBilling[IBillingService]
+      IEventStore[IEventStore]
+      IRepo[IRepository&lt;T&gt;]
+    end
+
+    subgraph Core["Core (Compendium.Core — zero deps)"]
+      Domain[Aggregates / Events / Value Objects]
+    end
+
+    HTTP --> AspNet
+    DB --> Pg
+    Stripe --> StripeAdapter
+    Zitadel --> Identity
+
+    AspNet --> Handlers
+    Handlers --> Domain
+    Handlers -.uses.-> Ports
+
+    Pg -.implements.-> IEventStore
+    StripeAdapter -.implements.-> IBilling
+```
+
+Reading the diagram: requests flow inward (HTTP → adapter → application → domain), and the domain talks to the outside world only through ports it owns. The arrows from adapters to ports are *implementation* arrows — adapters depend on the abstractions, not the other way around. This is the Dependency Inversion Principle made structural.
+
+## Layer rules
+
+The rules are simple and enforced by project references in `Compendium.sln`:
+
+| Layer | Project prefix | Allowed dependencies |
+|---|---|---|
+| Core | `Compendium.Core` | .NET BCL only |
+| Abstractions | `Compendium.Abstractions.*` | Core |
+| Application | `Compendium.Application` | Core, Abstractions |
+| Infrastructure | `Compendium.Infrastructure` | Core, Abstractions |
+| Adapters | `Compendium.Adapters.*` | Core, Abstractions, Infrastructure (sometimes), and the *one* third-party SDK they wrap |
+| Multitenancy | `Compendium.Multitenancy` | Core, Abstractions |
+
+If a Core class needs `Microsoft.Extensions.DependencyInjection` or `System.Text.Json.JsonSerializerOptions`, it does not belong in Core. That rule is the entire reason ports exist.
+
+## Ports: interfaces in `Abstractions`
+
+A port is an interface the Core needs but does not implement. We keep ports in `Compendium.Abstractions.*` projects, grouped by capability — billing, identity, email, AI, persistence — so consumers reference only the ports they actually use.
+
+`IBillingService` is a representative example. The Core (or, more often, the Application layer) needs "create a checkout session, look up a customer, generate a portal URL" — but has no opinion on which provider does that work:
+
+```csharp
+public interface IBillingService
+{
+    Task<Result<CheckoutSession>> CreateCheckoutSessionAsync(CreateCheckoutRequest request, CancellationToken cancellationToken = default);
+
+    Task<Result<BillingCustomer>> GetCustomerAsync(string customerId, CancellationToken cancellationToken = default);
+
+    Task<Result<BillingCustomer>> GetCustomerByEmailAsync(string email, CancellationToken cancellationToken = default);
+
+    Task<Result<BillingCustomer>> UpsertCustomerAsync(UpsertCustomerRequest request, CancellationToken cancellationToken = default);
+
+    Task<Result<string>> CreateCustomerPortalUrlAsync(string customerId, string? returnUrl = null, CancellationToken cancellationToken = default);
+}
+```
+
+Source: [`src/Abstractions/Compendium.Abstractions.Billing/IBillingService.cs#L17-L59`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Abstractions/Compendium.Abstractions.Billing/IBillingService.cs#L17-L59).
+
+Two things to notice:
+
+1. **No provider types leak.** No `Stripe.Customer`, no `Stripe.Checkout.Session`. The port speaks the domain's vocabulary (`BillingCustomer`, `CheckoutSession`) and adapters translate.
+2. **Every fallible call returns `Result<T>`.** Network failures, validation errors, and not-found are values; the Core never has to catch a `StripeException`. See [Result Pattern](result-pattern.md).
+
+## Adapters: implementations at the edge
+
+An adapter is the only place where a third-party SDK is allowed. `StripeBillingService` lives in `Compendium.Adapters.Stripe`, references `Stripe.net`, and translates between `Stripe.*` types and the port's domain types:
+
+```csharp
+public async Task<Result<CheckoutSession>> CreateCheckoutSessionAsync(
+    CreateCheckoutRequest request,
+    CancellationToken cancellationToken = default)
+{
+    ArgumentNullException.ThrowIfNull(request);
+
+    try
+    {
+        var opts = new SessionCreateOptions
+        {
+            Mode = "subscription",
+            LineItems = new List<SessionLineItemOptions>
+            {
+                new() { Price = request.VariantId, Quantity = 1 }
+            },
+            SuccessUrl = request.SuccessUrl,
+            CancelUrl = request.CancelUrl,
+            CustomerEmail = request.Email,
+            Metadata = ToMetadata(request.CustomData, request.UserId)
+        };
+
+        var service = new SessionService();
+        var session = await service.CreateAsync(opts, cancellationToken: cancellationToken);
+
+        return Result.Success(StripeMapper.ToCheckoutSession(session));
+    }
+    catch (StripeException ex)
+    {
+        _logger.LogError(ex, "Stripe checkout session creation failed: {Message}", ex.Message);
+        return Result.Failure<CheckoutSession>(
+            Error.Failure("Billing.Stripe.CheckoutFailed", ex.Message));
+    }
+}
+```
+
+Source: [`src/Adapters/Compendium.Adapters.Stripe/Services/StripeBillingService.cs#L39-L83`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Adapters/Compendium.Adapters.Stripe/Services/StripeBillingService.cs#L39-L83).
+
+Three patterns to notice — they recur in every adapter:
+
+- **Catch SDK exceptions at the boundary, return `Result.Failure(Error)`.** The Core does not see `StripeException`; the Application layer sees a typed `Error` it can branch on.
+- **Map provider types to domain types.** `StripeMapper.ToCheckoutSession(session)` is the seam. If Stripe changes its model, the change stops at the mapper.
+- **`internal sealed`.** Adapters are wired through DI extensions (`AddStripeBilling(...)`); the type itself is not part of the public API.
+
+The same shape repeats across `Compendium.Adapters.LemonSqueezy`, `Compendium.Adapters.PostgreSQL`, `Compendium.Adapters.Zitadel`, and so on. Swapping providers is a `services.AddStripeBilling(...)` → `services.AddLemonSqueezyBilling(...)` change at composition time.
+
+## The "zero-dep Core" rule
+
+The Core's `csproj` references **nothing** beyond the .NET BCL. No `Microsoft.Extensions.*`, no JSON library, no logging abstraction, no MediatR, no DI container. The discipline pays off in three ways:
+
+1. **Tests are pure.** A test against an aggregate boots no host, opens no connection, and runs in microseconds.
+2. **Versioning is decoupled.** A breaking change in `Microsoft.Extensions.Logging.Abstractions` cannot force a Core release.
+3. **The boundary is obvious.** When a contributor proposes adding a dependency to Core, the discussion is structural, not stylistic — the rule is "no", and the workaround is "introduce a port."
+
+ADR 0003 documents the rule and the exceptions (which are essentially: BCL only, with `System.Text.Json` allowed *only* in the secure event deserialiser because the alternative is unsafe).
+
+## What this buys you
+
+- **Replaceable infrastructure.** Today's PostgreSQL event store can become tomorrow's EventStoreDB without touching aggregates.
+- **Honest tests.** Domain tests don't need fixtures; integration tests target adapters specifically.
+- **Independent release cadence.** The Core and an adapter version separately because they *are* separate.
+- **A clean conversation about dependencies.** "Where does this go?" has a structural answer, not a taste-based one.
+
+## Where to look in the code
+
+- Solution layout: [`Compendium.sln`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/Compendium.sln)
+- Core (zero-dep): [`src/Core/Compendium.Core/`](https://github.com/sassy-solutions/compendium/tree/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Core/Compendium.Core)
+- Ports: [`src/Abstractions/`](https://github.com/sassy-solutions/compendium/tree/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Abstractions)
+- Adapters: [`src/Adapters/`](https://github.com/sassy-solutions/compendium/tree/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Adapters)
+
+## Related
+
+- [ADR 0002 — Hexagonal architecture](../adr/0002-hexagonal-architecture.md)
+- [ADR 0003 — Zero-dependency Core](../adr/0003-zero-dep-core.md)
+- [Result Pattern](result-pattern.md) — the contract every port uses for failures
+- [Event Sourcing](event-sourcing.md) — `IEventStore` is the canonical example of a port
+- [Multi-tenancy](multi-tenancy.md) — how the tenant context port threads through adapters

--- a/docs/concepts/multi-tenancy.md
+++ b/docs/concepts/multi-tenancy.md
@@ -1,5 +1,226 @@
 # Multi-tenancy
 
-> Coming soon — tracked in [POM-183](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-183).
+Compendium is **SaaS-first**: every operation runs in the context of a tenant, tenant isolation is enforced at the infrastructure layer (not just by application-level filters), and a request that can't be confidently attributed to one tenant is rejected before it touches a handler.
 
-`TenantContext`, multi-source resolution (header / subdomain / JWT), and consistency validation. See also [ADR 0004](../adr/0004-multi-tenancy-strategy.md).
+This page explains how a request becomes a tenant-scoped execution context, how Compendium reconciles tenant identity from multiple HTTP-level signals, and which isolation strategy fits which workload. For the decision, see [ADR 0004 — Multi-tenancy strategy](../adr/0004-multi-tenancy-strategy.md).
+
+## Why infra-level isolation
+
+The tempting design is "just add a `WHERE tenant_id = @id` to every query." It collapses for three reasons:
+
+- **One missed filter is a data leak.** New endpoints, new join tables, new background jobs, a new ORM developer — every change is a chance to forget. Defence in depth at the infra layer (row-level security, schema-per-tenant, or distinct databases) makes "I forgot the filter" a 0-row result instead of a cross-tenant breach.
+- **Tenant identity comes from multiple sources.** A header, a subdomain, and a JWT claim can all carry a tenant ID, and they need to *agree*. Reconciling them in every controller is duplicated, error-prone, and easy to bypass.
+- **Tenant context has to flow.** The aggregate, the event, the projection, the outgoing HTTP call to a downstream service — they all need to know which tenant they're acting on behalf of, without every method threading a `tenantId` parameter.
+
+Compendium's answer is a small set of components: a `TenantContext` that flows via `AsyncLocal`, a middleware that resolves and validates tenant identity at the edge, and a `TenantIsolation` primitive that wraps connection-string-level scoping for adapters.
+
+## The flow
+
+```mermaid
+flowchart TB
+    Req[HTTP Request]
+    Req --> MW[TenantValidationMiddleware]
+    MW --> Sources{Extract tenant ID from sources}
+    Sources --> H[Header: X-Tenant-ID]
+    Sources --> S[Subdomain: acme.app.example.com]
+    Sources --> J[JWT claim: tenant_id / tid / org_id]
+    H --> V[ITenantConsistencyValidator]
+    S --> V
+    J --> V
+    V -->|consistent| Store[ITenantStore.GetByIdAsync]
+    V -->|mismatch / missing| Reject[403 / 404 response]
+    Store -->|active tenant| Ctx[TenantContext.SetTenant]
+    Store -->|not found / inactive| Reject
+    Ctx --> Pipeline[Application pipeline<br/>handlers, repos, adapters]
+    Pipeline --> Clear[finally: clear context]
+```
+
+A request only reaches a handler if (a) at least one source supplied a tenant ID, (b) all supplied sources agree, and (c) the resolved tenant exists and is active. Anything else is a 4xx at the edge.
+
+## Tenant sources
+
+Three sources, each appropriate for a different access pattern:
+
+| Source | Where | Typical use |
+|---|---|---|
+| HTTP header | `X-Tenant-ID: acme` | Service-to-service calls, internal admin tools, programmatic API clients |
+| Subdomain | `acme.app.example.com` | Browser-based SaaS — tenant is part of the user's URL |
+| JWT claim | `tenant_id` / `tid` / `org_id` / `urn:zitadel:iam:org:id` | Authenticated users — tenant is part of the identity token |
+
+In practice you usually have *two* sources (e.g. subdomain + JWT). The validator's job is to make sure they don't disagree.
+
+## Consistency validation
+
+`TenantValidationMiddleware` extracts every available source and hands them to `ITenantConsistencyValidator`. The result is `Result<string>` — either the resolved tenant ID or a typed error:
+
+```csharp
+public Result<string> Validate(TenantSourceIdentifiers sources)
+{
+    ArgumentNullException.ThrowIfNull(sources);
+
+    if (sources.SourceCount == 0)
+    {
+        if (_options.RequireAtLeastOneSource)
+        {
+            _logger.LogWarning("No tenant identifier found in any source");
+            return Result.Failure<string>(TenantErrors.NoTenantIdentifier());
+        }
+
+        return Result.Success(string.Empty);
+    }
+
+    if (_options.MinimumRequiredSources > 0 && sources.SourceCount < _options.MinimumRequiredSources)
+    {
+        return Result.Failure<string>(TenantErrors.InsufficientSources(
+            _options.MinimumRequiredSources,
+            sources.SourceCount));
+    }
+
+    if (!sources.AreConsistent)
+    {
+        _logger.LogWarning(
+            "Tenant ID mismatch detected. Header: {Header}, Subdomain: {Subdomain}, JWT: {Jwt}",
+            sources.HeaderTenantId ?? "(none)",
+            sources.SubdomainTenantId ?? "(none)",
+            sources.JwtTenantId ?? "(none)");
+
+        return Result.Failure<string>(TenantErrors.TenantMismatch(
+            sources.HeaderTenantId,
+            sources.SubdomainTenantId,
+            sources.JwtTenantId));
+    }
+
+    var tenantId = sources.ResolvedTenantId!;
+    return Result.Success(tenantId);
+}
+```
+
+Source: [`src/Multitenancy/Compendium.Multitenancy/TenantConsistencyValidator.cs#L97-L147`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Multitenancy/Compendium.Multitenancy/TenantConsistencyValidator.cs#L97-L147).
+
+Three policy knobs on `TenantConsistencyOptions`:
+
+- `RequireAtLeastOneSource` — should anonymous (no-tenant) requests be allowed at all? Default `true`.
+- `MinimumRequiredSources` — for high-sensitivity APIs you can demand 2 or 3 agreeing sources (e.g. JWT *and* subdomain) to harden against a single compromised credential.
+- `ExcludedPaths` — health checks, metrics, and `.well-known` endpoints bypass tenant validation entirely.
+
+## The middleware
+
+`TenantValidationMiddleware` (in `Compendium.Adapters.AspNetCore`) is the single edge component that translates HTTP into a tenant-scoped pipeline:
+
+```csharp
+public async Task InvokeAsync(
+    HttpContext context,
+    ITenantConsistencyValidator validator,
+    ITenantStore tenantStore,
+    TenantContext tenantContext)
+{
+    if (IsExcludedPath(context.Request.Path))
+    {
+        await _next(context);
+        return;
+    }
+
+    var sources = ExtractTenantSources(context);
+    var validationResult = validator.Validate(sources);
+
+    if (validationResult.IsFailure)
+    {
+        await WriteErrorResponse(context, validationResult.Error.Message, StatusCodes.Status403Forbidden);
+        return;
+    }
+
+    var tenantId = validationResult.Value;
+
+    if (!string.IsNullOrEmpty(tenantId))
+    {
+        var tenantResult = await tenantStore.GetByIdAsync(tenantId, context.RequestAborted);
+
+        if (tenantResult.IsFailure || tenantResult.Value is null)
+        {
+            await WriteErrorResponse(context, TenantErrors.TenantNotFound(tenantId).Message, StatusCodes.Status404NotFound);
+            return;
+        }
+
+        if (!tenantResult.Value.IsActive)
+        {
+            await WriteErrorResponse(context, TenantErrors.TenantAccessDenied(tenantId).Message, StatusCodes.Status403Forbidden);
+            return;
+        }
+
+        tenantContext.SetTenant(tenantResult.Value);
+    }
+
+    try
+    {
+        await _next(context);
+    }
+    finally
+    {
+        tenantContext.SetTenant(null);
+    }
+}
+```
+
+Source: [`src/Adapters/Compendium.Adapters.AspNetCore/Security/TenantValidationMiddleware.cs#L43-L119`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Adapters/Compendium.Adapters.AspNetCore/Security/TenantValidationMiddleware.cs#L43-L119).
+
+The shape worth noticing:
+
+1. **Extract → Validate → Lookup → Set → Run → Clear.** No tenant context survives the request boundary; `finally` resets the `AsyncLocal` so a misconfigured worker can't leak state across requests.
+2. **Two layers of failure.** Inconsistent sources are `403 Forbidden` (caller is doing something wrong); active-but-missing or inactive tenant is `404 Not Found` / `403`.
+3. **The middleware is the *only* place tenant gets set.** Handlers and adapters consume `ITenantContext`; they never write it.
+
+## How tenant context flows
+
+`TenantContext` uses `AsyncLocal<TenantInfo?>`, which means it follows the `async`/`await` machinery automatically — handlers, repositories, projection processors, and outbound HTTP calls all see the same tenant without needing to thread it through arguments:
+
+```csharp
+public sealed class TenantContext : ITenantContext
+{
+    private readonly AsyncLocal<TenantInfo?> _currentTenant = new();
+
+    public string? TenantId => _currentTenant.Value?.Id;
+    public string? TenantName => _currentTenant.Value?.Name;
+    public TenantInfo? CurrentTenant => _currentTenant.Value;
+    public bool HasTenant => _currentTenant.Value is not null;
+
+    public void SetTenant(TenantInfo? tenant)
+    {
+        _currentTenant.Value = tenant;
+    }
+}
+```
+
+Source: [`src/Multitenancy/Compendium.Multitenancy/TenantContext.cs#L34-L66`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Multitenancy/Compendium.Multitenancy/TenantContext.cs#L34-L66).
+
+Two things that fall out of this:
+
+- **Outbound HTTP calls inherit the tenant.** `TenantPropagatingDelegatingHandler` (in `Compendium.Multitenancy.Http`) reads the current `ITenantContext` and adds `X-Tenant-ID` to outgoing requests, so service-to-service calls preserve scope without per-call boilerplate.
+- **Background work needs explicit scopes.** Hosted services and queue consumers don't have an inbound HTTP request to set context, so they must use `TenantScope` (a disposable that wraps a temporary `SetTenant`) before doing tenant work.
+
+## Isolation strategies
+
+ADR 0004 covers the trade-offs in depth; the short version is that Compendium supports three isolation levels and lets you pick per workload:
+
+| Strategy | Storage shape | Cost | Blast radius of a bug | When to use |
+|---|---|---|---|---|
+| **Database-per-tenant** | One physical DB per tenant | High (connection pools, migrations) | Smallest — bug only sees one tenant's DB | Regulated workloads, very large tenants, residency requirements |
+| **Schema-per-tenant** | One DB, schema per tenant | Medium (schema management at scale) | Schema-bounded — one tenant per connection | Mid-sized SaaS with moderate isolation needs |
+| **Row-level (RLS)** | Shared schema, `tenant_id` column + Postgres Row-Level Security | Low | RLS-enforced — even a missed `WHERE` clause is filtered by the database | Default for most SaaS — fast, cheap, defence-in-depth |
+
+Compendium's PostgreSQL adapter ships row-level helpers in `Compendium.Adapters.PostgreSQL.Security` (`RowLevelSecurityExtensions`) that set the `app.current_tenant` session variable from `ITenantContext` before each query. The application code keeps writing normal SQL; Postgres enforces the partition.
+
+## Where to look in the code
+
+- Tenant context: [`src/Multitenancy/Compendium.Multitenancy/TenantContext.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Multitenancy/Compendium.Multitenancy/TenantContext.cs)
+- Consistency validator: [`src/Multitenancy/Compendium.Multitenancy/TenantConsistencyValidator.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Multitenancy/Compendium.Multitenancy/TenantConsistencyValidator.cs)
+- ASP.NET Core middleware: [`src/Adapters/Compendium.Adapters.AspNetCore/Security/TenantValidationMiddleware.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Adapters/Compendium.Adapters.AspNetCore/Security/TenantValidationMiddleware.cs)
+- Outbound propagation: [`src/Multitenancy/Compendium.Multitenancy/Http/TenantPropagatingDelegatingHandler.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Multitenancy/Compendium.Multitenancy/Http/TenantPropagatingDelegatingHandler.cs)
+- Tenant isolation primitive: [`src/Multitenancy/Compendium.Multitenancy/TenantIsolation.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Multitenancy/Compendium.Multitenancy/TenantIsolation.cs)
+- Postgres row-level security wiring: [`src/Adapters/Compendium.Adapters.PostgreSQL/Security/RowLevelSecurityExtensions.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Adapters/Compendium.Adapters.PostgreSQL/Security/RowLevelSecurityExtensions.cs)
+
+## Related
+
+- [ADR 0004 — Multi-tenancy strategy](../adr/0004-multi-tenancy-strategy.md)
+- [Hexagonal Architecture](hexagonal-architecture.md) — `ITenantContext` and `ITenantStore` are ports; the middleware and store implementations are adapters
+- [Result Pattern](result-pattern.md) — tenant validation, lookup, and access-denied conditions are all returned as typed `Result`/`Error` rather than thrown
+- [Event Sourcing](event-sourcing.md) — events and projections carry `TenantId` in metadata so the audit trail is tenant-aware end-to-end

--- a/docs/concepts/result-pattern.md
+++ b/docs/concepts/result-pattern.md
@@ -1,5 +1,235 @@
-# Result Pattern
+# The Result Pattern
 
-> Coming soon — tracked in [POM-183](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-183).
+In Compendium, **errors are values, not exceptions**. Every fallible operation returns `Result` (no value) or `Result<T>` (with a value), and every failure carries a typed `Error`. Callers branch on `IsSuccess`, chain with `Map` / `Bind`, or destructure with `Match`. Exceptions exist for *bugs* (null arguments, disposed objects, programmer errors) — never for control flow.
 
-`Result<T>`, `Error`, and why Compendium does not use exceptions for control flow. See also [ADR 0001](../adr/0001-result-pattern.md).
+For the rationale, see [ADR 0001 — The Result pattern](../adr/0001-result-pattern.md).
+
+## Why no exceptions
+
+Exceptions are a fine tool for one job — *unwinding the stack when something is broken*. They are a poor tool for the job most application code is doing — *signalling that an expected, recoverable condition occurred and the caller should choose what to do next*.
+
+The case against exception-as-control-flow:
+
+- **Invisibility in the type system.** A method that `throws` looks identical to one that doesn't. The compiler can't tell you that you forgot to handle a `StripeException` — only production can. Result types put failure on the signature where it can't be missed.
+- **Cost on the hot path.** Throwing is expensive (stack capture, exception filters); on a request handling 10k events/minute it adds up. `Result` is a single allocation with no stack walk.
+- **Action-at-a-distance.** A `try`/`catch` ten frames away can swallow a domain error that should have been handled three frames up. Result types make the handler local and explicit.
+- **Bad ergonomics for known failure modes.** "Customer not found" isn't exceptional — it's an outcome. Returning `Result.Failure<BillingCustomer>(BillingErrors.CustomerNotFound(id))` says exactly what happened, with a code the API layer can map to `404`.
+
+What we do still throw on: programmer errors. Null arguments via `ArgumentNullException.ThrowIfNull`, accessing `.Value` on a failed result, using a disposed aggregate. These are bugs, and bugs should crash loudly in development and surface in observability in production.
+
+## The shape
+
+```mermaid
+flowchart LR
+    Op[Operation] -->|works| OK[Result.Success&lt;T&gt;<br/>IsSuccess = true<br/>Value = T]
+    Op -->|fails| Err[Result.Failure&lt;T&gt;<br/>IsFailure = true<br/>Error = Error]
+    OK --> Map[Map / Bind / Tap]
+    Err --> Match[Match / TapError]
+    Map --> Next[next operation]
+    Match --> Response[HTTP / log / retry]
+```
+
+Two states, mutually exclusive. The constructor enforces it: a successful result with an error throws, a failed result with `Error.None` throws.
+
+## The contract
+
+```csharp
+public class Result
+{
+    public bool IsSuccess { get; }
+    public bool IsFailure => !IsSuccess;
+    public Error Error { get; }
+
+    public static Result Success() { ... }
+    public static Result<TValue> Success<TValue>(TValue value) { ... }
+    public static Result Failure(Error error) { ... }
+    public static Result<TValue> Failure<TValue>(Error error) { ... }
+
+    public static Result Combine(params Result[] results) { ... }
+
+    public static implicit operator Result(Error error) { ... }
+}
+```
+
+Source: [`src/Core/Compendium.Core/Results/Result.cs#L14-L187`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Core/Compendium.Core/Results/Result.cs#L14-L187).
+
+The generic variant adds a `Value` property that *throws if you access it on a failure*. That's deliberate: forgetting to check `IsSuccess` is a bug, and it should fail fast in tests rather than silently propagate `default`.
+
+```csharp
+public sealed class Result<TValue> : Result
+{
+    public TValue Value
+    {
+        get
+        {
+            if (IsFailure)
+            {
+                throw new InvalidOperationException("Cannot access the value of a failed result.");
+            }
+
+            return _value!;
+        }
+    }
+
+    public static implicit operator Result<TValue>(TValue value) { ... }
+    public static implicit operator Result<TValue>(Error error) { ... }
+}
+```
+
+Source: [`src/Core/Compendium.Core/Results/Result.cs#L193-L252`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Core/Compendium.Core/Results/Result.cs#L193-L252).
+
+The implicit conversions are an ergonomic win: `return user;` produces `Result.Success(user)`, and `return BillingErrors.CustomerNotFound(id);` produces `Result.Failure<BillingCustomer>(...)`. No factory boilerplate at the call site.
+
+## `Error` as a value object
+
+`Error` is not a string, not an exception, and not an enum. It's a `ValueObject` with a code, a message, a typed category, and optional metadata:
+
+```csharp
+public sealed class Error : ValueObject
+{
+    public static readonly Error None = new(string.Empty, string.Empty, ErrorType.None);
+
+    public string Code { get; }      // e.g. "Billing.Stripe.CheckoutFailed"
+    public string Message { get; }
+    public ErrorType Type { get; }   // Validation | NotFound | Conflict | Forbidden | ...
+    public IReadOnlyDictionary<string, object> Metadata { get; }
+
+    public static Error Validation(string code, string message, ...) { ... }
+    public static Error NotFound(string code, string message, ...) { ... }
+    public static Error Conflict(string code, string message, ...) { ... }
+    public static Error Unauthorized(string code, string message, ...) { ... }
+    public static Error Forbidden(string code, string message, ...) { ... }
+}
+```
+
+Source: [`src/Core/Compendium.Core/Results/Error.cs#L16-L196`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Core/Compendium.Core/Results/Error.cs#L16-L196).
+
+`ErrorType` is the bridge to HTTP — adapters mapping a `Result` to an `IActionResult` look at `Type` (not `Code`) to pick `400`, `404`, `409`, `403`. `Code` is the stable identifier for logs, alerting, and i18n. `Metadata` carries field-level validation details, retry hints, etc.
+
+By convention, errors live as static factories on a per-bounded-context class — `BillingErrors.CustomerNotFound(id)`, `TenantErrors.TenantMismatch(...)`. That keeps codes consistent across the codebase and makes them grep-able.
+
+## Composition: `Map`, `Bind`, `Match`
+
+The point of values-over-exceptions is that *you can compose them*. The extension methods in `ResultExtensions` give you the standard functional toolkit:
+
+```csharp
+public static Result<TNewValue> Map<TValue, TNewValue>(this Result<TValue> result, Func<TValue, TNewValue> mapper)
+{
+    ArgumentNullException.ThrowIfNull(result);
+    ArgumentNullException.ThrowIfNull(mapper);
+
+    return result.IsSuccess
+        ? Result.Success(mapper(result.Value))
+        : Result.Failure<TNewValue>(result.Error);
+}
+
+public static Result<TNewValue> Bind<TValue, TNewValue>(this Result<TValue> result, Func<TValue, Result<TNewValue>> binder)
+{
+    ArgumentNullException.ThrowIfNull(result);
+    ArgumentNullException.ThrowIfNull(binder);
+
+    return result.IsSuccess
+        ? binder(result.Value)
+        : Result.Failure<TNewValue>(result.Error);
+}
+```
+
+Source: [`src/Core/Compendium.Core/Results/ResultExtensions.cs#L63-L89`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Core/Compendium.Core/Results/ResultExtensions.cs#L63-L89).
+
+A typical handler reads top-to-bottom as a pipeline, with errors short-circuiting at the first failure:
+
+```csharp
+public Task<Result<CheckoutUrl>> Handle(StartCheckout cmd, CancellationToken ct) =>
+    _users.GetByIdAsync(cmd.UserId, ct)
+        .BindAsync(user => _billing.UpsertCustomerAsync(new UpsertCustomerRequest { Email = user.Email }, ct))
+        .BindAsync(customer => _billing.CreateCheckoutSessionAsync(new CreateCheckoutRequest
+        {
+            VariantId = cmd.PriceId,
+            Email = customer.Email,
+            SuccessUrl = cmd.SuccessUrl,
+            CancelUrl = cmd.CancelUrl
+        }, ct))
+        .MapAsync(session => new CheckoutUrl(session.Url));
+```
+
+If any step fails, the rest is skipped and the original `Error` propagates. No `try`/`catch`, no early returns littering the body, no nullable-checking ceremony.
+
+For terminal handling (e.g. mapping to an HTTP response) use `Match`:
+
+```csharp
+return result.Match(
+    onSuccess: url => Results.Ok(new { url = url.Value }),
+    onFailure: err => err.Type switch
+    {
+        ErrorType.NotFound      => Results.NotFound(err),
+        ErrorType.Validation    => Results.BadRequest(err),
+        ErrorType.Unauthorized  => Results.Unauthorized(),
+        _                       => Results.Problem(err.Message)
+    });
+```
+
+## Anti-patterns
+
+A few mistakes recur often enough to be worth naming:
+
+### 1. Don't blindly wrap external exceptions in `Result`
+
+It's tempting to write a helper `Try(() => somethingThatThrows)` that catches everything and stuffs the message into an `Error`. Resist it.
+
+```csharp
+// Bad — losing the type and stack of every failure
+return Try(() => _stripeSdk.Charge(...));
+```
+
+The right shape: catch the *specific* exception types the SDK documents, map each to a *specific* `Error`, and let truly unexpected exceptions propagate (so they show up in your error tracker as bugs, not as `"General.Failure: Object reference not set..."`):
+
+```csharp
+// Good — narrow catches, semantically meaningful errors
+try
+{
+    var session = await _stripe.SessionService.CreateAsync(opts, ct);
+    return Result.Success(StripeMapper.ToCheckoutSession(session));
+}
+catch (StripeException ex) when (ex.StripeError?.Type == "card_error")
+{
+    return Result.Failure<CheckoutSession>(BillingErrors.PaymentDeclined(ex.Message));
+}
+catch (StripeException ex)
+{
+    _logger.LogError(ex, "Stripe checkout session creation failed");
+    return Result.Failure<CheckoutSession>(Error.Failure("Billing.Stripe.CheckoutFailed", ex.Message));
+}
+```
+
+This is exactly the pattern `StripeBillingService` uses. See [Hexagonal Architecture](hexagonal-architecture.md) for why this catch-and-translate happens at the adapter boundary.
+
+### 2. Don't throw inside `Bind` / `Map`
+
+If your mapper or binder can fail, return a `Result` from it — don't let it throw. A throwing function inside a `Bind` will propagate as a real exception and bypass all the failure-as-value plumbing the rest of the pipeline relies on.
+
+### 3. Don't access `.Value` without checking `IsSuccess`
+
+`result.Value` throws on failure. That's intentional — but it means `someResult.Value.SomeProp` is a code smell. Use `Map`, `Match`, or an explicit `if (result.IsFailure) return result.Error;`.
+
+### 4. Don't return `Result<Result<T>>`
+
+If you find yourself nesting, you wanted `Bind`, not `Map`. `Map` lifts a regular function (`T -> U`) over a `Result<T>`; `Bind` flattens a `Result`-returning function (`T -> Result<U>`).
+
+### 5. Don't use `string` errors
+
+The implicit conversion from `string` to `Error` exists for ergonomics in trivial cases, but a string error has no `Code`, no `Type`, and no `Metadata`. Production errors should always be constructed via `Error.Validation(...)`, `Error.NotFound(...)`, etc., or via a per-context factory like `BillingErrors`.
+
+## Where to look in the code
+
+- `Result` and `Result<T>`: [`src/Core/Compendium.Core/Results/Result.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Core/Compendium.Core/Results/Result.cs)
+- `Error` and `ErrorType`: [`src/Core/Compendium.Core/Results/Error.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Core/Compendium.Core/Results/Error.cs)
+- Functional combinators: [`src/Core/Compendium.Core/Results/ResultExtensions.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Core/Compendium.Core/Results/ResultExtensions.cs)
+- Real-world adapter usage: [`src/Adapters/Compendium.Adapters.Stripe/Services/StripeBillingService.cs`](https://github.com/sassy-solutions/compendium/blob/fe1ab5b7388a80f2d9b87bef9bcc543a6854be89/src/Adapters/Compendium.Adapters.Stripe/Services/StripeBillingService.cs)
+- Per-context error factories: search for `*Errors.cs` (e.g. `BillingErrors`, `TenantErrors`, `IdentityErrors`)
+
+## Related
+
+- [ADR 0001 — The Result pattern](../adr/0001-result-pattern.md)
+- [Hexagonal Architecture](hexagonal-architecture.md) — why ports return `Result<T>` and adapters do the catch-and-translate
+- [Event Sourcing](event-sourcing.md) — every event-store call returns `Result<T>`; concurrency conflicts are typed errors, not exceptions
+- [Multi-tenancy](multi-tenancy.md) — `ITenantConsistencyValidator` returns `Result<string>` for tenant validation

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,15 @@ Compendium distills years of building event-sourced SaaS into a small set of foc
 - Looking for a specific adapter? → [Adapters](adapters/aspnetcore.md)
 - Wondering what's next? → [Roadmap](roadmap.md)
 
+## Concepts
+
+The four pages below explain the framework's load-bearing ideas — read them in any order:
+
+- [Event Sourcing](concepts/event-sourcing.md) — append-only log as the source of truth, aggregates, projections, snapshots
+- [Hexagonal Architecture](concepts/hexagonal-architecture.md) — Core / Application / Adapters, ports vs adapters, the zero-dep Core rule
+- [Result Pattern](concepts/result-pattern.md) — `Result<T>` and `Error` instead of exceptions for control flow
+- [Multi-tenancy](concepts/multi-tenancy.md) — tenant context, multi-source resolution, isolation strategies
+
 ## Status
 
 Compendium is at **`v1.0.0-preview.1`**. APIs in `Compendium.Core` and `Compendium.Abstractions.*` are intended to be stable; adapter APIs may evolve based on production feedback. See [CHANGELOG](https://github.com/sassy-solutions/compendium/blob/main/CHANGELOG.md) for what has shipped.


### PR DESCRIPTION
## Summary

Replaces the four placeholder pages in `docs/concepts/` with real, pedagogical content (~3-4 minutes each, ~15 minutes total). Each page covers the *why*, the moving parts, and the rules that keep the model honest, with real code snippets pinned to the current `main` SHA.

- **`event-sourcing.md`** (166 lines) — append-only log as source of truth, `IDomainEvent`, `AggregateRoot<TId>`, idempotent projections, snapshots. Mermaid diagram of the command → aggregate → events → store → projections flow. Real snippets from `IDomainEvent`, `AggregateRoot.AddDomainEvent`, `IProjection<TEvent>`, `OrderSummaryProjection.ApplyAsync`.
- **`hexagonal-architecture.md`** (188 lines) — Core / Application / Adapters, ports vs adapters, the zero-dep Core rule, layer dependency table. Mermaid diagram of the hexagon with concrete adapter examples. Real snippets from `IBillingService` (port) and `StripeBillingService.CreateCheckoutSessionAsync` (adapter) showing the catch-and-translate pattern.
- **`result-pattern.md`** (235 lines) — `Result<T>`, `Error`, `ErrorType`, functional combinators (`Map`/`Bind`/`Match`), the case against exceptions, five anti-patterns. Mermaid state diagram. Real snippets from `Result.cs` (both base and generic), `Error.cs`, and `ResultExtensions.cs`.
- **`multi-tenancy.md`** (226 lines) — three tenant sources (header, subdomain, JWT), consistency validation, `AsyncLocal`-backed `TenantContext`, isolation strategies table (DB-per-tenant / schema-per-tenant / RLS). Mermaid flow of the validation pipeline. Real snippets from `TenantConsistencyValidator`, `TenantValidationMiddleware`, and `TenantContext`.

`docs/index.md` now lists all four concept pages directly under a "Concepts" section. The existing `docs/concepts/toc.yml` already pointed at the four files, so no TOC change was needed.

All GitHub permalinks pin to `fe1ab5b7388a80f2d9b87bef9bcc543a6854be89` (current `main` at PR open).

Closes POM-183.

## Test plan

- [ ] `Deploy Docs` workflow (`docs-deploy.yml`) builds without warnings on the four files
- [ ] Mermaid diagrams render in the modern DocFX template (verify in deployed `main` site)
- [ ] All ADR cross-links resolve (`../adr/0001-result-pattern.md` → `../adr/0005-event-sourcing-vs-state.md`)
- [ ] All cross-links between concept pages resolve
- [ ] All GitHub permalinks open at the highlighted line ranges