### PR TITLE
feat(sagas): typed-state reload on IProcessManagerRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Typed state reload on `IProcessManagerRepository`.** New
+  `Task<Result<IProcessManager<TState>>> GetByIdAsync<TState>(Guid id, ct)` overload
+  rehydrates a saga's persisted state into the original typed shape so resumed steps
+  can detect already-completed external work (the foundation for idempotent saga
+  retries). Implemented for `PostgresProcessManagerRepository`
+  (deserializes the existing `state_json` column) and `InMemoryProcessManagerRepository`
+  (returns the original instance, with a `Conflict` error on type mismatch).
+  Existing untyped `GetByIdAsync(Guid id, ct)` is unchanged.
+
 ### Fixed
 
 - `Compendium.Adapters.Zitadel.ZitadelOrganizationIdentityProvisioner` now treats

--- a/src/Abstractions/Compendium.Abstractions/Sagas/ProcessManagers/IProcessManagerRepository.cs
+++ b/src/Abstractions/Compendium.Abstractions/Sagas/ProcessManagers/IProcessManagerRepository.cs
@@ -24,6 +24,22 @@ public interface IProcessManagerRepository
     Task<Result<IProcessManager>> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Retrieves a process manager by id, deserializing its persisted <typeparamref name="TState"/>
+    /// snapshot. Required for resuming a saga from any step with full typed state access — e.g.
+    /// to detect already-completed external work and stay idempotent.
+    /// </summary>
+    /// <typeparam name="TState">The state shape persisted by the saga. Must match the type used at <see cref="SaveAsync"/> time.</typeparam>
+    /// <param name="id">The unique identifier of the process manager.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>
+    /// A successful result with the process manager and rehydrated state, a not-found error,
+    /// or a deserialization error if the persisted state cannot be decoded into <typeparamref name="TState"/>.
+    /// If no state has been persisted yet, a default-constructed <typeparamref name="TState"/> is returned.
+    /// </returns>
+    Task<Result<IProcessManager<TState>>> GetByIdAsync<TState>(Guid id, CancellationToken cancellationToken = default)
+        where TState : class, new();
+
+    /// <summary>
     /// Persists the given process manager.
     /// </summary>
     /// <remarks>

--- a/src/Adapters/Compendium.Adapters.PostgreSQL/Sagas/PersistedProcessManager{TState}.cs
+++ b/src/Adapters/Compendium.Adapters.PostgreSQL/Sagas/PersistedProcessManager{TState}.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="PersistedProcessManager{TState}.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Sagas.Common;
+using Compendium.Abstractions.Sagas.ProcessManagers;
+using Compendium.Application.Sagas.ProcessManagers;
+
+namespace Compendium.Adapters.PostgreSQL.Sagas;
+
+/// <summary>
+/// Lightweight projection of an <see cref="IProcessManager{TState}"/> rehydrated from
+/// PostgreSQL with its typed state snapshot. Used by callers resuming a saga from an
+/// arbitrary step that need access to the full domain state (e.g. to skip external work
+/// already completed in a previous attempt).
+/// </summary>
+/// <typeparam name="TState">The state type captured at save time.</typeparam>
+internal sealed class PersistedProcessManager<TState> : IProcessManager<TState>, IMutableProcessManager
+    where TState : class, new()
+{
+    private readonly List<SagaStep> _steps;
+
+    public PersistedProcessManager(
+        Guid id,
+        SagaStatus status,
+        DateTime createdAt,
+        DateTime? completedAt,
+        IEnumerable<SagaStep> steps,
+        TState state)
+    {
+        ArgumentNullException.ThrowIfNull(steps);
+        ArgumentNullException.ThrowIfNull(state);
+
+        Id = id;
+        Status = status;
+        CreatedAt = createdAt;
+        CompletedAt = completedAt;
+        State = state;
+        _steps = steps.OrderBy(s => s.Order).ToList();
+    }
+
+    public Guid Id { get; }
+
+    public SagaStatus Status { get; private set; }
+
+    public DateTime CreatedAt { get; }
+
+    public DateTime? CompletedAt { get; private set; }
+
+    public TState State { get; }
+
+    public IReadOnlyList<SagaStep> Steps => _steps.AsReadOnly();
+
+    public void TransitionTo(SagaStatus status)
+    {
+        Status = status;
+        if (status is SagaStatus.Completed or SagaStatus.Compensated)
+        {
+            CompletedAt = DateTime.UtcNow;
+        }
+    }
+
+    public void TransitionStep(Guid stepId, SagaStepStatus status, string? errorMessage = null)
+    {
+        var idx = _steps.FindIndex(s => s.Id == stepId);
+        if (idx < 0)
+        {
+            return;
+        }
+
+        var step = _steps[idx];
+        _steps[idx] = new SagaStep
+        {
+            Id = step.Id,
+            Name = step.Name,
+            Order = step.Order,
+            Status = status,
+            ErrorMessage = errorMessage,
+            ExecutedAt = status == SagaStepStatus.Completed ? DateTime.UtcNow : step.ExecutedAt,
+            CompensatedAt = status == SagaStepStatus.Compensated ? DateTime.UtcNow : step.CompensatedAt,
+        };
+    }
+}

