### PR TITLE
fix(zitadel): reuse existing user when CreateUser returns Conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Compendium.Adapters.Zitadel.ZitadelOrganizationIdentityProvisioner` now treats
+  the "user already exists" conflict from Zitadel as a recoverable state. When
+  `IUserService.CreateUserAsync` returns `ErrorType.Conflict`, the provisioner
+  falls back to `GetUserByEmailAsync` and reuses the existing user id for the
+  org-membership step. Without this, every subsequent organization provision
+  for the same admin email left an orphan Zitadel org behind and stuck the
+  upstream Nexus aggregate in `Provisioning` state. Other failure types
+  (validation, unauthorized, network) still propagate as before.
+
 ### Added
 
 - **AI agent loop primitives.** New `Compendium.Abstractions.AI.Agents` namespace

--- a/src/Adapters/Compendium.Adapters.Zitadel/Services/ZitadelOrganizationIdentityProvisioner.cs
+++ b/src/Adapters/Compendium.Adapters.Zitadel/Services/ZitadelOrganizationIdentityProvisioner.cs
@@ -149,7 +149,13 @@ internal sealed class ZitadelOrganizationIdentityProvisioner : IOrganizationIden
         _logger.LogInformation("Created OIDC app with clientId {ClientId} for project {ProjectId}",
             clientId, projectId);
 
-        // Step 4: Create admin user
+        // Step 4: Create admin user (idempotent — reuse existing user if present)
+        // Zitadel usernames are unique across the entire instance; the same human can
+        // legitimately be admin of multiple orgs. When CreateUserAsync returns a
+        // conflict, fall back to GetUserByEmailAsync and reuse the existing user id
+        // for the membership step. Without this, every subsequent Org provisioning
+        // for the same admin email leaves an orphan Zitadel org behind and gets
+        // stuck in `Provisioning` on the Nexus side.
         var userResult = await _userService.CreateUserAsync(
             new CreateUserRequest
             {
@@ -162,17 +168,43 @@ internal sealed class ZitadelOrganizationIdentityProvisioner : IOrganizationIden
             },
             cancellationToken);
 
+        string adminUserId;
         if (userResult.IsFailure)
         {
-            _logger.LogWarning(
-                "Failed to create admin user {Email} for organization {ZitadelOrgId}: {Error}",
-                request.AdminUser.Email, zitadelOrgId, userResult.Error.Message);
-            return userResult.Error;
-        }
+            // Conflict on user creation → look up the existing user by email and reuse it.
+            // Any other failure (auth, network, validation) propagates as before.
+            if (userResult.Error.Type != ErrorType.Conflict)
+            {
+                _logger.LogWarning(
+                    "Failed to create admin user for organization {ZitadelOrgId}: {Error}",
+                    zitadelOrgId, userResult.Error.Message);
+                return userResult.Error;
+            }
 
-        var adminUserId = userResult.Value.Id;
-        _logger.LogInformation("Created admin user {AdminUserId} for organization {ZitadelOrgId}",
-            adminUserId, zitadelOrgId);
+            _logger.LogInformation(
+                "Admin user already exists in Zitadel for organization {ZitadelOrgId}; looking up to reuse",
+                zitadelOrgId);
+
+            var existing = await _userService.GetUserByEmailAsync(request.AdminUser.Email, cancellationToken);
+            if (existing.IsFailure)
+            {
+                _logger.LogWarning(
+                    "Admin user creation reported conflict but lookup by email failed: {Error}",
+                    existing.Error.Message);
+                return existing.Error;
+            }
+
+            adminUserId = existing.Value.Id;
+            _logger.LogInformation(
+                "Reusing existing admin user {AdminUserId} for organization {ZitadelOrgId}",
+                adminUserId, zitadelOrgId);
+        }
+        else
+        {
+            adminUserId = userResult.Value.Id;
+            _logger.LogInformation("Created admin user {AdminUserId} for organization {ZitadelOrgId}",
+                adminUserId, zitadelOrgId);
+        }
 
         // Step 5: Add user as organization member with ORG_OWNER role
         var memberResult = await _organizationService.AddMemberAsync(


### PR DESCRIPTION
## Why

Reproduced live on `nexus-live` after the projection-runner backfill (preview.5) and the org-read race fix (Nexus PR #76) landed. Provisioning a brand-new organization with admin email `majid@sassy.solutions` (which already exists as a user in the default Zitadel org from a previous attempt) now fails on Step 4 of `ZitadelOrganizationIdentityProvisioner.ProvisionIdentityAsync`:

```
fail: ProvisionOrganizationCommandHandler[0]
      Identity provisioning failed for organization 0d4a323c-...:
      User already exists (V3-DKcYh)
```

Zitadel usernames are unique across the whole instance, not per-org. So the same human ends up rejected on every subsequent provision call, while the Zitadel org/project/oidc-app created in Steps 1-3 are left orphaned. The Nexus aggregate stays in `Provisioning` forever.

## Fix

When `IUserService.CreateUserAsync` returns `Result.Failure` with `Error.Type == ErrorType.Conflict`, fall back to `IUserService.GetUserByEmailAsync` and reuse the existing user id for Step 5 (`AddMember` with `ORG_OWNER`). Other failure types (validation, unauthorized, network) still propagate exactly as before.

This treats "user already exists" as the recoverable state it is — the same human can legitimately be admin of multiple orgs.

```csharp
var userResult = await _userService.CreateUserAsync(...);
string adminUserId;
if (userResult.IsFailure)
{
    if (userResult.Error.Type != ErrorType.Conflict) return userResult.Error;
    var existing = await _userService.GetUserByEmailAsync(request.AdminUser.Email, ct);
    if (existing.IsFailure) return existing.Error;
    adminUserId = existing.Value.Id;
}
else
{
    adminUserId = userResult.Value.Id;
}
```

## Test plan

- [x] `dotnet test tests/Unit/Compendium.Adapters.Zitadel.Tests` — **20 / 20** pass
- [x] Build clean across whole solution
- [ ] CI green
- [ ] Tag `v1.0.0-preview.6` post-merge → release workflow publishes 20 packages
- [ ] Downstream Nexus PR: bump `Compendium.* preview.5 → preview.6`, redeploy, verify the stuck Nexus orgs (`Liquid`, `test`, plus any new ones with the same admin email) provision cleanly

## Out of scope

- Compensating cleanup of orphan Zitadel orgs/projects/oidc-apps left behind by previous failures. The full saga refactor (POM-A1b on Nexus) handles this with proper rollback.
- Per-org username scheme (e.g. `majid+{org}@sassy.solutions`). The reuse semantics is the right model — humans are humans, orgs are orgs.

## Note on autonomous execution

PR opened directly without VK delegation because the diagnostic was tightly coupled to live cluster state and the fix is small + mechanical. Happy to course-correct if you'd prefer a different recovery semantics.