### PR TITLE
fix(projections): resolve projections from DI instead of new() (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Projections can now use DI dependencies.** `IProjectionManager.RegisterProjection<T>()`,
+  `IProjectionManager.RebuildProjectionAsync<T>()`,
+  `ILiveProjectionProcessor.RegisterProjection<T>()`, and
+  `ServiceCollectionExtensions.AddProjection<T>()` no longer require
+  `where TProjection : IProjection, new()`. Projections are resolved through the
+  injected `IServiceProvider`, so any constructor dependency (logger, connection
+  string, cache, metrics) is supported. Existing parameterless projections keep
+  working as long as they are registered in DI; `AddProjection<T>()` now uses
+  `TryAddSingleton<T>()` to register them automatically. Resolves #35.
+
 ### Added
 
 - **Saga pattern, two flavors clearly separated.** Compendium now ships two

--- a/src/Infrastructure/Compendium.Infrastructure/Projections/EnhancedProjectionManager.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/Projections/EnhancedProjectionManager.cs
@@ -9,6 +9,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Compendium.Infrastructure.Projections;
@@ -60,9 +61,9 @@ public class EnhancedProjectionManager : IProjectionManager, IDisposable
         string? streamId = null,
         DateTime? fromTimestamp = null,
         IProgress<RebuildProgress>? progress = null,
-        CancellationToken cancellationToken = default) where TProjection : IProjection, new()
+        CancellationToken cancellationToken = default) where TProjection : IProjection
     {
-        var projection = new TProjection();
+        var projection = _serviceProvider.GetRequiredService<TProjection>();
         var projectionName = projection.ProjectionName;
 
         await _rebuildSemaphore.WaitAsync(cancellationToken);
@@ -270,9 +271,9 @@ public class EnhancedProjectionManager : IProjectionManager, IDisposable
     }
 
     /// <inheritdoc />
-    public void RegisterProjection<TProjection>() where TProjection : IProjection, new()
+    public void RegisterProjection<TProjection>() where TProjection : IProjection
     {
-        var projection = new TProjection();
+        var projection = _serviceProvider.GetRequiredService<TProjection>();
         _registeredProjections.TryAdd(projection.ProjectionName, typeof(TProjection));
         _logger.LogInformation("Registered projection {ProjectionName}", projection.ProjectionName);
     }

--- a/src/Infrastructure/Compendium.Infrastructure/Projections/IProjectionManager.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/Projections/IProjectionManager.cs
@@ -25,7 +25,7 @@ public interface IProjectionManager
         string? streamId = null,
         DateTime? fromTimestamp = null,
         IProgress<RebuildProgress>? progress = null,
-        CancellationToken cancellationToken = default) where TProjection : IProjection, new();
+        CancellationToken cancellationToken = default) where TProjection : IProjection;
 
     /// <summary>
     /// Gets the current state of a projection.
@@ -60,10 +60,12 @@ public interface IProjectionManager
     Task DeleteProjectionAsync(string projectionName, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Registers a projection for live processing.
+    /// Registers a projection for live processing. The projection instance is resolved
+    /// from the DI container, so <typeparamref name="TProjection"/> must be registered as
+    /// a service (typically a singleton) before this call.
     /// </summary>
     /// <typeparam name="TProjection">The type of projection to register.</typeparam>
-    void RegisterProjection<TProjection>() where TProjection : IProjection, new();
+    void RegisterProjection<TProjection>() where TProjection : IProjection;
 
     /// <summary>
     /// Gets statistics about all registered projections.

--- a/src/Infrastructure/Compendium.Infrastructure/Projections/LiveProjectionProcessor.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/Projections/LiveProjectionProcessor.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
@@ -32,10 +33,12 @@ public interface ILiveProjectionProcessor
     Task StopAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Registers a projection for live processing.
+    /// Registers a projection for live processing. The projection instance is resolved
+    /// from the DI container, so <typeparamref name="TProjection"/> must be registered as
+    /// a service (typically a singleton) before this call.
     /// </summary>
     /// <typeparam name="TProjection">The type of projection to register.</typeparam>
-    void RegisterProjection<TProjection>() where TProjection : IProjection, new();
+    void RegisterProjection<TProjection>() where TProjection : IProjection;
 
     /// <summary>
     /// Unregisters a projection from live processing.
@@ -99,9 +102,9 @@ public class LiveProjectionProcessor : BackgroundService, ILiveProjectionProcess
     }
 
     /// <inheritdoc />
