### PR TITLE
chore(deps): defer .NET 10 major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,18 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "Pomdapis"
+    # Defer .NET 10 major bumps until Nexus (downstream consumer) is also
+    # ready to move; otherwise transitive System.Text.Json / Configuration.Binder
+    # downgrades break the build (NU1605). Lift this once Nexus pins .NET 10.
+    ignore:
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.AspNetCore.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Serilog.Settings.Configuration"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "System.Text.Json"
+        update-types: ["version-update:semver-major"]
     groups:
       microsoft-extensions:
         patterns:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - CodeQL Default Setup switched from `default` to `extended` query suite — adds maintainability/quality queries on top of security (csharp + actions).
+- Dependabot now skips semver-major bumps on `Microsoft.Extensions.*`, `Microsoft.AspNetCore.*`, `Serilog.Settings.Configuration`, and `System.Text.Json` until the project moves to .NET 10 alongside Nexus (#25). Patch and minor bumps continue to flow.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-preview.2] - 2026-04-26
+## [1.0.0-preview.3] - 2026-04-26
+
+### Added
+
+- Documentation site (DocFX, multi-version, GitHub Pages) (#17).
+- 5 Architecture Decision Records (#14).
+- Public `ROADMAP.md` (#15).
+- Getting-started guide and 3 runnable samples (#20).
+- 4 concept pages: event sourcing, hexagonal architecture, Result pattern, multi-tenancy (#21).
+- 8 adapter how-to guides (AspNetCore, LemonSqueezy, Listmonk, OpenRouter, PostgreSQL, Redis, Stripe, Zitadel) (#22).
 
 ### Changed
 
@@ -15,7 +24,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Pinned `softprops/action-gh-release` to commit SHA in `.github/workflows/release.yml` (CodeQL `actions/unpinned-tag`, CWE-829). 3rd-party action refs are now immutable.
+- Pinned `softprops/action-gh-release` to commit SHA in `.github/workflows/release.yml` (#16, CodeQL `actions/unpinned-tag`, CWE-829, alert #28). 3rd-party action refs are now immutable.
+
+## [1.0.0-preview.2] - 2026-04-25
+
+### Added
+
+- `Compendium.Adapters.Shared` — PII masking utilities used across adapters (introduced in #3).
+
+### Changed
+
+- Dependabot updates: `actions/upload-artifact` 4→7 (#4), `softprops/action-gh-release` 2→3 (#5), `actions/checkout` 4→6 (#6), `actions/cache` 4→5 (#7).
+- OSS governance: CODEOWNERS, PR/issue templates, `SECURITY.md`, Code of Conduct, Dependabot config.
+
+### Security
+
+- CI: minimal `permissions:` block on workflows (#1, CodeQL `actions/missing-workflow-permissions`).
+- Sanitize user-controlled path in tenant validation logs (#2, CodeQL `cs/log-forging`).
+- Remove email from adapter logs for GDPR data minimization (#3, CodeQL `cs/exposure-of-sensitive-information`, 14 alerts closed).
 
 ## [1.0.0-preview.1] - 2026-04-24
 
@@ -61,6 +87,7 @@ First public preview release of Compendium, extracted from the
 - Git history preserved from the originating Nexus monorepo via `git filter-repo`.
 - Full MIT license.
 
-[Unreleased]: https://github.com/sassy-solutions/compendium/compare/v1.0.0-preview.2...HEAD
+[Unreleased]: https://github.com/sassy-solutions/compendium/compare/v1.0.0-preview.3...HEAD
+[1.0.0-preview.3]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.3
 [1.0.0-preview.2]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.2
 [1.0.0-preview.1]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.1


### PR DESCRIPTION
## Summary

Closes Dependabot's open .NET-10-major bumps (#8 microsoft-extensions, #9 serilog) until Nexus (downstream consumer) is also ready to move.

## Why

Both PRs failed CI with NU1605 — bumping Microsoft.Extensions.* / Serilog.Settings.Configuration to 10.x pulls transitive System.Text.Json 10.x, but the project pins on .NET 9 runtime (System.Text.Json 9.0.0). To accept the bump cleanly we'd need to pin System.Text.Json explicitly to 10.x, which crosses framework lines.

## Scope

Adds an \`ignore\` block to the NuGet update group:

\`\`\`yaml
ignore:
  - dependency-name: "Microsoft.Extensions.*"
    update-types: ["version-update:semver-major"]
  - dependency-name: "Microsoft.AspNetCore.*"
    update-types: ["version-update:semver-major"]
  - dependency-name: "Serilog.Settings.Configuration"
    update-types: ["version-update:semver-major"]
  - dependency-name: "System.Text.Json"
    update-types: ["version-update:semver-major"]
\`\`\`

Patch and minor bumps stay enabled. \`Microsoft.AspNetCore.Mvc.Testing 9.0.x\` patches will still flow.

## Follow-up

Lift this when Nexus also moves to .NET 10. Tracked informally for now; convert to a roadmap-input issue if useful.