### PR TITLE
docs: how-to guides for 8 adapters

### DIFF
--- a/docs/adapters/aspnetcore.md
+++ b/docs/adapters/aspnetcore.md
@@ -1,5 +1,109 @@
 # Compendium.Adapters.AspNetCore
 
-> Coming soon — tracked in [POM-184](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-184).
+> ASP.NET Core integration: security headers, CORS, tenant validation middleware, and health checks.
 
-ASP.NET Core integration: tenant validation middleware, problem details, auth helpers.
+## Install
+
+```bash
+dotnet add package Compendium.Adapters.AspNetCore
+```
+
+## Configuration
+
+This adapter is configured primarily via DI extension methods rather than `appsettings.json`. There are no required configuration sections; defaults are tuned for either an API or a web app.
+
+### DI registration
+
+```csharp
+using Compendium.Adapters.AspNetCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Security headers (HSTS, CSP, X-Frame-Options, ...)
+builder.Services.AddCompendiumSecurityHeaders(options =>
+{
+    options.HstsMaxAgeSeconds = 31_536_000;
+    options.HstsIncludeSubDomains = true;
+    options.ContentSecurityPolicy = "default-src 'none'; frame-ancestors 'none'";
+});
+
+// CORS — strict allowlist
+builder.Services.AddCompendiumStrictCors(allowedOrigins: new[]
+{
+    "https://app.example.com",
+});
+
+// Tenant validation middleware (in-memory store for dev)
+builder.Services.AddTenantValidationWithInMemoryStore(
+    new TenantInfo("tenant-a", "Tenant A"),
+    new TenantInfo("tenant-b", "Tenant B"));
+
+// Health checks for PostgreSQL and Redis (pass null to skip a check)
+builder.Services.AddCompendiumHealthChecks(
+    postgresConnectionString: builder.Configuration.GetConnectionString("EventStore"),
+    redisConnectionMultiplexer: null);
+
+var app = builder.Build();
+
+app.UseCompendiumHsts();
+app.UseCompendiumSecurityHeaders();
+app.UseCompendiumCors();
+
+app.UseAuthentication();
+app.UseTenantValidation();
+app.UseAuthorization();
+
+app.MapCompendiumHealthChecks();
+```
+
+### `SecurityHeadersOptions`
+
+| Property | Default | Description |
+|---|---|---|
+| `EnableHsts` | `true` | Enable HTTP Strict Transport Security. |
+| `HstsMaxAgeSeconds` | `31_536_000` | HSTS `max-age` (1 year). |
+| `HstsIncludeSubDomains` | `true` | Include subdomains in HSTS. |
+| `HstsPreload` | `false` | Opt in to the HSTS preload list. |
+| `EnableNoSniff` | `true` | `X-Content-Type-Options: nosniff`. |
+| `EnableFrameOptions` | `true` | Emit `X-Frame-Options`. |
+| `FrameOptionsValue` | `"DENY"` | `DENY` or `SAMEORIGIN`. |
+| `EnableContentSecurityPolicy` | `true` | Emit `Content-Security-Policy`. |
+| `ContentSecurityPolicy` | `"default-src 'none'; frame-ancestors 'none'"` | CSP value (API-strict default). |
+| `EnablePermittedCrossDomainPolicies` | `true` | Emit `X-Permitted-Cross-Domain-Policies`. |
+| `EnableReferrerPolicy` | `true` | Emit `Referrer-Policy`. |
+| `ReferrerPolicyValue` | `"strict-origin-when-cross-origin"` | Referrer policy value. |
+| `EnablePermissionsPolicy` | `true` | Emit `Permissions-Policy`. |
+| `RemoveServerHeader` | `true` | Strip the `Server` response header. |
+| `RemoveXPoweredByHeader` | `true` | Strip the `X-Powered-By` response header. |
+
+The `TenantValidationMiddlewareOptions` and `TenantConsistencyOptions` types expose the knobs for the tenant pipeline; pass configuration actions to `AddTenantValidation` if you need non-default behavior.
+
+## Usage
+
+The middleware pipeline order matters: security headers and CORS go before authentication, tenant validation goes between authentication and authorization, and health checks are mapped on the endpoint router.
+
+```csharp
+app.UseCompendiumHsts();
+app.UseCompendiumSecurityHeaders();
+app.UseCompendiumCors();
+
+app.UseAuthentication();
+app.UseTenantValidation(); // populates TenantContext from claims/headers
+app.UseAuthorization();
+
+app.MapCompendiumHealthChecks(); // /health (liveness) + /health/ready (readiness)
+```
+
+`TenantContext` is the primary consumer-facing surface for the current tenant once validation has run; resolve it from DI in your handlers.
+
+## Gotchas
+
+- `UseTenantValidation()` must run **after** `UseAuthentication()` and **before** `UseAuthorization()`, otherwise the tenant claim is not available when policies execute.
+- `AddCompendiumSecurityHeaders` defaults to API-strict CSP (`default-src 'none'`). If you serve HTML, override `ContentSecurityPolicy` or your pages will fail to load assets.
+- `MapCompendiumHealthChecks` exposes `/health` (liveness, no checks) and `/health/ready` (readiness, filtered by the `ready` tag). Don't put either behind authentication if your orchestrator probes them anonymously.
+- Health check registration is opt-in per dependency: pass `null` for `postgresConnectionString` or `redisConnectionMultiplexer` to skip it.
+
+## See also
+
+- [API Reference](../api/Compendium.Adapters.AspNetCore.html)
+- Sample app — coming via POM-182.

