### PR TITLE
fix(projections): opt-in backfill from position 0 on empty checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ProjectionOptions.BackfillFromBeginningOnEmptyCheckpoint` (default `false`).
+  Controls the cold-start behaviour of `LiveProjectionProcessor` when no
+  projection has a persisted checkpoint:
+  - `false` (legacy default) — jump to the current head of the event stream.
+    Avoids replaying weeks of events on every restart.
+  - `true` — start from position 0 and replay every event. Required when
+    projections are the *only* writers to the read model; without it the read
+    model stays empty and never catches up to the event store.
+  Once any projection persists a checkpoint, that checkpoint takes over and
+  this option is ignored.
+
 ## [1.0.0-preview.4] - 2026-04-27
 
 ### Changed

--- a/src/Infrastructure/Compendium.Infrastructure/Compendium.Infrastructure.csproj
+++ b/src/Infrastructure/Compendium.Infrastructure/Compendium.Infrastructure.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Infrastructure.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/src/Infrastructure/Compendium.Infrastructure/Projections/LiveProjectionProcessor.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/Projections/LiveProjectionProcessor.cs
@@ -201,7 +201,7 @@ public class LiveProjectionProcessor : BackgroundService, ILiveProjectionProcess
     /// <summary>
     /// Initializes all registered projections by loading snapshots and determining starting positions.
     /// </summary>
-    private async Task InitializeProjectionsAsync(CancellationToken cancellationToken)
+    internal async Task InitializeProjectionsAsync(CancellationToken cancellationToken)
     {
         foreach (var (projectionName, projectionType) in _registeredProjections)
         {
@@ -249,11 +249,25 @@ public class LiveProjectionProcessor : BackgroundService, ILiveProjectionProcess
             }
         }
 
-        // If no checkpoints exist, start from the current end of the stream
+        // If no checkpoints exist, decide where to start. Two policies:
+        //   - jump to the current head (default — avoids replaying weeks of events on
+        //     every cold restart)
+        //   - backfill from position 0 (opt-in via BackfillFromBeginningOnEmptyCheckpoint
+        //     — required when projections are the *only* writers to the read model)
         if (_lastProcessedPosition == 0)
         {
-            _lastProcessedPosition = await _eventStore.GetMaxGlobalPositionAsync(cancellationToken);
-            _logger.LogInformation("Starting live processing from current position: {Position}", _lastProcessedPosition);
+            if (_options.BackfillFromBeginningOnEmptyCheckpoint)
+            {
+                _logger.LogInformation(
+                    "No projection checkpoints found; backfilling from position 0 (BackfillFromBeginningOnEmptyCheckpoint=true)");
+                // Leave _lastProcessedPosition at 0 — the polling loop will read from
+                // position > 0 and apply every event in the store.
+            }
+            else
+            {
+                _lastProcessedPosition = await _eventStore.GetMaxGlobalPositionAsync(cancellationToken);
+                _logger.LogInformation("Starting live processing from current position: {Position}", _lastProcessedPosition);
+            }
         }
     }
 

--- a/src/Infrastructure/Compendium.Infrastructure/Projections/LiveProjectionProcessor.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/Projections/LiveProjectionProcessor.cs
@@ -203,6 +203,13 @@ public class LiveProjectionProcessor : BackgroundService, ILiveProjectionProcess
     /// </summary>
     internal async Task InitializeProjectionsAsync(CancellationToken cancellationToken)
     {
+        // Track whether ANY projection has a persisted checkpoint, distinct from
+        // _lastProcessedPosition staying at 0 (which would also be the case if a
+        // projection persisted checkpoint=0 — e.g. just-started, no events yet).
+        // Conflating "no checkpoint" with "checkpoint at 0" would cause the cold-start
+        // policy to fire every time a projection sits at 0, which is not what we want.
+        var anyCheckpointFound = false;
+
         foreach (var (projectionName, projectionType) in _registeredProjections)
         {
             try
@@ -235,9 +242,13 @@ public class LiveProjectionProcessor : BackgroundService, ILiveProjectionProcess
 
                 // Get checkpoint to determine starting position
                 var checkpoint = await _projectionStore.GetCheckpointAsync(projectionName, cancellationToken);
-                if (checkpoint.HasValue && checkpoint.Value > _lastProcessedPosition)
+                if (checkpoint.HasValue)
                 {
-                    _lastProcessedPosition = checkpoint.Value;
+                    anyCheckpointFound = true;
+                    if (checkpoint.Value > _lastProcessedPosition)
+                    {
+                        _lastProcessedPosition = checkpoint.Value;
+                    }
                 }
 
                 _logger.LogDebug("Initialized projection {ProjectionName} with checkpoint at position {Position}",
@@ -249,12 +260,14 @@ public class LiveProjectionProcessor : BackgroundService, ILiveProjectionProcess
             }
         }
 
-        // If no checkpoints exist, decide where to start. Two policies:
+        // If no checkpoints exist for any projection, decide where to start. Two policies:
         //   - jump to the current head (default — avoids replaying weeks of events on
         //     every cold restart)
         //   - backfill from position 0 (opt-in via BackfillFromBeginningOnEmptyCheckpoint
         //     — required when projections are the *only* writers to the read model)
-        if (_lastProcessedPosition == 0)
+        // When at least one projection persisted a checkpoint (even if all were at 0),
+        // we trust the persisted state and don't apply the cold-start policy.
+        if (!anyCheckpointFound)
         {
             if (_options.BackfillFromBeginningOnEmptyCheckpoint)
             {

--- a/src/Infrastructure/Compendium.Infrastructure/Projections/ProjectionOptions.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/Projections/ProjectionOptions.cs
@@ -70,4 +70,24 @@ public class ProjectionOptions
     /// Default is 1 second.
     /// </summary>
     public TimeSpan RetryDelay { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Gets or sets whether <see cref="ILiveProjectionProcessor"/> should backfill from
+    /// position 0 on first start, when no checkpoints exist for any registered projection.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Default <see langword="false"/></b> — preserves the historical behaviour where the
+    /// processor jumps to the current head of the event stream on a cold start, so a fresh
+    /// deploy doesn't re-replay weeks of events on every restart.
+    /// </para>
+    /// <para>
+    /// Set to <see langword="true"/> when projections are the <i>only</i> writers to the
+    /// read model (no manual writers, no parallel materialisers): otherwise a cold-start
+    /// processor leaves the read model permanently behind the event store. The flag only
+    /// affects the very first start — once any projection persists a checkpoint, that
+    /// checkpoint takes over and this option is ignored.
+    /// </para>
+    /// </remarks>
+    public bool BackfillFromBeginningOnEmptyCheckpoint { get; set; }
 }

--- a/tests/Unit/Compendium.Infrastructure.Tests/Projections/LiveProjectionProcessorBackfillTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Projections/LiveProjectionProcessorBackfillTests.cs
@@ -79,6 +79,41 @@ public sealed class LiveProjectionProcessorBackfillTests
         await eventStore.DidNotReceive().GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task CheckpointPersistedAtZero_DefaultOptions_StaysAtZero_NoHeadJump()
+    {
+        // Edge case: a projection legitimately persisted checkpoint=0 (just started, no
+        // events yet, but the row exists). The cold-start policy must NOT fire — we
+        // distinguish "checkpoint absent" from "checkpoint = 0".
+        var (eventStore, projectionStore) = SetupStores(headPosition: 999L, checkpoint: 0L);
+
+        var processor = CreateProcessor(eventStore, projectionStore, backfill: false);
+        processor.RegisterProjection<TestProjection>();
+
+        await processor.InitializeProjectionsAsync(CancellationToken.None);
+
+        processor.GetStatus().LastProcessedPosition.Should().Be(0L,
+            "an explicit checkpoint at 0 means the projection trusts the persisted state, even with the legacy default flag");
+        await eventStore.DidNotReceive().GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckpointPersistedAtZero_BackfillFlagOn_StaysAtZero()
+    {
+        // Same edge case under the opt-in flag — the persisted state still wins.
+        // No head-jump (already covered by the assertion above) and no warning needed:
+        // backfill flag is only a *cold start* policy, not "always start at 0".
+        var (eventStore, projectionStore) = SetupStores(headPosition: 999L, checkpoint: 0L);
+
+        var processor = CreateProcessor(eventStore, projectionStore, backfill: true);
+        processor.RegisterProjection<TestProjection>();
+
+        await processor.InitializeProjectionsAsync(CancellationToken.None);
+
+        processor.GetStatus().LastProcessedPosition.Should().Be(0L);
+        await eventStore.DidNotReceive().GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>());
+    }
+
     private static (IStreamingEventStore eventStore, IProjectionStore projectionStore) SetupStores(
         long headPosition,
         long? checkpoint)

--- a/tests/Unit/Compendium.Infrastructure.Tests/Projections/LiveProjectionProcessorBackfillTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Projections/LiveProjectionProcessorBackfillTests.cs
@@ -1,0 +1,128 @@
+// -----------------------------------------------------------------------
+// <copyright file="LiveProjectionProcessorBackfillTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Projections;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Compendium.Infrastructure.Tests.Projections;
+
+/// <summary>
+/// Verifies the cold-start position picked by <see cref="LiveProjectionProcessor"/>
+/// based on <see cref="ProjectionOptions.BackfillFromBeginningOnEmptyCheckpoint"/>.
+/// </summary>
+public sealed class LiveProjectionProcessorBackfillTests
+{
+    [Fact]
+    public async Task EmptyCheckpoints_DefaultOptions_JumpsToHead()
+    {
+        var (eventStore, projectionStore) = SetupStores(headPosition: 250L, checkpoint: null);
+
+        var processor = CreateProcessor(eventStore, projectionStore, backfill: false);
+        processor.RegisterProjection<TestProjection>();
+
+        await processor.InitializeProjectionsAsync(CancellationToken.None);
+
+        processor.GetStatus().LastProcessedPosition.Should().Be(250L,
+            "default behaviour avoids replaying weeks of history on cold restart");
+        await eventStore.Received().GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EmptyCheckpoints_BackfillFlagOn_StaysAtZero()
+    {
+        var (eventStore, projectionStore) = SetupStores(headPosition: 250L, checkpoint: null);
+
+        var processor = CreateProcessor(eventStore, projectionStore, backfill: true);
+        processor.RegisterProjection<TestProjection>();
+
+        await processor.InitializeProjectionsAsync(CancellationToken.None);
+
+        processor.GetStatus().LastProcessedPosition.Should().Be(0L,
+            "BackfillFromBeginningOnEmptyCheckpoint=true keeps the cursor at 0 so the polling loop reads from position > 0");
+        await eventStore.DidNotReceive().GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExistingCheckpoint_TakesPrecedence_RegardlessOfBackfillFlag()
+    {
+        var (eventStore, projectionStore) = SetupStores(headPosition: 999L, checkpoint: 100L);
+
+        // Even with backfill=true, a real checkpoint always wins.
+        var processor = CreateProcessor(eventStore, projectionStore, backfill: true);
+        processor.RegisterProjection<TestProjection>();
+
+        await processor.InitializeProjectionsAsync(CancellationToken.None);
+
+        processor.GetStatus().LastProcessedPosition.Should().Be(100L);
+        await eventStore.DidNotReceive().GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExistingCheckpoint_DefaultOptions_DoesNotJumpToHead()
+    {
+        var (eventStore, projectionStore) = SetupStores(headPosition: 999L, checkpoint: 100L);
+
+        var processor = CreateProcessor(eventStore, projectionStore, backfill: false);
+        processor.RegisterProjection<TestProjection>();
+
+        await processor.InitializeProjectionsAsync(CancellationToken.None);
+
+        processor.GetStatus().LastProcessedPosition.Should().Be(100L);
+        await eventStore.DidNotReceive().GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>());
+    }
+
+    private static (IStreamingEventStore eventStore, IProjectionStore projectionStore) SetupStores(
+        long headPosition,
+        long? checkpoint)
+    {
+        var eventStore = Substitute.For<IStreamingEventStore>();
+        eventStore.GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>())
+            .Returns(headPosition);
+
+        var projectionStore = Substitute.For<IProjectionStore>();
+        projectionStore.GetCheckpointAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(checkpoint);
+        // Snapshot path is intentionally not exercised — EnableSnapshots=false in CreateProcessor.
+
+        return (eventStore, projectionStore);
+    }
+
+    private static LiveProjectionProcessor CreateProcessor(
+        IStreamingEventStore eventStore,
+        IProjectionStore projectionStore,
+        bool backfill)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<TestProjection>();
+        var sp = services.BuildServiceProvider();
+
+        var options = Options.Create(new ProjectionOptions
+        {
+            BackfillFromBeginningOnEmptyCheckpoint = backfill,
+            EnableSnapshots = false,
+        });
+
+        return new LiveProjectionProcessor(
+            eventStore,
+            projectionStore,
+            sp,
+            NullLogger<LiveProjectionProcessor>.Instance,
+            options);
+    }
+
+    /// <summary>Minimal projection used purely so the processor has at least one registered.</summary>
+    private sealed class TestProjection : Compendium.Infrastructure.Projections.IProjection
+    {
+        public string ProjectionName => "Test";
+        public int Version => 1;
+        public Task ResetAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Why

Found in production after the Nexus monorepo retired its parallel manual writers and made projections the sole writer to the read model. With no checkpoints persisted yet, `LiveProjectionProcessor.InitializeProjectionsAsync` unconditionally calls `GetMaxGlobalPositionAsync()` and starts from the current head — which means **every event written before the first deploy of the new topology is permanently invisible to the read model**, even though it's still in the event store.

The processor reported \"running, position N, 0 events processed\" the whole time. From its own perspective everything was healthy. From the user's: 7 `ProjectCreated` events in the store → 1 row in `nexus_projects`. 23 `OrganizationCreated` events → 3 rows in `nexus_organizations`.

## What

Add `ProjectionOptions.BackfillFromBeginningOnEmptyCheckpoint` (default `false`).

- **`false`** (current behaviour, kept for safety): cold start jumps to head. A multi-week event store doesn't get re-replayed every restart.
- **`true`**: cold start leaves `_lastProcessedPosition` at 0 and the polling loop reads every event from position 1 onwards. Required when projections are the *only* writers to the read model.

Once any projection persists a checkpoint, that checkpoint takes over and the flag is ignored — this is a one-time first-deploy concern, not a per-restart toggle.

## Test plan

- [x] 4 new `LiveProjectionProcessorBackfillTests` covering: default+empty-checkpoint jumps to head; backfill+empty-checkpoint stays at 0; existing-checkpoint takes precedence regardless of flag (both directions).
- [x] `dotnet test tests/Unit/Compendium.Infrastructure.Tests` — **240 / 240** (+ 2 skipped, pre-existing)
- [x] `dotnet test tests/Unit/Compendium.Core.Tests` — **386 / 386**
- [ ] CI green on this PR
- [ ] Tag `v1.0.0-preview.5` post-merge (MinVer derives the version from the tag)
- [ ] Downstream Nexus PR (separate): bump Compendium versions to preview.5, set `BackfillFromBeginningOnEmptyCheckpoint = true` in `Program.cs`, fix the orthogonal event-deserialization issues on certain Nexus value objects (missing `[JsonConverter]` on `ApplicationId` / `ApiKeyId`).

## Plumbing notes

- `LiveProjectionProcessor.InitializeProjectionsAsync` is now `internal` so tests can drive it directly without spinning up the `BackgroundService` loop. `Compendium.Infrastructure.csproj` exposes `InternalsVisibleTo` to `Compendium.Infrastructure.Tests` for that purpose only — no other internals were promoted.
- CHANGELOG entry under `[Unreleased]`. Will release alongside the AI-agent primitives in PR #39 as `1.0.0-preview.5` once both merge and the tag is cut.

## Out of scope

- Per-projection cold-start position policy. Right now the flag is global. If we ever want \"backfill projection X but jump-to-head for Y\" we'd need a per-projection setting; not motivated yet.
- Auto-detection (\"is this a fresh deploy or a planned restart?\"). Explicit opt-in is safer than guessing.
- Fixing the ResetAsync semantics for partial replays — out of scope, the rebuild path already handles that case.