--- a/src/Adapters/Compendium.Adapters.PostgreSQL/Sagas/PostgresProcessManagerRepository.cs
+++ b/src/Adapters/Compendium.Adapters.PostgreSQL/Sagas/PostgresProcessManagerRepository.cs
@@ -109,8 +109,66 @@ public sealed class PostgresProcessManagerRepository : IProcessManagerRepository
     /// <inheritdoc />
     public async Task<Result<IProcessManager>> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
+        var loaded = await LoadCoreAsync(id, cancellationToken).ConfigureAwait(false);
+        return loaded.IsFailure
+            ? Result.Failure<IProcessManager>(loaded.Error)
+            : Result.Success<IProcessManager>(new PersistedProcessManager(
+                loaded.Value.Saga.Id,
+                Enum.Parse<SagaStatus>(loaded.Value.Saga.Status, ignoreCase: true),
+                DateTime.SpecifyKind(loaded.Value.Saga.CreatedAt, DateTimeKind.Utc),
+                loaded.Value.Saga.CompletedAt is null ? null : DateTime.SpecifyKind(loaded.Value.Saga.CompletedAt.Value, DateTimeKind.Utc),
+                MapSteps(loaded.Value.Steps)));
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IProcessManager<TState>>> GetByIdAsync<TState>(Guid id, CancellationToken cancellationToken = default)
+        where TState : class, new()
+    {
+        var loaded = await LoadCoreAsync(id, cancellationToken).ConfigureAwait(false);
+        if (loaded.IsFailure)
+        {
+            return Result.Failure<IProcessManager<TState>>(loaded.Error);
+        }
+
+        TState state;
+        if (string.IsNullOrWhiteSpace(loaded.Value.Saga.StateJson))
+        {
+            // No state was persisted yet (saga saved before any step ran). Hand back a
+            // fresh default — callers can write to it and SaveAsync will pick it up.
+            state = new TState();
+        }
+        else
+        {
+            try
+            {
+                state = JsonSerializer.Deserialize<TState>(loaded.Value.Saga.StateJson!, JsonOptions)
+                        ?? new TState();
+            }
+            catch (JsonException ex)
+            {
+                _logger?.LogError(
+                    ex,
+                    "Failed to deserialize process manager {Id} state into {StateType}",
+                    id, typeof(TState).FullName);
+                return Result.Failure<IProcessManager<TState>>(Error.Failure(
+                    "ProcessManager.StateDeserializationFailed",
+                    $"Could not deserialize persisted state of process manager {id} into {typeof(TState).FullName}: {ex.Message}"));
+            }
+        }
+
+        return Result.Success<IProcessManager<TState>>(new PersistedProcessManager<TState>(
+            loaded.Value.Saga.Id,
+            Enum.Parse<SagaStatus>(loaded.Value.Saga.Status, ignoreCase: true),
+            DateTime.SpecifyKind(loaded.Value.Saga.CreatedAt, DateTimeKind.Utc),
+            loaded.Value.Saga.CompletedAt is null ? null : DateTime.SpecifyKind(loaded.Value.Saga.CompletedAt.Value, DateTimeKind.Utc),
+            MapSteps(loaded.Value.Steps),
+            state));
+    }
+
+    private async Task<Result<(SagaRow Saga, IReadOnlyList<StepRow> Steps)>> LoadCoreAsync(Guid id, CancellationToken cancellationToken)
+    {
         const string sagaSql = """
-            SELECT id, status, created_at, completed_at
+            SELECT id, status, state_json AS StateJson, created_at AS CreatedAt, completed_at AS CompletedAt
             FROM process_managers
             WHERE id = @Id AND (@TenantId IS NULL OR tenant_id = @TenantId)
             LIMIT 1;
@@ -136,7 +194,7 @@ public sealed class PostgresProcessManagerRepository : IProcessManagerRepository
 
             if (saga is null)
             {
-                return Result.Failure<IProcessManager>(
+                return Result.Failure<(SagaRow, IReadOnlyList<StepRow>)>(
                     Error.NotFound("ProcessManager.NotFound", $"Process manager {id} not found."));
             }
 
@@ -144,38 +202,31 @@ public sealed class PostgresProcessManagerRepository : IProcessManagerRepository
                 new CommandDefinition(stepsSql, new { Id = id }, cancellationToken: cancellationToken))
                 .ConfigureAwait(false)).ToList();
 
-            var steps = stepRows.Select(r => new SagaStep
-            {
-                Id = r.Id,
-                Name = r.Name,
-                Order = r.Order,
-                Status = Enum.Parse<SagaStepStatus>(r.Status, ignoreCase: true),
-                ExecutedAt = r.ExecutedAt,
-                CompensatedAt = r.CompensatedAt,
-                ErrorMessage = r.ErrorMessage,
-            });
-
-            var pm = new PersistedProcessManager(
-                saga.Id,
-                Enum.Parse<SagaStatus>(saga.Status, ignoreCase: true),
-                DateTime.SpecifyKind(saga.CreatedAt, DateTimeKind.Utc),
-                saga.CompletedAt is null ? null : DateTime.SpecifyKind(saga.CompletedAt.Value, DateTimeKind.Utc),
-                steps);
-
-            return Result.Success<IProcessManager>(pm);
+            return Result.Success<(SagaRow, IReadOnlyList<StepRow>)>((saga, stepRows));
         }
         catch (NpgsqlException ex)
         {
             _logger?.LogError(ex, "Database failure loading process manager {Id}", id);
-            return Result.Failure<IProcessManager>(Error.Failure("ProcessManager.LoadFailed", ex.Message));
+            return Result.Failure<(SagaRow, IReadOnlyList<StepRow>)>(Error.Failure("ProcessManager.LoadFailed", ex.Message));
         }
         catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
         {
-            // Row mapping or Enum.Parse rejected unexpected data.
             _logger?.LogError(ex, "Mapping failure loading process manager {Id}", id);
-            return Result.Failure<IProcessManager>(Error.Failure("ProcessManager.LoadFailed", ex.Message));
+            return Result.Failure<(SagaRow, IReadOnlyList<StepRow>)>(Error.Failure("ProcessManager.LoadFailed", ex.Message));
         }
     }
+
+    private static IEnumerable<SagaStep> MapSteps(IEnumerable<StepRow> rows) =>
+        rows.Select(r => new SagaStep
+        {
+            Id = r.Id,
+            Name = r.Name,
+            Order = r.Order,
+            Status = Enum.Parse<SagaStepStatus>(r.Status, ignoreCase: true),
+            ExecutedAt = r.ExecutedAt,
+            CompensatedAt = r.CompensatedAt,
+            ErrorMessage = r.ErrorMessage,
+        });
 
     /// <inheritdoc />
     public async Task<Result> SaveAsync(IProcessManager processManager, CancellationToken cancellationToken = default)
@@ -383,6 +434,8 @@ public sealed class PostgresProcessManagerRepository : IProcessManagerRepository
         public Guid Id { get; init; }
 
         public string Status { get; init; } = string.Empty;
+
+        public string? StateJson { get; init; }
 
         public DateTime CreatedAt { get; init; }
 

--- a/src/Application/Compendium.Application/Sagas/ProcessManagers/InMemoryProcessManagerRepository.cs
+++ b/src/Application/Compendium.Application/Sagas/ProcessManagers/InMemoryProcessManagerRepository.cs
@@ -33,6 +33,29 @@ public sealed class InMemoryProcessManagerRepository : IProcessManagerRepository
     }
 
     /// <inheritdoc />
+    public Task<Result<IProcessManager<TState>>> GetByIdAsync<TState>(Guid id, CancellationToken cancellationToken = default)
+        where TState : class, new()
+    {
+        if (!_store.TryGetValue(id, out var pm))
+        {
+            return Task.FromResult(Result.Failure<IProcessManager<TState>>(
+                Error.NotFound("ProcessManager.NotFound", $"Process manager {id} not found.")));
+        }
+
+        // The in-memory store keeps the original IProcessManager<TState> reference, so the
+        // typed shape is just a runtime cast. Mismatches surface as a clear Conflict
+        // (e.g. saving a process manager with state TStateA and reloading with TStateB).
+        if (pm is IProcessManager<TState> typed)
+        {
+            return Task.FromResult(Result.Success(typed));
+        }
+
+        return Task.FromResult(Result.Failure<IProcessManager<TState>>(Error.Conflict(
+            "ProcessManager.StateTypeMismatch",
+            $"Process manager {id} was saved with a state type that is not assignable to {typeof(TState).FullName}.")));
+    }
+
+    /// <inheritdoc />
     public Task<Result> SaveAsync(IProcessManager processManager, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(processManager);

--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/PostgresProcessManagerStateReloadTests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/PostgresProcessManagerStateReloadTests.cs
@@ -1,0 +1,172 @@
+// -----------------------------------------------------------------------
+// <copyright file="PostgresProcessManagerStateReloadTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Sagas.Common;
+using Compendium.Abstractions.Sagas.ProcessManagers;
+using Compendium.Adapters.PostgreSQL.Configuration;
+using Compendium.Adapters.PostgreSQL.Sagas;
+using Compendium.Application.Sagas.ProcessManagers;
+using Compendium.Core.Results;
+using Compendium.IntegrationTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
+
+/// <summary>
+/// Validates the typed-state reload contract added in preview.5: a saga whose state was
+/// persisted by <see cref="PostgresProcessManagerRepository.SaveAsync"/> can be reloaded
+/// via <c>GetByIdAsync&lt;TState&gt;</c> with its full domain state intact. This is the
+/// foundation for idempotent saga step retries — without it, resumption can't tell what
+/// external work has already been done.
+/// </summary>
+[Trait("Category", "E2E")]
+[Trait("Category", "Saga")]
+public sealed class PostgresProcessManagerStateReloadTests : IClassFixture<PostgreSqlFixture>, IAsyncLifetime
+{
+    private readonly PostgreSqlFixture _pg;
+    private PostgresProcessManagerRepository _repository = null!;
+
+    public PostgresProcessManagerStateReloadTests(PostgreSqlFixture pg)
+    {
+        _pg = pg;
+    }
+
+    public async Task InitializeAsync()
+    {
+        if (!_pg.IsAvailable)
+        {
+            return;
+        }
+
+        var options = Options.Create(new PostgreSqlOptions { ConnectionString = _pg.ConnectionString });
+        _repository = new PostgresProcessManagerRepository(options);
+        await _repository.InitializeAsync();
+        await _pg.CleanTableAsync("process_manager_steps");
+        await _pg.CleanTableAsync("process_managers");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [RequiresDockerFact]
+    public async Task GetByIdAsyncTyped_AfterSave_RestoresStateUntouched()
+    {
+        if (!_pg.IsAvailable)
+        {
+            return;
+        }
+
+        var pm = ProvisionOrgProcessManager.Create("acme", "admin@acme.test");
+        pm.State.ZitadelOrgId = "zit-001";
+        pm.State.K8sNamespace = "acme-prod";
+        pm.State.DbSchemaCreated = true;
+
+        var save = await _repository.SaveAsync(pm);
+        save.IsSuccess.Should().BeTrue();
+
+        var loaded = await _repository.GetByIdAsync<ProvisionOrgState>(pm.Id);
+
+        loaded.IsSuccess.Should().BeTrue();
+        loaded.Value.Id.Should().Be(pm.Id);
+        loaded.Value.State.OrgName.Should().Be("acme");
+        loaded.Value.State.AdminEmail.Should().Be("admin@acme.test");
+        loaded.Value.State.ZitadelOrgId.Should().Be("zit-001");
+        loaded.Value.State.K8sNamespace.Should().Be("acme-prod");
+        loaded.Value.State.DbSchemaCreated.Should().BeTrue();
+        loaded.Value.Steps.Should().HaveCount(3);
+    }
+
+    [RequiresDockerFact]
+    public async Task GetByIdAsyncTyped_NotFound_ReturnsNotFoundError()
+    {
+        if (!_pg.IsAvailable)
+        {
+            return;
+        }
+
+        var loaded = await _repository.GetByIdAsync<ProvisionOrgState>(Guid.NewGuid());
+
+        loaded.IsFailure.Should().BeTrue();
+        loaded.Error.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [RequiresDockerFact]
+    public async Task GetByIdAsyncTyped_StateWritesAfterLoadDoNotEscapeBack()
+    {
+        // The reload returns a snapshot; mutating it without calling SaveAsync must not
+        // round-trip into the database. This confirms the rehydrated instance is decoupled
+        // from the persisted row — the orchestrator stays the only writer.
+        if (!_pg.IsAvailable)
+        {
+            return;
+        }
+
+        var pm = ProvisionOrgProcessManager.Create("widget", "owner@widget.test");
+        await _repository.SaveAsync(pm);
+
+        var firstLoad = await _repository.GetByIdAsync<ProvisionOrgState>(pm.Id);
+        firstLoad.Value.State.ZitadelOrgId = "leaked";
+
+        var secondLoad = await _repository.GetByIdAsync<ProvisionOrgState>(pm.Id);
+        secondLoad.Value.State.ZitadelOrgId.Should().BeNull();
+    }
+
+    [RequiresDockerFact]
+    public async Task GetByIdAsyncTyped_AfterCrashAndResume_StateRestored()
+    {
+        // Simulates the saga reuse case: step 1 completes and persists state, the host
+        // crashes, a new repository instance reloads — the typed state must let step 2
+        // detect that step 1's external work is already done and skip duplicates.
+        if (!_pg.IsAvailable)
+        {
+            return;
+        }
+
+        var pm = ProvisionOrgProcessManager.Create("foo", "bar@foo.test");
+        pm.State.ZitadelOrgId = "zit-foo-001";
+        pm.State.AdminUserId = "user-007";
+        await _repository.SaveAsync(pm);
+
+        // Fresh repository instance — mirrors a process restart.
+        var freshRepo = new PostgresProcessManagerRepository(
+            Options.Create(new PostgreSqlOptions { ConnectionString = _pg.ConnectionString }));
+
+        var resumed = await freshRepo.GetByIdAsync<ProvisionOrgState>(pm.Id);
+        resumed.IsSuccess.Should().BeTrue();
+        resumed.Value.State.ZitadelOrgId.Should().Be("zit-foo-001");
+        resumed.Value.State.AdminUserId.Should().Be("user-007");
+    }
+
+    private sealed class ProvisionOrgState
+    {
+        public string OrgName { get; set; } = string.Empty;
+
+        public string AdminEmail { get; set; } = string.Empty;
+
+        public string? ZitadelOrgId { get; set; }
+
+        public string? AdminUserId { get; set; }
+
+        public string? K8sNamespace { get; set; }
+
+        public bool DbSchemaCreated { get; set; }
+    }
+
+    private sealed class ProvisionOrgProcessManager : ProcessManager<ProvisionOrgState>
+    {
+        private ProvisionOrgProcessManager(Guid id, ProvisionOrgState state)
+            : base(id, state, new[] { "ProvisionZitadel", "CreateDbSchema", "CreateK8sNamespace" })
+        {
+        }
+
+        public static ProvisionOrgProcessManager Create(string orgName, string adminEmail) =>
+            new(
+                Guid.NewGuid(),
+                new ProvisionOrgState { OrgName = orgName, AdminEmail = adminEmail });
+    }
+}

--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ProcessManagerE2ETests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ProcessManagerE2ETests.cs
@@ -104,6 +104,46 @@ public sealed class ProcessManagerE2ETests
     }
 
     [Fact]
+    public async Task Repository_TypedGetByIdAsync_ReturnsSameInstanceWithTypedState()
+    {
+        var (_, repository, _) = BuildOrchestrator();
+        var pm = OrderProcessManager.Create("order-typed", 99.99m);
+        await repository.SaveAsync(pm);
+
+        var typed = await repository.GetByIdAsync<OrderProcessState>(pm.Id);
+
+        typed.IsSuccess.Should().BeTrue();
+        typed.Value.Id.Should().Be(pm.Id);
+        typed.Value.State.OrderId.Should().Be("order-typed");
+        typed.Value.State.Amount.Should().Be(99.99m);
+    }
+
+    [Fact]
+    public async Task Repository_TypedGetByIdAsync_StateTypeMismatch_ReturnsConflict()
+    {
+        var (_, repository, _) = BuildOrchestrator();
+        var pm = OrderProcessManager.Create("order-mismatch", 1.0m);
+        await repository.SaveAsync(pm);
+
+        var wrongType = await repository.GetByIdAsync<UnrelatedState>(pm.Id);
+
+        wrongType.IsFailure.Should().BeTrue();
+        wrongType.Error.Type.Should().Be(ErrorType.Conflict);
+        wrongType.Error.Code.Should().Be("ProcessManager.StateTypeMismatch");
+    }
+
+    [Fact]
+    public async Task Repository_TypedGetByIdAsync_NotFound_ReturnsNotFound()
+    {
+        var (_, repository, _) = BuildOrchestrator();
+
+        var loaded = await repository.GetByIdAsync<OrderProcessState>(Guid.NewGuid());
+
+        loaded.IsFailure.Should().BeTrue();
+        loaded.Error.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
     public async Task Orchestrator_MultipleStepsInSequence_TimestampsAreNonDecreasing()
     {
         // Note: assertion uses BeOnOrBefore rather than BeBefore because system-clock
@@ -141,6 +181,11 @@ public sealed class ProcessManagerE2ETests
         public string OrderId { get; set; } = string.Empty;
 
         public decimal Amount { get; set; }
+    }
+
+    private sealed class UnrelatedState
+    {
+        public string Anything { get; set; } = string.Empty;
     }
 
     private sealed class OrderProcessManager : ProcessManager<OrderProcessState>


### PR DESCRIPTION
## Summary

Adds `Task<Result<IProcessManager<TState>>> GetByIdAsync<TState>(Guid id, ct)` to `IProcessManagerRepository`. This is the foundation needed by upstream consumers (Nexus org/project provisioning sagas) to **resume a saga from any step with full typed state**, so each step can detect work it has already completed and stay idempotent on retries.

Without this, durable adapters serialize the state on `SaveAsync` (already implemented) but never read it back — every reload returns a stateless `IProcessManager` and resumed steps can't tell what's already been done. The result was orphaned external resources (Zitadel orgs, K8s namespaces) on every partial failure.

## Changes

- `IProcessManagerRepository`: new typed `GetByIdAsync<TState>` overload. Untyped overload unchanged.
- `PostgresProcessManagerRepository`: shared `LoadCoreAsync` selects `state_json`; typed path deserializes via `JsonSerializer.Deserialize<TState>`. Returns `ProcessManager.StateDeserializationFailed` on malformed JSON. If no state was saved before `SaveAsync`, hands back a fresh `TState`.
- `InMemoryProcessManagerRepository`: typed path casts the in-memory instance; surfaces `ProcessManager.StateTypeMismatch` (Conflict) on a wrong type parameter.
- New `PersistedProcessManager<TState>` (internal, Postgres adapter).

## Tests

- `ProcessManagerE2ETests` — 3 new InMemory facts: typed reload, type mismatch, not-found.
- `PostgresProcessManagerStateReloadTests` (new file, 4 facts) — gated on `RequiresDockerFact`. Covers happy-path round-trip, not-found, snapshot isolation (mutations after load don't escape back), and crash-and-resume via a fresh repository instance.

All 8 ProcessManager E2E tests pass locally without Docker; Postgres-gated facts skip cleanly.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test --filter ProcessManagerE2ETests` — 8 passed
- [ ] CI: Docker-gated Postgres facts run green on the runner
- [ ] Tag preview.5 + Nexus bump after merge so the org/project saga PRs can consume this

## Why this matters (context)

This unblocks Phase 1/2 of the Nexus stabilization plan: rewriting `ProvisionOrganizationCommandHandler` and `ProvisionProjectCommandHandler` as `ProcessManager`-backed sagas with idempotent steps + compensation. Both depend on being able to inspect the typed state on resume to decide whether external work is already done.