### PR TITLE
docs(changelog): release 1.0.0-preview.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-preview.4] - 2026-04-27
+
 ### Changed
 
 - **Projections can now use DI dependencies.** `IProjectionManager.RegisterProjection<T>()`,
@@ -129,7 +131,8 @@ First public preview release of Compendium, extracted from the
 - Git history preserved from the originating Nexus monorepo via `git filter-repo`.
 - Full MIT license.
 
-[Unreleased]: https://github.com/sassy-solutions/compendium/compare/v1.0.0-preview.3...HEAD
+[Unreleased]: https://github.com/sassy-solutions/compendium/compare/v1.0.0-preview.4...HEAD
+[1.0.0-preview.4]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.4
 [1.0.0-preview.3]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.3
 [1.0.0-preview.2]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.2
 [1.0.0-preview.1]: https://github.com/sassy-solutions/compendium/releases/tag/v1.0.0-preview.1


### PR DESCRIPTION
Release-prep PR. Renames [Unreleased] → [1.0.0-preview.4] - 2026-04-27 ahead of the release tag.

Notable in preview.4:
- Projection DI fix (#35/#36): drops the `new()` constraint so projections can have ctor dependencies.
- Saga pattern flavors: `Compendium.Abstractions.Sagas.ProcessManagers` (DDD orchestration) and `Compendium.Abstractions.Sagas.Choreography` (event-driven).
- Deprecation of legacy `ISaga` API with `[Obsolete]`.

After this merges, I'll tag `v1.0.0-preview.4` on main, which triggers the publish workflow (nuget.org + GitHub Packages) and creates the GitHub Release.