--- a/docs/adapters/lemonsqueezy.md
+++ b/docs/adapters/lemonsqueezy.md
@@ -1,5 +1,125 @@
 # Compendium.Adapters.LemonSqueezy
 
-> Coming soon — tracked in [POM-184](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-184).
+> LemonSqueezy billing adapter: subscriptions, license keys, customer portal, and webhook handling.
 
-LemonSqueezy billing adapter.
+## Install
+
+```bash
+dotnet add package Compendium.Adapters.LemonSqueezy
+```
+
+## Configuration
+
+`appsettings.json`:
+
+```json
+{
+  "LemonSqueezy": {
+    "ApiKey": "ls_...",
+    "StoreId": "12345",
+    "WebhookSigningSecret": "whsec_...",
+    "BaseUrl": "https://api.lemonsqueezy.com/v1/",
+    "TimeoutSeconds": 30,
+    "MaxRetries": 3,
+    "TestMode": false
+  }
+}
+```
+
+DI registration:
+
+```csharp
+using Compendium.Adapters.LemonSqueezy;
+
+builder.Services.AddLemonSqueezy(options =>
+{
+    builder.Configuration.GetSection("LemonSqueezy").Bind(options);
+});
+
+// Or bind directly from a configuration section:
+builder.Services.AddLemonSqueezy(builder.Configuration.GetSection("LemonSqueezy"));
+```
+
+### `LemonSqueezyOptions`
+
+| Property | Default | Description |
+|---|---|---|
+| `ApiKey` | `""` | LemonSqueezy API key. Required. |
+| `StoreId` | `""` | Your LemonSqueezy store ID. Required. |
+| `WebhookSigningSecret` | `""` | Webhook signing secret for HMAC-SHA256 validation. **Empty disables validation — dev only.** |
+| `BaseUrl` | `"https://api.lemonsqueezy.com/v1/"` | API base URL. |
+| `TimeoutSeconds` | `30` | HTTP request timeout. |
+| `MaxRetries` | `3` | Retry attempts for transient failures (incl. HTTP 429). |
+| `TestMode` | `false` | Convenience flag for test mode. |
+
+## Usage
+
+Resolve the billing/subscription/license ports from DI:
+
+```csharp
+public class CheckoutHandler
+{
+    private readonly IBillingService _billing;
+    private readonly ILicenseService _licenses;
+
+    public CheckoutHandler(IBillingService billing, ILicenseService licenses)
+    {
+        _billing = billing;
+        _licenses = licenses;
+    }
+
+    public Task<Result<Uri>> StartCheckout(
+        string variantId,
+        string customerEmail,
+        TenantId tenantId,
+        CancellationToken ct) =>
+        _billing.CreateCheckoutSessionAsync(
+            new CheckoutSpec(
+                variantId: variantId,
+                customerEmail: customerEmail,
+                metadata: new() { ["tenant_id"] = tenantId.ToString() }),
+            ct);
+
+    public Task<Result<LicenseStatus>> Validate(string licenseKey, CancellationToken ct) =>
+        _licenses.ValidateLicenseAsync(licenseKey, ct);
+}
+```
+
+### Webhooks
+
+Inject `IPaymentWebhookHandler` (resolved to `LemonSqueezyWebhookHandler`) into a minimal endpoint:
+
+```csharp
+app.MapPost("/webhooks/lemonsqueezy", async (
+    HttpRequest request,
+    IPaymentWebhookHandler handler,
+    CancellationToken ct) =>
+{
+    using var reader = new StreamReader(request.Body);
+    var payload = await reader.ReadToEndAsync(ct);
+    var signature = request.Headers["X-Signature"].ToString();
+
+    var result = await handler.ProcessWebhookAsync(payload, signature, ct);
+    return result.IsSuccess ? Results.Ok() : Results.BadRequest(result.Error);
+});
+```
+
+The handler verifies the HMAC-SHA256 signature (with or without the `sha256=` prefix) and parses the documented event types: `subscription_created`, `subscription_updated`, `subscription_cancelled`, `subscription_resumed`, `subscription_expired`, `subscription_paused`, `subscription_unpaused`, `subscription_payment_*`, `order_created`, `order_refunded`, `license_key_created`, `license_key_updated`.
+
+### Multi-tenant
+
+Pass `metadata["tenant_id"]` into checkout sessions; the webhook handler propagates the metadata onto the resulting events.
+
+## Gotchas
+
+- **LemonSqueezy does not support direct customer creation.** `IBillingService.UpsertCustomerAsync` returns an unsupported-operation error — customers are created automatically during checkout. Use `GetCustomerByEmailAsync` to look existing customers up.
+- **Customer portal URL requires an active subscription.** `CreateCustomerPortalUrlAsync` looks up the customer's active subscription to derive the portal URL; if the customer has no active subscription it returns a `NoActiveSubscription` error.
+- License activation has a per-key activation limit (configured in LemonSqueezy). The adapter detects this in upstream error messages and surfaces a `LicenseActivationLimitReached` error so callers can show a useful message.
+- The HTTP client retries on transient errors and HTTP 429 with exponential backoff (`2^attempt` seconds), and breaks the circuit after 5 consecutive transient failures for 30 seconds.
+- If `WebhookSigningSecret` is empty, signature validation is bypassed. Never deploy without a signing secret.
+
+## See also
+
+- [API Reference](../api/Compendium.Adapters.LemonSqueezy.html)
+- [LemonSqueezy webhooks documentation](https://docs.lemonsqueezy.com/help/webhooks)
+- Sample app — coming via POM-182.

--- a/docs/adapters/listmonk.md
+++ b/docs/adapters/listmonk.md
@@ -1,5 +1,103 @@
 # Compendium.Adapters.Listmonk
 
-> Coming soon — tracked in [POM-184](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-184).
+> Listmonk integration: transactional templated email and newsletter subscriber management.
 
-Listmonk newsletter adapter.
+## Install
+
+```bash
+dotnet add package Compendium.Adapters.Listmonk
+```
+
+## Configuration
+
+`appsettings.json`:
+
+```json
+{
+  "Listmonk": {
+    "BaseUrl": "https://listmonk.example.com",
+    "Username": "api",
+    "Password": "...",
+    "DefaultFromEmail": "no-reply@example.com",
+    "DefaultFromName": "Example",
+    "DefaultListId": 1,
+    "TimeoutSeconds": 30,
+    "MaxRetries": 3,
+    "SkipSslValidation": false
+  }
+}
+```
+
+DI registration:
+
+```csharp
+using Compendium.Adapters.Listmonk;
+
+builder.Services.AddListmonk(options =>
+{
+    builder.Configuration.GetSection("Listmonk").Bind(options);
+});
+```
+
+### `ListmonkOptions`
+
+| Property | Default | Description |
+|---|---|---|
+| `BaseUrl` | `""` | Base URL of the Listmonk instance. Required. |
+| `Username` | `""` | Username for HTTP Basic auth. Required. |
+| `Password` | `""` | Password for HTTP Basic auth. Required. |
+| `DefaultFromEmail` | `""` | Default `From:` email address. |
+| `DefaultFromName` | `""` | Default `From:` display name. |
+| `DefaultListId` | `null` | Default list ID for new subscribers when none is specified. |
+| `TimeoutSeconds` | `30` | HTTP request timeout. |
+| `MaxRetries` | `3` | Retry attempts for transient failures (incl. HTTP 429). |
+| `SkipSslValidation` | `false` | Disable TLS validation. **Dev only.** |
+
+## Usage
+
+Resolve the email/newsletter ports from DI:
+
+```csharp
+public class WelcomeHandler
+{
+    private readonly IEmailService _email;
+    private readonly INewsletterService _newsletter;
+
+    public WelcomeHandler(IEmailService email, INewsletterService newsletter)
+    {
+        _email = email;
+        _newsletter = newsletter;
+    }
+
+    public async Task<Result<Unit>> WelcomeAsync(string email, CancellationToken ct)
+    {
+        var subscribed = await _newsletter.SubscribeAsync(
+            new SubscribeSpec(email, listIds: null /* falls back to DefaultListId */),
+            ct);
+        if (subscribed.IsFailure) return Result<Unit>.Failure(subscribed.Error);
+
+        return await _email.SendTemplatedAsync(
+            new TemplatedMessage(
+                templateId: "42", // Listmonk template ID, parsed as int
+                to: email,
+                data: new() { ["FirstName"] = "Friend" }),
+            ct);
+    }
+}
+```
+
+## Gotchas
+
+- **No raw email.** Listmonk requires a template for transactional sends. `IEmailService.SendAsync` (raw body) returns an error directing callers to `SendTemplatedAsync`. Build the template in Listmonk first, then reference its numeric ID.
+- **One recipient per send.** The transactional API targets a single subscriber; the adapter sends to the first recipient in the message's To list. Use `SendBatchAsync` for multi-recipient flows.
+- **No delivery status.** Listmonk transactional emails do not expose per-message delivery status. `GetMessageStatusAsync` always reports `Sent` — wire your own tracking (e.g., bounce webhooks at the SMTP layer) if you need delivery telemetry.
+- **Confirmations are owned by Listmonk.** `ConfirmSubscriptionAsync` is a no-op; subscribers confirm via the link Listmonk emails them. Use the `RequireConfirmation` flag on `SubscribeSpec` to control whether new subscribers are double-opt-in or pre-confirmed.
+- Subscriber statuses map as: `enabled` → Confirmed, `disabled` → Unsubscribed, `blocklisted` → Blocked.
+- The adapter logs the template ID and recipient count, never the recipient address — keeping PII out of the log pipeline. Don't add address fields to your own log lines either.
+- Resilience: 3-attempt exponential backoff with circuit breaker (5 failures, 30s open).
+
+## See also
+
+- [API Reference](../api/Compendium.Adapters.Listmonk.html)
+- [Listmonk transactional API](https://listmonk.app/docs/apis/transactional/)
+- Sample app — coming via POM-182.

--- a/docs/adapters/openrouter.md
+++ b/docs/adapters/openrouter.md
@@ -1,5 +1,128 @@
 # Compendium.Adapters.OpenRouter
 
-> Coming soon — tracked in [POM-184](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-184).
+> OpenRouter LLM gateway adapter: completions, streaming completions, and model discovery.
 
-OpenRouter AI provider adapter.
+## Install
+
+```bash
+dotnet add package Compendium.Adapters.OpenRouter
+```
+
+## Configuration
+
+`appsettings.json`:
+
+```json
+{
+  "OpenRouter": {
+    "ApiKey": "sk-or-v1-...",
+    "BaseUrl": "https://openrouter.ai/api/v1",
+    "DefaultModel": "anthropic/claude-3.5-sonnet",
+    "DefaultTemperature": 0.7,
+    "DefaultMaxTokens": 4096,
+    "TimeoutSeconds": 120,
+    "RetryAttempts": 3,
+    "SiteUrl": "https://app.example.com",
+    "SiteName": "Example",
+    "EnableLogging": false,
+    "Models": {
+      "anthropic/claude-3.5-sonnet": {
+        "MaxTokens": 8192,
+        "Temperature": 0.2
+      }
+    }
+  }
+}
+```
+
+DI registration:
+
+```csharp
+using Compendium.Adapters.OpenRouter;
+
+// Bind directly from configuration (uses OpenRouterOptions.SectionName = "OpenRouter")
+builder.Services.AddOpenRouter(builder.Configuration);
+
+// Or configure inline
+builder.Services.AddOpenRouter(options =>
+{
+    options.ApiKey = "sk-or-v1-...";
+    options.DefaultModel = "anthropic/claude-3.5-sonnet";
+});
+```
+
+### `OpenRouterOptions`
+
+Bound from configuration section `OpenRouter` (constant `OpenRouterOptions.SectionName`).
+
+| Property | Default | Description |
+|---|---|---|
+| `ApiKey` | `""` | OpenRouter API key. Required. |
+| `BaseUrl` | `"https://openrouter.ai/api/v1"` | API base URL. |
+| `DefaultModel` | `"anthropic/claude-3.5-sonnet"` | Default model when the request does not specify one. |
+| `DefaultTemperature` | `0.7f` | Default sampling temperature. |
+| `DefaultMaxTokens` | `4096` | Default maximum completion tokens. |
+| `TimeoutSeconds` | `120` | HTTP timeout. LLM calls take longer than typical APIs. |
+| `RetryAttempts` | `3` | Retry attempts for transient failures. |
+| `SiteUrl` | `null` | Optional site URL forwarded to OpenRouter for app rankings. |
+| `SiteName` | `null` | Optional site name forwarded to OpenRouter for app rankings. |
+| `EnableLogging` | `false` | Log full request/response bodies. **PII risk — keep off in production.** |
+| `Models` | `{}` | Per-model overrides (`MaxTokens`, `Temperature`, custom `Parameters`). |
+
+`ModelConfig` (entries in `Models`):
+
+| Property | Default | Description |
+|---|---|---|
+| `MaxTokens` | `null` | Override `DefaultMaxTokens` for this model. |
+| `Temperature` | `null` | Override `DefaultTemperature` for this model. |
+| `Parameters` | `null` | Custom request parameters merged into the body. |
+
+## Usage
+
+Resolve `IAIProvider` from DI (the adapter registers `OpenRouterAIProvider` as a singleton with `ProviderId = "openrouter"`):
+
+```csharp
+public class AssistantHandler
+{
+    private readonly IAIProvider _ai;
+
+    public AssistantHandler(IAIProvider ai) => _ai = ai;
+
+    public Task<Result<CompletionResponse>> Complete(string prompt, CancellationToken ct) =>
+        _ai.CompleteAsync(
+            new CompletionRequest(
+                model: "anthropic/claude-3.5-sonnet",
+                systemPrompt: "You are a helpful assistant.",
+                messages: new[] { new ChatMessage("user", prompt) }),
+            ct);
+
+    public async IAsyncEnumerable<CompletionChunk> Stream(
+        string prompt,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        var request = new CompletionRequest(
+            model: "anthropic/claude-3.5-sonnet",
+            messages: new[] { new ChatMessage("user", prompt) });
+
+        await foreach (var chunk in _ai.StreamCompleteAsync(request, ct))
+            yield return chunk;
+    }
+}
+```
+
+`ListModelsAsync` returns the catalog of available models with context window, max output, streaming/vision/tool support, and pricing per million tokens. `HealthCheckAsync` pings OpenRouter for liveness.
+
+## Gotchas
+
+- **No embeddings.** `EmbedAsync` returns "Embeddings are not directly supported via OpenRouter." Use a dedicated embedding provider (OpenAI, Voyage, etc.) for vector workloads.
+- **Default timeout is 120 s.** LLM calls take long enough that the typical 30 s default is too aggressive; raise it if you target reasoning-heavy models.
+- **Pricing is reported per million tokens.** OpenRouter returns a per-token figure; the adapter multiplies by 1,000,000 for `AIModel.Pricing` to match the standard SaaS pricing convention.
+- **Vision capability is heuristic.** Detected from the model's `architecture.modality` field containing `"image"`. Trust the upstream metadata — this is not a hand-curated list.
+- **`EnableLogging` logs prompt and response bodies.** Useful for development; do not turn on in production unless you have explicit data-handling approval.
+- `SiteUrl` and `SiteName` are optional metadata sent to OpenRouter for app rankings. They have no effect on routing, just visibility on OpenRouter's leaderboards.
+
+## See also
+
+- [API Reference](../api/Compendium.Adapters.OpenRouter.html)
+- [OpenRouter API documentation](https://openrouter.ai/docs)
+- Sample app — coming via POM-182.

--- a/docs/adapters/postgresql.md
+++ b/docs/adapters/postgresql.md
@@ -1,5 +1,123 @@
 # Compendium.Adapters.PostgreSQL
 
-> Coming soon — tracked in [POM-184](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-184).
+> PostgreSQL-backed event store, streaming event store, projection store, and projection checkpoint store.
 
-PostgreSQL event store and projection store.
+## Install
+
+```bash
+dotnet add package Compendium.Adapters.PostgreSQL
+```
+
+## Configuration
+
+`appsettings.json`:
+
+```json
+{
+  "Compendium": {
+    "EventStore": {
+      "ConnectionString": "Host=localhost;Port=5432;Database=app;Username=app;Password=secret",
+      "TableName": "event_store",
+      "AutoCreateSchema": false,
+      "MinimumPoolSize": 50,
+      "MaximumPoolSize": 200,
+      "MaxPoolSize": 200,
+      "CommandTimeout": 60
+    }
+  }
+}
+```
+
+DI registration:
+
+```csharp
+using Compendium.Adapters.PostgreSQL;
+
+builder.Services.AddPostgreSqlEventStore(options =>
+{
+    builder.Configuration.GetSection("Compendium:EventStore").Bind(options);
+});
+
+builder.Services.AddPostgreSqlProjectionStore(options =>
+{
+    builder.Configuration.GetSection("Compendium:EventStore").Bind(options);
+});
+
+builder.Services.AddPostgreSqlProjectionCheckpointStore(options =>
+{
+    builder.Configuration.GetSection("Compendium:EventStore").Bind(options);
+});
+
+// Streaming event store depends on the singleton registered above; call last.
+builder.Services.AddPostgreSqlStreamingEventStore(options =>
+{
+    builder.Configuration.GetSection("Compendium:EventStore").Bind(options);
+});
+```
+
+A connection-string overload is available for each method when you want to skip the options builder:
+
+```csharp
+builder.Services.AddPostgreSqlEventStore(
+    builder.Configuration.GetConnectionString("EventStore")!);
+```
+
+### `PostgreSqlOptions`
+
+Bound from configuration section `Compendium:EventStore`.
+
+| Property | Default | Description |
+|---|---|---|
+| `ConnectionString` | `""` | PostgreSQL connection string (required). |
+| `TableName` | `"event_store"` | Event storage table name. |
+| `AutoCreateSchema` | `false` | Create the schema on startup. Off by default — prefer migrations. |
+| `BatchSize` | `1000` | Batch size for bulk operations. |
+| `CommandTimeout` | `60` | Per-command timeout, in seconds. |
+| `MaxPoolSize` | `200` | Application-level concurrency limit (semaphore). |
+| `MinimumPoolSize` | `50` | Npgsql minimum pool size — pre-warms connections. |
+| `MaximumPoolSize` | `200` | Npgsql maximum pool size. Must be `<` server `max_connections`. |
+| `ConnectionIdleLifetime` | `900` | Seconds before idle connections are closed (15 min). |
+| `ConnectionLifetime` | `3600` | Connection recycling period in seconds (1 hour). |
+| `ConnectionTimeout` | `30` | Seconds to wait for a connection from the pool. |
+| `Keepalive` | `30` | TCP keepalive interval, in seconds. `0` disables. |
+| `EnablePooling` | `true` | Enable Npgsql connection pooling. Disable only for debugging. |
+
+## Usage
+
+Resolve `IEventStore` (or the streaming variant) from DI and use it through the standard Compendium ports:
+
+```csharp
+public class OrderHandler
+{
+    private readonly IEventStore _eventStore;
+
+    public OrderHandler(IEventStore eventStore) => _eventStore = eventStore;
+
+    public async Task<Result<Unit>> Handle(PlaceOrder cmd, CancellationToken ct)
+    {
+        var order = Order.Create(cmd.OrderId, cmd.TenantId, cmd.Lines);
+        return await _eventStore.AppendAsync(
+            streamId: order.Id.ToString(),
+            tenantId: cmd.TenantId,
+            expectedVersion: 0,
+            events: order.UncommittedEvents,
+            ct);
+    }
+}
+```
+
+For projections, inject `IProjectionStore` to read/write projection state and `IProjectionCheckpointStore` to track stream position. `IStreamingEventStore` exposes a live `Subscribe`-style API for projection workers.
+
+## Gotchas
+
+- `AddPostgreSqlStreamingEventStore` **must** be called after `AddPostgreSqlEventStore` — it depends on the singleton registered there.
+- `AutoCreateSchema` is off by default. In production, run the schema script as a migration step rather than at app start.
+- Connection pooling is two-tiered: Npgsql's pool (`MinimumPoolSize`/`MaximumPoolSize`) plus a semaphore-based application limit (`MaxPoolSize`). Tune both together.
+- Set `MaximumPoolSize` below your server's `max_connections`, leaving headroom for other clients.
+- Multi-tenant streams: always pass `tenantId` to `AppendAsync`/`ReadAsync`. Cross-tenant reads are an explicit choice, not a default.
+
+## See also
+
+- [API Reference](../api/Compendium.Adapters.PostgreSQL.html)
+- [Event Sourcing concepts](../concepts/event-sourcing.md)
+- Sample app — coming via POM-182.

--- a/docs/adapters/redis.md
+++ b/docs/adapters/redis.md
@@ -1,5 +1,123 @@
 # Compendium.Adapters.Redis
 
-> Coming soon — tracked in [POM-184](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-184).
+> Redis connection multiplexer, idempotency store, and projection checkpoint store.
 
-Redis cache adapter.
+## Install
+
+```bash
+dotnet add package Compendium.Adapters.Redis
+```
+
+## Configuration
+
+`appsettings.json`:
+
+```json
+{
+  "Compendium": {
+    "Redis": {
+      "ConnectionString": "localhost:6379",
+      "DefaultDatabase": 0,
+      "KeyPrefix": "compendium",
+      "ConnectTimeout": 5000,
+      "CommandTimeout": 5000,
+      "RetryCount": 3,
+      "RetryDelayMs": 1000
+    }
+  }
+}
+```
+
+DI registration:
+
+```csharp
+using Compendium.Adapters.Redis;
+
+builder.Services.AddRedis(options =>
+{
+    builder.Configuration.GetSection("Compendium:Redis").Bind(options);
+});
+
+builder.Services.AddRedisIdempotencyStore(options =>
+{
+    builder.Configuration.GetSection("Compendium:Redis").Bind(options);
+});
+
+builder.Services.AddRedisProjectionCheckpointStore(
+    configure: options =>
+    {
+        builder.Configuration.GetSection("Compendium:Redis").Bind(options);
+    },
+    defaultExpiration: TimeSpan.FromDays(7));
+```
+
+A connection-string overload is available for each method:
+
+```csharp
+builder.Services.AddRedis("localhost:6379");
+builder.Services.AddRedisIdempotencyStore("localhost:6379");
+```
+
+### `RedisOptions`
+
+Bound from configuration section `Compendium:Redis`.
+
+| Property | Default | Description |
+|---|---|---|
+| `ConnectionString` | `"localhost:6379"` | Redis connection string. |
+| `DefaultDatabase` | `0` | Redis database number. |
+| `KeyPrefix` | `"compendium"` | Prefix for all keys this adapter writes. |
+| `ConnectTimeout` | `5000` | Connection timeout in milliseconds. |
+| `CommandTimeout` | `5000` | Command timeout in milliseconds. |
+| `RetryCount` | `3` | Retry attempts for transient failures. |
+| `RetryDelayMs` | `1000` | Delay between retries in milliseconds. |
+| `ValidateConnectionString` | `true` | Validate the connection string at startup. |
+
+## Usage
+
+`IConnectionMultiplexer` is registered as a singleton — inject it directly when you need raw access:
+
+```csharp
+public class CacheReader
+{
+    private readonly IConnectionMultiplexer _redis;
+
+    public CacheReader(IConnectionMultiplexer redis) => _redis = redis;
+
+    public Task<RedisValue> GetAsync(string key) =>
+        _redis.GetDatabase().StringGetAsync($"compendium:{key}");
+}
+```
+
+`IIdempotencyService` (backed by `RedisIdempotencyStore`) wraps command execution so that a duplicate idempotency key returns the cached result instead of re-running the operation:
+
+```csharp
+public class CreateOrderHandler
+{
+    private readonly IIdempotencyService _idempotency;
+
+    public CreateOrderHandler(IIdempotencyService idempotency) => _idempotency = idempotency;
+
+    public Task<Result<OrderId>> Handle(CreateOrder cmd, CancellationToken ct) =>
+        _idempotency.ExecuteAsync(
+            key: cmd.IdempotencyKey,
+            tenantId: cmd.TenantId,
+            operation: () => CreateOrderInternalAsync(cmd, ct),
+            ct);
+}
+```
+
+`RedisProjectionCheckpointStore` (resolves `IProjectionCheckpointStore`) tracks the last processed event position per projection — the configured TTL doubles as a recovery window.
+
+## Gotchas
+
+- The connection multiplexer is a process-wide singleton; never `Dispose()` it from consumer code — the adapter manages its lifecycle.
+- Idempotency operations surface infrastructure failures (timeouts, serialization, dropped connections) as `Result.Failure` rather than throwing. Inspect the `Error` to decide whether to retry.
+- `KeyPrefix` is applied per adapter instance; if you share a Redis instance across services, give each one its own prefix to avoid collisions.
+- Default checkpoint TTL is 7 days — long enough to recover most projections from a checkpoint, short enough to evict abandoned ones. Override per store if you replay frequently.
+- All three registrations can be called independently; you do not need the multiplexer registration if you only want the idempotency or checkpoint store.
+
+## See also
+
+- [API Reference](../api/Compendium.Adapters.Redis.html)
+- Sample app — coming via POM-182.

--- a/docs/adapters/stripe.md
+++ b/docs/adapters/stripe.md
@@ -1,5 +1,120 @@
 # Compendium.Adapters.Stripe
 
-> Coming soon — tracked in [POM-184](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-184).
+> Stripe billing adapter: customers, subscriptions, checkout sessions, customer portal, and webhook handling.
 
-Stripe billing adapter.
+## Install
+
+```bash
+dotnet add package Compendium.Adapters.Stripe
+```
+
+## Configuration
+
+`appsettings.json`:
+
+```json
+{
+  "Stripe": {
+    "SecretKey": "sk_test_...",
+    "PublishableKey": "pk_test_...",
+    "WebhookSigningSecret": "whsec_...",
+    "TestMode": true
+  }
+}
+```
+
+DI registration:
+
+```csharp
+using Compendium.Adapters.Stripe;
+
+builder.Services.AddStripeAdapter(options =>
+{
+    builder.Configuration.GetSection("Stripe").Bind(options);
+});
+
+// Or bind directly from a configuration section:
+builder.Services.AddStripeAdapter(builder.Configuration.GetSection("Stripe"));
+```
+
+### `StripeOptions`
+
+| Property | Default | Description |
+|---|---|---|
+| `SecretKey` | `""` | Stripe secret API key (`sk_live_...` / `sk_test_...`). Required. |
+| `PublishableKey` | `null` | Optional publishable key (`pk_live_...` / `pk_test_...`). Used by the frontend; not required server-side. |
+| `WebhookSigningSecret` | `""` | Webhook signing secret (`whsec_...`) for HMAC-SHA256 validation. **Empty disables signature validation — dev only.** |
+| `ApiVersion` | `null` | Optional pinned Stripe API version. See gotcha below. |
+| `TestMode` | `false` | Convenience flag. Actual mode is determined by the secret key prefix. |
+
+## Usage
+
+Resolve the billing/subscription ports from DI:
+
+```csharp
+public class CheckoutHandler
+{
+    private readonly IBillingService _billing;
+    private readonly ISubscriptionService _subs;
+
+    public CheckoutHandler(IBillingService billing, ISubscriptionService subs)
+    {
+        _billing = billing;
+        _subs = subs;
+    }
+
+    public async Task<Result<Uri>> StartCheckout(
+        TenantId tenantId,
+        string priceId,
+        string customerEmail,
+        CancellationToken ct)
+    {
+        var customer = await _billing.UpsertCustomerAsync(
+            new CustomerSpec(customerEmail, metadata: new() { ["tenant_id"] = tenantId.ToString() }),
+            ct);
+        if (customer.IsFailure) return Result<Uri>.Failure(customer.Error);
+
+        return await _billing.CreateCheckoutSessionAsync(
+            new CheckoutSpec(customer.Value.Id, priceId, successUrl: "https://app.example.com/done"),
+            ct);
+    }
+}
+```
+
+### Webhooks
+
+Inject `IPaymentWebhookHandler` (resolved to `StripeWebhookHandler`) into a minimal endpoint and forward the raw body and `Stripe-Signature` header:
+
+```csharp
+app.MapPost("/webhooks/stripe", async (
+    HttpRequest request,
+    IPaymentWebhookHandler handler,
+    CancellationToken ct) =>
+{
+    using var reader = new StreamReader(request.Body);
+    var payload = await reader.ReadToEndAsync(ct);
+    var signature = request.Headers["Stripe-Signature"].ToString();
+
+    var result = await handler.ProcessWebhookAsync(payload, signature, ct);
+    return result.IsSuccess ? Results.Ok() : Results.BadRequest(result.Error);
+});
+```
+
+The handler verifies the HMAC-SHA256 signature using `WebhookSigningSecret`, parses Stripe `Subscription`, `Customer`, `Checkout.Session`, and `Invoice` events, and extracts the `tenant_id` from object metadata for multi-tenant routing.
+
+### Multi-tenant
+
+Always set `metadata["tenant_id"]` when creating customers, subscriptions, and checkout sessions. The webhook handler reads this metadata to route events to the right tenant; without it, you have to maintain a customer-id → tenant-id map yourself.
+
+## Gotchas
+
+- `ApiVersion` is currently informational. Stripe.net pins the API version at compile time via the SDK package version; pinning a different version requires a custom `StripeClient`, which is out of scope for this adapter. Choose your SDK package version to control the effective API version.
+- If `WebhookSigningSecret` is empty, signature validation is bypassed and any payload is accepted. Never deploy without a signing secret.
+- `IBillingService` is a shared port across billing providers (Stripe, LemonSqueezy). `UpsertCustomerAsync` works in Stripe; in LemonSqueezy it returns an unsupported-operation error.
+- Pause-then-resume of a subscription clears `pause_collection` by sending an empty string to the raw Stripe API parameter — it is not a no-op.
+
+## See also
+
+- [API Reference](../api/Compendium.Adapters.Stripe.html)
+- [Stripe webhooks documentation](https://stripe.com/docs/webhooks)
+- Sample app — coming via POM-182.

--- a/docs/adapters/zitadel.md
+++ b/docs/adapters/zitadel.md
@@ -1,5 +1,140 @@
 # Compendium.Adapters.Zitadel
 
-> Coming soon — tracked in [POM-184](https://github.com/sassy-solutions/compendium/issues?q=is%3Aissue+POM-184).
+> Zitadel identity provider integration: user/organization services, token validation, claims transformation, and identity provisioning.
 
-Zitadel OIDC identity adapter.
+## Install
+
+```bash
+dotnet add package Compendium.Adapters.Zitadel
+```
+
+## Configuration
+
+The adapter exposes two distinct option types: `ZitadelOptions` (platform/admin operations) and `ZitadelEndUserOptions` (consumer-facing self-service flows). They are configured separately.
+
+`appsettings.json`:
+
+```json
+{
+  "Zitadel": {
+    "Authority": "https://zitadel.example.com",
+    "ServiceAccountKeyPath": "/run/secrets/zitadel-sa.json",
+    "ProjectId": "123456789",
+    "DefaultOrganizationId": "987654321",
+    "TimeoutSeconds": 30,
+    "MaxRetries": 3
+  },
+  "ZitadelEndUser": {
+    "Authority": "https://zitadel.example.com",
+    "ClientId": "enduser-app-client-id",
+    "ClientSecret": "enduser-app-client-secret",
+    "ProjectId": "123456789",
+    "Audience": "enduser-app",
+    "WebhookSecret": "whsec_...",
+    "DefaultSubscriptionTier": "Free"
+  }
+}
+```
+
+DI registration:
+
+```csharp
+using Compendium.Adapters.Zitadel;
+
+builder.Services.AddZitadel(options =>
+{
+    builder.Configuration.GetSection("Zitadel").Bind(options);
+});
+
+// Optional: register the Zitadel health check
+builder.Services.AddHealthChecks().AddZitadelHealthCheck();
+```
+
+### `ZitadelOptions` (platform)
+
+| Property | Default | Description |
+|---|---|---|
+| `Authority` | `""` | Base URL of the Zitadel instance (required). |
+| `ServiceAccountKeyJson` | `null` | Service account key JSON content (M2M auth). |
+| `ServiceAccountKeyPath` | `null` | File path to a service account JSON key. |
+| `ClientId` | `null` | OAuth2 client ID. |
+| `ClientSecret` | `null` | OAuth2 client secret. |
+| `PersonalAccessToken` | `null` | PAT for M2M auth (skips client_credentials when set). |
+| `ProjectId` | `null` | Zitadel project ID. |
+| `DefaultOrganizationId` | `null` | Default org ID for operations that require one. |
+| `TimeoutSeconds` | `30` | HTTP request timeout. |
+| `MaxRetries` | `3` | Retry attempts for transient HTTP failures. |
+| `InternalBaseUrl` | `null` | Cluster-local base URL (avoids NAT hairpin); `Host` header is set to `Authority`. |
+| `SkipSslValidation` | `false` | Disable TLS validation. **Dev only.** |
+| `RedirectUriTemplate` | `null` | OIDC redirect URI; supports `{organization}` placeholder. |
+| `PostLogoutUriTemplate` | `null` | Post-logout redirect; supports `{organization}` placeholder. |
+
+### `ZitadelEndUserOptions` (consumer)
+
+Bound from configuration section `ZitadelEndUser`.
+
+| Property | Default | Description |
+|---|---|---|
+| `Authority` | `""` | Base URL of the Zitadel instance. |
+| `ClientId` | `null` | OIDC client ID for the end-user app. |
+| `ClientSecret` | `null` | OIDC client secret for the end-user app. |
+| `ProjectId` | `null` | Zitadel project ID for end-users. |
+| `Audience` | `null` | Expected `aud` claim in end-user tokens. |
+| `SelfRegistrationEnabled` | `true` | Allow self-registration. |
+| `WebhookSecret` | `null` | Secret for Zitadel webhook signature validation. |
+| `WebhookSignatureHeader` | `"X-Zitadel-Signature"` | Header name carrying the webhook signature. |
+| `TimeoutSeconds` | `30` | HTTP request timeout. |
+| `SkipSslValidation` | `false` | Disable TLS validation. **Dev only.** |
+| `DefaultSubscriptionTier` | `"Free"` | Default subscription tier for new end-users. |
+| `OrgToTenantMapping` | `{}` | Static map of Zitadel Org ID → Tenant ID. Empty falls back to dynamic lookup. |
+
+## Usage
+
+Resolve the identity ports from DI:
+
+```csharp
+public class OnboardingHandler
+{
+    private readonly IIdentityUserService _users;
+    private readonly IOrganizationService _orgs;
+    private readonly IOrganizationIdentityProvisioner _provisioner;
+
+    public OnboardingHandler(
+        IIdentityUserService users,
+        IOrganizationService orgs,
+        IOrganizationIdentityProvisioner provisioner)
+    {
+        _users = users;
+        _orgs = orgs;
+        _provisioner = provisioner;
+    }
+
+    public async Task<Result<TenantId>> ProvisionAsync(
+        string orgName,
+        string adminEmail,
+        CancellationToken ct)
+    {
+        var org = await _orgs.CreateAsync(orgName, ct);
+        if (org.IsFailure) return Result<TenantId>.Failure(org.Error);
+
+        return await _provisioner.ProvisionAsync(org.Value.Id, adminEmail, ct);
+    }
+}
+```
+
+`ITokenValidator` validates incoming bearer tokens against Zitadel's JWKS or introspection endpoint; `ZitadelClaimsTransformation` projects Zitadel claims into the framework's `TenantContext` so downstream `[Authorize]` policies see the tenant.
+
+## Gotchas
+
+- **Two configurations, not one.** `ZitadelOptions` and `ZitadelEndUserOptions` are independent — mixing platform and end-user credentials will silently produce the wrong audience.
+- The `{organization}` placeholder in `RedirectUriTemplate` / `PostLogoutUriTemplate` is a literal token substituted at provision time. If you use OIDC config with these templates, do the substitution before handing them to your auth library.
+- `InternalBaseUrl` is the escape hatch for Kubernetes NAT hairpin issues: API calls go to the internal URL but the `Host` header is set to `Authority`, so Zitadel still routes by hostname.
+- `SkipSslValidation` is wired through the HTTP client. Never set it in production — there is no secondary check.
+- The HTTP client uses Polly: 3-attempt exponential backoff plus a circuit breaker (5 failures, 30s open). HTTP 429 is treated as transient.
+- Token refresh is mutex-protected — concurrent calls share a single in-flight token request.
+
+## See also
+
+- [API Reference](../api/Compendium.Adapters.Zitadel.html)
+- [Multi-tenancy strategy (ADR 0004)](../adr/0004-multi-tenancy-strategy.md)
+- Sample app — coming via POM-182.


### PR DESCRIPTION
## Summary
- Replaces the 8 "Coming soon" placeholders in `docs/adapters/` with structured how-to pages: install, configuration (with options table), usage snippets, gotchas, and API reference link.
- All extension method names, options types, and default values are pulled from the adapter sources — no invented APIs.
- Covers infra (`aspnetcore`, `postgresql`, `redis`, `zitadel`) and SaaS (`stripe`, `lemonsqueezy`, `listmonk`, `openrouter`).

## Test plan
- [x] `docfx build docs/docfx.json` succeeds locally (warnings on `~/api/...` links resolve once `docfx metadata` runs in CI).
- [x] `docs/adapters/toc.yml` already lists all 8 pages (no change needed).
- [x] `docs/index.md` already references the adapters section.
- [ ] CI `docs-deploy.yml` build passes on this PR.

POM-184