-    public void RegisterProjection<TProjection>() where TProjection : IProjection, new()
+    public void RegisterProjection<TProjection>() where TProjection : IProjection
     {
-        var projection = new TProjection();
+        var projection = _serviceProvider.GetRequiredService<TProjection>();
         _registeredProjections.TryAdd(projection.ProjectionName, typeof(TProjection));
         _logger.LogInformation("Registered projection {ProjectionName} for live processing", projection.ProjectionName);
     }
@@ -204,7 +207,7 @@ public class LiveProjectionProcessor : BackgroundService, ILiveProjectionProcess
         {
             try
             {
-                var projection = (IProjection)Activator.CreateInstance(projectionType)!;
+                var projection = (IProjection)_serviceProvider.GetRequiredService(projectionType);
 
                 // Load snapshot if available and enabled
                 if (_options.EnableSnapshots)

--- a/src/Infrastructure/Compendium.Infrastructure/Projections/README.md
+++ b/src/Infrastructure/Compendium.Infrastructure/Projections/README.md
@@ -39,22 +39,39 @@ services.AddProjections(options =>
 // Add PostgreSQL projection store
 services.AddPostgreSqlProjections();
 
-// Register your projections
+// Register your projections in DI. The runner resolves projections via IServiceProvider,
+// so they MUST be registered as services. AddProjection<T>() does TryAddSingleton<T>()
+// for projections without ctor args; for projections that need DI, register a factory
+// first (see below) and then call AddProjection<T>() to wire it into the runner.
+services.AddSingleton<OrderSummaryProjection>(sp =>
+    new OrderSummaryProjection(
+        connectionString,
+        sp.GetRequiredService<ILogger<OrderSummaryProjection>>()));
 services.AddProjection<OrderSummaryProjection>();
 services.AddProjection<CustomerStatsProjection>();
 ```
 
 ### 2. Create a Projection
 
+Projections can use any DI dependency (logger, connection string, cache, metrics).
+
 ```csharp
 public class OrderSummaryProjection : IProjection<OrderPlacedEvent>, IProjection<OrderShippedEvent>
 {
+    private readonly string _connectionString;
+    private readonly ILogger<OrderSummaryProjection> _logger;
+    private readonly Dictionary<Guid, OrderSummary> _summaries = new();
+
+    public OrderSummaryProjection(string connectionString, ILogger<OrderSummaryProjection> logger)
+    {
+        _connectionString = connectionString;
+        _logger = logger;
+    }
+
     public string ProjectionName => "OrderSummary";
     public int Version => 1;
-    
-    private readonly Dictionary<Guid, OrderSummary> _summaries = new();
     public IReadOnlyDictionary<Guid, OrderSummary> Summaries => _summaries;
-    
+
     public Task ApplyAsync(OrderPlacedEvent @event, EventMetadata metadata, CancellationToken cancellationToken = default)
     {
         _summaries[@event.OrderId] = new OrderSummary
@@ -66,7 +83,8 @@ public class OrderSummaryProjection : IProjection<OrderPlacedEvent>, IProjection
             PlacedAt = @event.OccurredOn.DateTime,
             TenantId = metadata.TenantId
         };
-        
+
+        _logger.LogDebug("Projected OrderPlaced for {OrderId}", @event.OrderId);
         return Task.CompletedTask;
     }
     
@@ -172,7 +190,7 @@ public class ResilientProjectionService
     private readonly IProjectionManager _projectionManager;
     private readonly ILogger<ResilientProjectionService> _logger;
     
-    public async Task SafeRebuildAsync<TProjection>() where TProjection : IProjection, new()
+    public async Task SafeRebuildAsync<TProjection>() where TProjection : IProjection
     {
         var retryCount = 0;
         const int maxRetries = 3;

--- a/src/Infrastructure/Compendium.Infrastructure/Projections/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/Projections/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@
 // -----------------------------------------------------------------------
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Compendium.Infrastructure.Projections;
@@ -59,15 +60,19 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Registers a projection for processing.
+    /// Registers a projection for processing. The projection is also registered as a
+    /// singleton in the DI container if it has not been registered already; consumers
+    /// that need a custom factory (e.g. to inject a connection string) should call
+    /// <c>services.AddSingleton&lt;TProjection&gt;(sp =&gt; ...)</c> explicitly first and
+    /// then call this method.
     /// </summary>
     /// <typeparam name="TProjection">The type of projection to register.</typeparam>
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddProjection<TProjection>(this IServiceCollection services)
-        where TProjection : class, IProjection, new()
+        where TProjection : class, IProjection
     {
-        services.AddSingleton<TProjection>();
+        services.TryAddSingleton<TProjection>();
 
         // Register projection with the manager during startup
         services.Configure<ProjectionRegistrationOptions>(options =>

--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/LiveProjectionE2ETests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/LiveProjectionE2ETests.cs
@@ -96,6 +96,9 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
         services.AddSingleton<IStreamingEventStore, PostgreSqlStreamingEventStore>();
         services.AddSingleton<IProjectionStore, PostgreSqlProjectionStore>();
 
+        // Projections must be DI-registered so the manager can resolve them
+        services.AddSingleton<OrderSummaryProjection>();
+
         var provider = services.BuildServiceProvider();
 
         _eventStore = provider.GetRequiredService<PostgreSqlEventStore>();

--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ProjectionRebuildE2ETests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ProjectionRebuildE2ETests.cs
@@ -97,6 +97,9 @@ public sealed class ProjectionRebuildE2ETests : IAsyncLifetime
         services.AddSingleton<IProjectionStore, PostgreSqlProjectionStore>();
         services.AddSingleton<IProjectionManager, EnhancedProjectionManager>();
 
+        // Projections must be DI-registered so the manager can resolve them
+        services.AddSingleton<OrderSummaryProjection>();
+
         var provider = services.BuildServiceProvider();
 
         _eventStore = provider.GetRequiredService<PostgreSqlEventStore>();

--- a/tests/Integration/Compendium.IntegrationTests/Projections/ProjectionManagerIntegrationTests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/Projections/ProjectionManagerIntegrationTests.cs
@@ -99,6 +99,10 @@ public class ProjectionManagerIntegrationTests : IAsyncLifetime
         services.AddSingleton<IProjectionManager, EnhancedProjectionManager>();
         services.AddSingleton<ILiveProjectionProcessor, LiveProjectionProcessor>();
 
+        // Projections must be DI-registered so the manager can resolve them
+        services.AddSingleton<TestCounterProjection>();
+        services.AddSingleton<TestSummaryProjection>();
+
         var provider = services.BuildServiceProvider();
 
         _eventStore = provider.GetRequiredService<IStreamingEventStore>();


### PR DESCRIPTION
Closes #35.

## Problem

Every projection-management API was constrained `where TProjection : IProjection, new()`, and the implementations called `new TProjection()` / `Activator.CreateInstance(projectionType)`. That ruled out any constructor dependency (logger, connection string, cache, metrics) and forced consumers to either bypass the runner or use static service-locator workarounds.

## Fix

The `IServiceProvider` was already injected into both `EnhancedProjectionManager` and `LiveProjectionProcessor`. This PR wires it up properly:

- Drop `new()` constraint from `IProjectionManager.RegisterProjection<T>`, `IProjectionManager.RebuildProjectionAsync<T>`, `ILiveProjectionProcessor.RegisterProjection<T>`, and `ServiceCollectionExtensions.AddProjection<T>`.
- Replace `new TProjection()` with `_serviceProvider.GetRequiredService<TProjection>()`.
- Replace `Activator.CreateInstance(projectionType)!` with `(IProjection)_serviceProvider.GetRequiredService(projectionType)`.
- `AddProjection<T>()` now does `TryAddSingleton<T>()` so projections without ctor args still work zero-config; projections that need DI register a factory first and call `AddProjection<T>()` after.
- README + example updated to demonstrate DI-injected projections.
- Integration tests register the test projections in DI (`TestCounterProjection`, `TestSummaryProjection`, `OrderSummaryProjection`) so resolution doesn't blow up.

## Backwards compatibility

Removing a generic constraint is not a binary break — existing callers that satisfied `new()` continue to compile.

The behavioural change is that callers must register their projection type in DI before `RegisterProjection<T>()` resolves it. But anyone using the runner already needed a singleton instance to preserve state across batches, so this aligns with what consumers were doing in practice. Acceptable for `1.0.0-preview.*`.

## Test plan

- [x] `dotnet build Compendium.sln` — 0 errors.
- [x] `dotnet test tests/Unit/Compendium.Infrastructure.Tests/...` — 236 passed, 2 skipped.
- [ ] Integration tests (`ProjectionManagerIntegrationTests`, `LiveProjectionE2ETests`, `ProjectionRebuildE2ETests`) — run by CI; locally would require docker.

## Out of scope

- Auto-discovery of projections via assembly scanning (`services.AddProjections(typeof(MyAssembly).Assembly)`) — separate issue if useful.