### PR TITLE
docs(changelog): correct preview.2 retroactively + cut preview.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-preview.2] - 2026-04-26
+## [1.0.0-preview.3] - 2026-04-26
+
+### Added
+
+- Documentation site (DocFX, multi-version, GitHub Pages) (#17).
+- 5 Architecture Decision Records (#14).
+- Public `ROADMAP.md` (#15).
+- Getting-started guide and 3 runnable samples (#20).
+- 4 concept pages: event sourcing, hexagonal architecture, Result pattern, multi-tenancy (#21).
+- 8 adapter how-to guides (AspNetCore, LemonSqueezy, Listmonk, OpenRouter, PostgreSQL, Redis, Stripe, Zitadel) (#22).
 
 ### Changed
 
@@ -15,7 +24,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Pinned `softprops/action-gh-release` to commit SHA in `.github/workflows/release.yml` (CodeQL `actions/unpinned-tag`, CWE-829). 3rd-party action refs are now immutable.
+- Pinned `softprops/action-gh-release` to commit SHA in `.github/workflows/release.yml` (#16, CodeQL `actions/unpinned-tag`, CWE-829, alert #28). 3rd-party action refs are now immutable.
+
+## [1.0.0-preview.2] - 2026-04-25
+
+### Added
+
+- `Compendium.Adapters.Shared` — PII masking utilities used across adapters (introduced in #3).
+
+### Changed
+
+- Dependabot updates: `actions/upload-artifact` 4→7 (#4), `softprops/action-gh-release` 2→3 (#5), `actions/checkout` 4→6 (#6), `actions/cache` 4→5 (#7).
+- OSS governance: CODEOWNERS, PR/issue templates, `SECURITY.md`, Code of Conduct, Dependabot config.
+
+### Security
+
+- CI: minimal `permissions:` block on workflows (#1, CodeQL `actions/missing-workflow-permissions`).
+- Sanitize user-controlled path in tenant validation logs (#2, CodeQL `cs/log-forging`).
+- Remove email from adapter logs for GDPR data minimization (#3, CodeQL `cs/exposure-of-sensitive-information`, 14 alerts closed).
 
 ## [1.0.0-preview.1] - 2026-04-24
 
@@ -61,6 +87,7 @@ First public preview release of Compendium, extracted from the
 - Git history preserved from the originating Nexus monorepo via `git filter-repo`.
 - Full MIT license.
 
-[Unreleased]: https://github.com/sassy-solutions/compendium/compare/v1.0.0-preview.2...HEAD
+[Unreleased]: https://github.com/sassy-solutions/compendium/compare/v1.0.0-preview.3...HEAD
+[1.0.0-preview.3]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.3
 [1.0.0-preview.2]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.2
 [1.0.0-preview.1]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.1


### PR DESCRIPTION
## Summary

PR #23 incorrectly bumped CHANGELOG to `[1.0.0-preview.2] - 2026-04-26` with the quality-sweep entries — but tag `v1.0.0-preview.2` was already cut on **2026-04-25** from a different commit set (PRs #1-7) and **already published to nuget.org** (`Compendium.Core 1.0.0-preview.2` is live). Reusing that version was a mistake.

This PR reconciles the CHANGELOG with the published reality and rolls today's work into a new **preview.3**:

### `[1.0.0-preview.2] - 2026-04-25` — rewritten retroactively

Now matches the auto-generated GitHub release notes for `v1.0.0-preview.2`:
- **Added** — `Compendium.Adapters.Shared` (PII masking utilities, introduced in #3).
- **Changed** — Dependabot bumps #4-7, OSS governance scaffolding.
- **Security** — workflow `permissions:` block (#1), tenant log sanitization (#2), email removal from adapter logs / GDPR (#3).

### `[1.0.0-preview.3] - 2026-04-26` — new

Everything since `v1.0.0-preview.2`:
- **Added** — DocFX site (#17), 5 ADRs (#14), public ROADMAP (#15), getting-started guide (#20), 4 concept pages (#21), 8 adapter how-to guides (#22).
- **Changed** — CodeQL Default Setup → `extended` query suite.
- **Security** — `softprops/action-gh-release` pinned to commit SHA (#16, alert #28 closed).

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, tag `v1.0.0-preview.3` triggers Release workflow successfully.
- [ ] `Compendium.* @ 1.0.0-preview.3` published on nuget.org.
- [ ] GitHub Release `v1.0.0-preview.3` created with auto-generated notes.

VK: POM-186 (Code Quality sweep parent).