### PR TITLE
docs(changelog): cut 1.0.0-preview.2 with quality sweep notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-preview.2] - 2026-04-26
+
+### Changed
+
+- CodeQL Default Setup switched from `default` to `extended` query suite — adds maintainability/quality queries on top of security (csharp + actions).
+
+### Security
+
+- Pinned `softprops/action-gh-release` to commit SHA in `.github/workflows/release.yml` (CodeQL `actions/unpinned-tag`, CWE-829). 3rd-party action refs are now immutable.
+
 ## [1.0.0-preview.1] - 2026-04-24
 
 ### Added
@@ -51,5 +61,6 @@ First public preview release of Compendium, extracted from the
 - Git history preserved from the originating Nexus monorepo via `git filter-repo`.
 - Full MIT license.
 
-[Unreleased]: https://github.com/sassy-solutions/compendium/compare/v1.0.0-preview.1...HEAD
+[Unreleased]: https://github.com/sassy-solutions/compendium/compare/v1.0.0-preview.2...HEAD
+[1.0.0-preview.2]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.2
 [1.0.0-preview.1]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.1


### PR DESCRIPTION
## Summary

Rotates `[Unreleased]` into `[1.0.0-preview.2] - 2026-04-26` with the two changes shipped since `preview.1`:

- **Changed** — CodeQL Default Setup switched from `default` to `extended` query suite. Adds maintainability/quality queries on top of security for both `csharp` and `actions` languages.
- **Security** — Pinned `softprops/action-gh-release` to commit SHA `b430933...` (= v3.0.0) in `.github/workflows/release.yml`. Closes CodeQL alert #28 (`actions/unpinned-tag`, CWE-829). 3rd-party action refs are now immutable, hardening the release pipeline against supply-chain risk.

After merge, tag `v1.0.0-preview.2` will be cut from the resulting commit on `main` to trigger the Release workflow → publish to nuget.org + GitHub Packages.

## Test plan

- [ ] CI green on this PR (build + CodeQL).
- [ ] After merge, tag `v1.0.0-preview.2` triggers Release workflow successfully.
- [ ] Packages `Compendium.*@1.0.0-preview.2` visible on nuget.org.
- [ ] GitHub Release `v1.0.0-preview.2` published with auto-generated notes.

VK: POM-186 (Code Quality sweep parent), POM-187 (alert #28 fix).