### PR TITLE
fix(zitadel): idempotent CREATE on Org/Project + fail-fast OIDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for the same admin email left an orphan Zitadel org behind and stuck the
   upstream Nexus aggregate in `Provisioning` state. Other failure types
   (validation, unauthorized, network) still propagate as before.
+- `Compendium.Adapters.Zitadel.ZitadelOrganizationIdentityProvisioner` now also
+  treats "resource already exists" conflicts on the Organization, Project, and
+  OIDC App creation steps as recoverable, mirroring the user-conflict handling
+  already in place. On Conflict for org/project, the provisioner falls back to
+  a lookup by name and reuses the existing id. For OIDC apps, the provisioner
+  fails fast with `Zitadel.OidcAppExistsButSecretLost` because the client
+  secret is only returned once by Zitadel and cannot be safely re-derived from
+  a lookup. Operators must manually rotate the OIDC secret in Zitadel and
+  re-run provisioning. Without these changes, every retry of a saga that got
+  past the user step but failed later left orphan Zitadel resources behind.
+  Adds `IOrganizationService.GetOrganizationByNameAsync` to the public
+  identity-abstractions surface so consumers can implement the same idempotent
+  pattern against other identity providers.
 
 ### Added
 

--- a/src/Abstractions/Compendium.Abstractions.Identity/IOrganizationService.cs
+++ b/src/Abstractions/Compendium.Abstractions.Identity/IOrganizationService.cs
@@ -33,6 +33,21 @@ public interface IOrganizationService
     Task<Result<IdentityOrganization>> GetOrganizationAsync(string organizationId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Retrieves an organization by name (case-insensitive equals).
+    /// </summary>
+    /// <param name="name">The organization name to look up.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the organization or <see cref="IdentityErrors.OrganizationNotFound"/> if no match.</returns>
+    /// <remarks>
+    /// Primary use case is recovery from <see cref="ErrorType.Conflict"/> on
+    /// <see cref="CreateOrganizationAsync"/>: when the create call fails because the org
+    /// already exists, the caller can look up the existing id and reuse it. Identity
+    /// providers may legitimately have a single shared organization across many tenants
+    /// keyed by name (e.g. a re-run of a saga that previously created the org).
+    /// </remarks>
+    Task<Result<IdentityOrganization>> GetOrganizationByNameAsync(string name, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Adds a user as a member of an organization with specified roles.
     /// </summary>
     /// <param name="organizationId">The unique identifier of the organization.</param>

--- a/src/Abstractions/Compendium.Abstractions.Identity/IdentityErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Identity/IdentityErrors.cs
@@ -37,6 +37,12 @@ public static class IdentityErrors
         Error.NotFound("Identity.OrganizationNotFound", $"Organization with ID '{organizationId}' was not found.");
 
     /// <summary>
+    /// Error returned when no organization matches the supplied name.
+    /// </summary>
+    public static Error OrganizationNotFoundByName(string name) =>
+        Error.NotFound("Identity.OrganizationNotFoundByName", $"Organization with name '{name}' was not found.");
+
+    /// <summary>
     /// Error returned when an organization with the specified name already exists.
     /// </summary>
     public static Error OrganizationAlreadyExists(string name) =>

--- a/src/Adapters/Compendium.Adapters.Zitadel/Compendium.Adapters.Zitadel.csproj
+++ b/src/Adapters/Compendium.Adapters.Zitadel/Compendium.Adapters.Zitadel.csproj
@@ -24,6 +24,13 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Compendium.Adapters.Zitadel.Tests" />
+    <!--
+      Castle DynamicProxy (used by NSubstitute) generates proxy types in a runtime
+      assembly named "DynamicProxyGenAssembly2". The Zitadel test suite partial-mocks
+      ZitadelHttpClient (an internal, non-sealed class with virtual methods) to avoid
+      having to mock raw HTTP, so we must grant DynamicProxyGen access to internals.
+    -->
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
 </Project>

--- a/src/Adapters/Compendium.Adapters.Zitadel/Http/Models/ZitadelApiModels.cs
+++ b/src/Adapters/Compendium.Adapters.Zitadel/Http/Models/ZitadelApiModels.cs
@@ -633,3 +633,167 @@ internal sealed record ZitadelErrorDetail
     [JsonPropertyName("message")]
     public string? Message { get; init; }
 }
+
+/// <summary>
+/// Search request for organizations (POST /v2/organizations/_search).
+/// </summary>
+internal sealed record ZitadelOrganizationSearchRequest
+{
+    [JsonPropertyName("query")]
+    public ZitadelSearchQuery? Query { get; init; }
+
+    [JsonPropertyName("queries")]
+    public List<ZitadelOrganizationQuery>? Queries { get; init; }
+}
+
+/// <summary>
+/// Single query filter for organization search.
+/// </summary>
+internal sealed record ZitadelOrganizationQuery
+{
+    [JsonPropertyName("nameQuery")]
+    public ZitadelOrgNameQuery? NameQuery { get; init; }
+}
+
+/// <summary>
+/// Name query filter for organization search.
+/// </summary>
+internal sealed record ZitadelOrgNameQuery
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("method")]
+    public string? Method { get; init; }
+}
+
+/// <summary>
+/// Search response wrapping a list of organizations.
+/// </summary>
+internal sealed record ZitadelOrganizationSearchResponse
+{
+    [JsonPropertyName("details")]
+    public ZitadelListDetails? Details { get; init; }
+
+    [JsonPropertyName("result")]
+    public List<ZitadelOrganization>? Result { get; init; }
+}
+
+/// <summary>
+/// Search request for projects (POST /management/v1/projects/_search).
+/// </summary>
+internal sealed record ZitadelProjectSearchRequest
+{
+    [JsonPropertyName("query")]
+    public ZitadelSearchQuery? Query { get; init; }
+
+    [JsonPropertyName("queries")]
+    public List<ZitadelProjectQuery>? Queries { get; init; }
+}
+
+/// <summary>
+/// Single query filter for project search.
+/// </summary>
+internal sealed record ZitadelProjectQuery
+{
+    [JsonPropertyName("nameQuery")]
+    public ZitadelProjectNameQuery? NameQuery { get; init; }
+}
+
+/// <summary>
+/// Name query filter for project search.
+/// </summary>
+internal sealed record ZitadelProjectNameQuery
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("method")]
+    public string? Method { get; init; }
+}
+
+/// <summary>
+/// Search response wrapping a list of projects.
+/// </summary>
+internal sealed record ZitadelProjectSearchResponse
+{
+    [JsonPropertyName("details")]
+    public ZitadelListDetails? Details { get; init; }
+
+    [JsonPropertyName("result")]
+    public List<ZitadelProject>? Result { get; init; }
+}
+
+/// <summary>
+/// Search request for OIDC applications within a project
+/// (POST /management/v1/projects/{projectId}/apps/_search).
+/// </summary>
+internal sealed record ZitadelAppSearchRequest
+{
+    [JsonPropertyName("query")]
+    public ZitadelSearchQuery? Query { get; init; }
+
+    [JsonPropertyName("queries")]
+    public List<ZitadelAppQuery>? Queries { get; init; }
+}
+
+/// <summary>
+/// Single query filter for application search.
+/// </summary>
+internal sealed record ZitadelAppQuery
+{
+    [JsonPropertyName("nameQuery")]
+    public ZitadelAppNameQuery? NameQuery { get; init; }
+}
+
+/// <summary>
+/// Name query filter for application search.
+/// </summary>
+internal sealed record ZitadelAppNameQuery
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("method")]
+    public string? Method { get; init; }
+}
+
+/// <summary>
+/// Search response wrapping a list of applications.
+/// </summary>
+internal sealed record ZitadelAppSearchResponse
+{
+    [JsonPropertyName("details")]
+    public ZitadelListDetails? Details { get; init; }
+
+    [JsonPropertyName("result")]
+    public List<ZitadelApp>? Result { get; init; }
+}
+
+/// <summary>
+/// Application list item returned from app search
+/// (subset — does not include client_secret, which Zitadel only returns once at creation).
+/// </summary>
+internal sealed record ZitadelApp
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("state")]
+    public string? State { get; init; }
+
+    [JsonPropertyName("oidcConfig")]
+    public ZitadelAppOidcConfigSummary? OidcConfig { get; init; }
+}
+
+/// <summary>
+/// Subset of OIDC config returned by app search — notably without client_secret.
+/// </summary>
+internal sealed record ZitadelAppOidcConfigSummary
+{
+    [JsonPropertyName("clientId")]
+    public string? ClientId { get; init; }
+}

--- a/src/Adapters/Compendium.Adapters.Zitadel/Http/ZitadelHttpClient.cs
+++ b/src/Adapters/Compendium.Adapters.Zitadel/Http/ZitadelHttpClient.cs
@@ -14,7 +14,12 @@ namespace Compendium.Adapters.Zitadel.Http;
 /// HTTP client for communicating with Zitadel REST API.
 /// Handles authentication, token management, and API calls.
 /// </summary>
-internal sealed class ZitadelHttpClient : IDisposable
+/// <remarks>
+/// Non-sealed and selected methods are <c>virtual</c> so unit tests can substitute
+/// a fake without spinning up a real <see cref="HttpClient"/>. Production behaviour
+/// is unchanged — the class still implements the same contract.
+/// </remarks>
+internal class ZitadelHttpClient : IDisposable
 {
     private readonly HttpClient _httpClient;
     private readonly ZitadelOptions _options;
@@ -323,7 +328,7 @@ internal sealed class ZitadelHttpClient : IDisposable
     /// <summary>
     /// Creates a project within an organization.
     /// </summary>
-    public async Task<Result<ZitadelProject>> CreateProjectAsync(
+    public virtual async Task<Result<ZitadelProject>> CreateProjectAsync(
         ZitadelCreateProjectRequest request,
         string organizationId,
         CancellationToken cancellationToken = default)
@@ -336,9 +341,56 @@ internal sealed class ZitadelHttpClient : IDisposable
     }
 
     /// <summary>
+    /// Looks up a project within an organization by name (case-insensitive equals).
+    /// </summary>
+    /// <remarks>
+    /// Used by <c>ZitadelOrganizationIdentityProvisioner</c> to recover from
+    /// Conflict on <see cref="CreateProjectAsync"/>. Returns
+    /// <see cref="Error.NotFound"/> when no project matches.
+    /// </remarks>
+    public virtual async Task<Result<ZitadelProject>> GetProjectByNameAsync(
+        string projectName,
+        string organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(projectName);
+        ArgumentNullException.ThrowIfNull(organizationId);
+        const string url = "management/v1/projects/_search";
+
+        var searchRequest = new ZitadelProjectSearchRequest
+        {
+            Query = new ZitadelSearchQuery { Limit = 1 },
+            Queries = new List<ZitadelProjectQuery>
+            {
+                new()
+                {
+                    NameQuery = new ZitadelProjectNameQuery
+                    {
+                        Name = projectName,
+                        Method = "TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE"
+                    }
+                }
+            }
+        };
+
+        var result = await PostAsync<ZitadelProjectSearchResponse>(
+            url, searchRequest, organizationId, cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return result.Error;
+        }
+
+        var project = result.Value.Result?.FirstOrDefault();
+        return project is null
+            ? Error.NotFound("Zitadel.ProjectNotFound", $"No project with name '{projectName}' found in organization '{organizationId}'.")
+            : Result.Success(project);
+    }
+
+    /// <summary>
     /// Creates an OIDC application within a project.
     /// </summary>
-    public async Task<Result<ZitadelOidcApp>> CreateOidcApplicationAsync(
+    public virtual async Task<Result<ZitadelOidcApp>> CreateOidcApplicationAsync(
         string projectId,
         ZitadelCreateOidcAppRequest request,
         string organizationId,
@@ -350,6 +402,95 @@ internal sealed class ZitadelHttpClient : IDisposable
         var url = $"management/v1/projects/{projectId}/apps/oidc";
 
         return await PostAsync<ZitadelOidcApp>(url, request, organizationId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Looks up an OIDC application within a project by name (case-insensitive equals).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Used by <c>ZitadelOrganizationIdentityProvisioner</c> to surface a clear error when
+    /// <see cref="CreateOidcApplicationAsync"/> reports Conflict.
+    /// </para>
+    /// <para>
+    /// Note: the response from this endpoint <b>does not include the client_secret</b>.
+    /// Zitadel only returns the client_secret once, at creation time. Callers must not
+    /// silently reuse a found application as if creation had succeeded.
+    /// </para>
+    /// </remarks>
+    public virtual async Task<Result<ZitadelApp>> GetOidcApplicationByNameAsync(
+        string projectId,
+        string appName,
+        string organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(projectId);
+        ArgumentNullException.ThrowIfNull(appName);
+        ArgumentNullException.ThrowIfNull(organizationId);
+        var url = $"management/v1/projects/{projectId}/apps/_search";
+
+        var searchRequest = new ZitadelAppSearchRequest
+        {
+            Query = new ZitadelSearchQuery { Limit = 1 },
+            Queries = new List<ZitadelAppQuery>
+            {
+                new()
+                {
+                    NameQuery = new ZitadelAppNameQuery
+                    {
+                        Name = appName,
+                        Method = "TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE"
+                    }
+                }
+            }
+        };
+
+        var result = await PostAsync<ZitadelAppSearchResponse>(
+            url, searchRequest, organizationId, cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return result.Error;
+        }
+
+        var app = result.Value.Result?.FirstOrDefault();
+        return app is null
+            ? Error.NotFound("Zitadel.AppNotFound", $"No application with name '{appName}' found in project '{projectId}'.")
+            : Result.Success(app);
+    }
+
+    /// <summary>
+    /// Searches organizations by name (case-insensitive equals).
+    /// </summary>
+    /// <remarks>
+    /// Used by <c>ZitadelOrganizationService.GetOrganizationByNameAsync</c>
+    /// to recover from Conflict on <see cref="CreateOrganizationAsync"/>.
+    /// </remarks>
+    public virtual async Task<Result<ZitadelOrganizationSearchResponse>> SearchOrganizationsByNameAsync(
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        const string url = "v2/organizations/_search";
+
+        var searchRequest = new ZitadelOrganizationSearchRequest
+        {
+            Query = new ZitadelSearchQuery { Limit = 1 },
+            Queries = new List<ZitadelOrganizationQuery>
+            {
+                new()
+                {
+                    NameQuery = new ZitadelOrgNameQuery
+                    {
+                        Name = name,
+                        Method = "TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE"
+                    }
+                }
+            }
+        };
+
+        return await PostAsync<ZitadelOrganizationSearchResponse>(
+            url, searchRequest, null, cancellationToken);
     }
 
     /// <summary>

--- a/src/Adapters/Compendium.Adapters.Zitadel/Services/ZitadelOrganizationIdentityProvisioner.cs
+++ b/src/Adapters/Compendium.Adapters.Zitadel/Services/ZitadelOrganizationIdentityProvisioner.cs
@@ -74,27 +74,61 @@ internal sealed class ZitadelOrganizationIdentityProvisioner : IOrganizationIden
             return postLogoutUriResult.Error;
         }
 
-        // Step 1: Create Zitadel organization
+        // Step 1: Create Zitadel organization (idempotent — reuse on Conflict).
+        // Mirrors Step 4's user-conflict handling: if the org already exists in
+        // Zitadel (typical when a previous saga run created the org but failed
+        // later, e.g. on the project step), look it up by name and reuse the id.
+        // Without this, every retry leaks an orphan org because each create
+        // generates a new id even when Zitadel rejects the request.
+        var displayName = request.DisplayName ?? request.Name;
         var orgResult = await _organizationService.CreateOrganizationAsync(
-            new CreateOrganizationRequest { Name = request.DisplayName ?? request.Name },
+            new CreateOrganizationRequest { Name = displayName },
             cancellationToken);
 
+        string zitadelOrgId;
         if (orgResult.IsFailure)
         {
-            _logger.LogWarning(
-                "Failed to create Zitadel organization for {OrganizationName}: {Error}",
-                request.Name, orgResult.Error.Message);
-            return orgResult.Error;
+            if (orgResult.Error.Type != ErrorType.Conflict)
+            {
+                _logger.LogWarning(
+                    "Failed to create Zitadel organization for {OrganizationName}: {Error}",
+                    request.Name, orgResult.Error.Message);
+                return orgResult.Error;
+            }
+
+            _logger.LogInformation(
+                "Zitadel organization already exists for {OrganizationName}; looking up to reuse",
+                request.Name);
+
+            var existingOrg = await _organizationService.GetOrganizationByNameAsync(
+                displayName, cancellationToken);
+            if (existingOrg.IsFailure)
+            {
+                _logger.LogWarning(
+                    "Organization create reported conflict but lookup by name failed: {Error}",
+                    existingOrg.Error.Message);
+                return existingOrg.Error;
+            }
+
+            zitadelOrgId = existingOrg.Value.Id;
+            _logger.LogInformation(
+                "Reusing existing Zitadel organization {ZitadelOrgId} for {OrganizationName}",
+                zitadelOrgId, request.Name);
+        }
+        else
+        {
+            zitadelOrgId = orgResult.Value.Id;
+            _logger.LogInformation("Created Zitadel organization {ZitadelOrgId}", zitadelOrgId);
         }
 
-        var zitadelOrgId = orgResult.Value.Id;
-        _logger.LogInformation("Created Zitadel organization {ZitadelOrgId}", zitadelOrgId);
-
-        // Step 2: Create project
+        // Step 2: Create project (idempotent — reuse on Conflict).
+        // Same shape as Step 1: project names within an org are unique in Zitadel,
+        // so a Conflict here means the project survives from a previous saga run.
+        var projectName = $"nexus-{request.Name}";
         var projectResult = await _httpClient.CreateProjectAsync(
             new ZitadelCreateProjectRequest
             {
-                Name = $"nexus-{request.Name}",
+                Name = projectName,
                 ProjectRoleAssertion = true,
                 ProjectRoleCheck = true,
                 HasProjectCheck = true
@@ -102,26 +136,60 @@ internal sealed class ZitadelOrganizationIdentityProvisioner : IOrganizationIden
             zitadelOrgId,
             cancellationToken);
 
+        string projectId;
         if (projectResult.IsFailure)
         {
-            _logger.LogWarning(
-                "Failed to create project for organization {ZitadelOrgId}: {Error}",
-                zitadelOrgId, projectResult.Error.Message);
-            return projectResult.Error;
+            if (projectResult.Error.Type != ErrorType.Conflict)
+            {
+                _logger.LogWarning(
+                    "Failed to create project for organization {ZitadelOrgId}: {Error}",
+                    zitadelOrgId, projectResult.Error.Message);
+                return projectResult.Error;
+            }
+
+            _logger.LogInformation(
+                "Project {ProjectName} already exists in Zitadel organization {ZitadelOrgId}; looking up to reuse",
+                projectName, zitadelOrgId);
+
+            var existingProject = await _httpClient.GetProjectByNameAsync(
+                projectName, zitadelOrgId, cancellationToken);
+            if (existingProject.IsFailure)
+            {
+                _logger.LogWarning(
+                    "Project create reported conflict but lookup by name failed: {Error}",
+                    existingProject.Error.Message);
+                return existingProject.Error;
+            }
+
+            projectId = existingProject.Value.Id ?? string.Empty;
+            _logger.LogInformation(
+                "Reusing existing project {ProjectId} in organization {ZitadelOrgId}",
+                projectId, zitadelOrgId);
+        }
+        else
+        {
+            projectId = projectResult.Value.Details?.ResourceOwner is not null
+                ? projectResult.Value.Id ?? projectResult.Value.Details.ResourceOwner
+                : projectResult.Value.Id ?? string.Empty;
+            _logger.LogInformation("Created project {ProjectId} for organization {ZitadelOrgId}",
+                projectId, zitadelOrgId);
         }
 
-        var projectId = projectResult.Value.Details?.ResourceOwner is not null
-            ? projectResult.Value.Id ?? projectResult.Value.Details.ResourceOwner
-            : projectResult.Value.Id ?? string.Empty;
-        _logger.LogInformation("Created project {ProjectId} for organization {ZitadelOrgId}",
-            projectId, zitadelOrgId);
-
-        // Step 3: Create OIDC application using URIs resolved in Step 0
+        // Step 3: Create OIDC application using URIs resolved in Step 0.
+        // Conflict here is NOT recoverable the same way as Steps 1, 2, 4.
+        // Zitadel returns the OIDC client_secret only once, at creation time. If
+        // we silently reused a found app, the saga's downstream secrets step
+        // would persist an empty/wrong secret, leaving the OIDC app permanently
+        // broken from the platform's point of view. Fail fast with a clearly
+        // labelled error so an operator knows to rotate the secret in Zitadel
+        // and re-run provisioning. Cleanup of the org/project created above is
+        // the saga's responsibility — the provisioner does not roll back.
+        var appName = $"nexus-{request.Name}-app";
         var oidcResult = await _httpClient.CreateOidcApplicationAsync(
             projectId,
             new ZitadelCreateOidcAppRequest
             {
-                Name = $"nexus-{request.Name}-app",
+                Name = appName,
                 RedirectUris = [redirectUriResult.Value],
                 PostLogoutRedirectUris = [postLogoutUriResult.Value],
                 ResponseTypes = ["OIDC_RESPONSE_TYPE_CODE"],
@@ -138,6 +206,20 @@ internal sealed class ZitadelOrganizationIdentityProvisioner : IOrganizationIden
 
         if (oidcResult.IsFailure)
         {
+            if (oidcResult.Error.Type == ErrorType.Conflict)
+            {
+                _logger.LogWarning(
+                    "OIDC application {AppName} already exists in project {ProjectId}: client_secret " +
+                    "is no longer recoverable. Operator must rotate the OIDC secret in Zitadel and retry.",
+                    appName, projectId);
+                return Error.Conflict(
+                    "Zitadel.OidcAppExistsButSecretLost",
+                    $"OIDC application '{appName}' already exists in project '{projectId}'. " +
+                    "Zitadel only returns the client_secret at creation time, so it cannot be " +
+                    "recovered by lookup. Rotate the OIDC client secret for this application in " +
+                    "Zitadel (or delete the application) and re-run provisioning.");
+            }
+
             _logger.LogWarning(
                 "Failed to create OIDC application for project {ProjectId}: {Error}",
                 projectId, oidcResult.Error.Message);

--- a/src/Adapters/Compendium.Adapters.Zitadel/Services/ZitadelOrganizationService.cs
+++ b/src/Adapters/Compendium.Adapters.Zitadel/Services/ZitadelOrganizationService.cs
@@ -87,6 +87,31 @@ internal sealed class ZitadelOrganizationService : IOrganizationService
     }
 
     /// <inheritdoc />
+    public async Task<Result<IdentityOrganization>> GetOrganizationByNameAsync(
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        _logger.LogDebug("Getting organization by name {Name}", name);
+
+        var result = await _httpClient.SearchOrganizationsByNameAsync(name, cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return result.Error;
+        }
+
+        var match = result.Value.Result?.FirstOrDefault();
+        if (match is null)
+        {
+            return IdentityErrors.OrganizationNotFoundByName(name);
+        }
+
+        return MapToIdentityOrganization(match);
+    }
+
+    /// <inheritdoc />
     public async Task<Result> AddMemberAsync(
         string organizationId,
         string userId,

--- a/tests/Unit/Compendium.Adapters.Zitadel.Tests/Services/ZitadelOrganizationIdentityProvisionerTests.cs
+++ b/tests/Unit/Compendium.Adapters.Zitadel.Tests/Services/ZitadelOrganizationIdentityProvisionerTests.cs
@@ -1,0 +1,242 @@
+// -----------------------------------------------------------------------
+// <copyright file="ZitadelOrganizationIdentityProvisionerTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Identity;
+using Compendium.Abstractions.Identity.Models;
+using Compendium.Abstractions.Identity.Models.Requests;
+using Compendium.Adapters.Zitadel.Configuration;
+using Compendium.Adapters.Zitadel.Http;
+using Compendium.Adapters.Zitadel.Http.Models;
+using Compendium.Adapters.Zitadel.Services;
+using Compendium.Core.Results;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Compendium.Adapters.Zitadel.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ZitadelOrganizationIdentityProvisioner"/>'s
+/// idempotent-create behaviour.
+/// </summary>
+/// <remarks>
+/// Mirrors the user-conflict tests already covered by PR #41. We verify three
+/// additional Conflict paths:
+/// <list type="bullet">
+/// <item>Org Conflict → reuse existing org id.</item>
+/// <item>Project Conflict → reuse existing project id.</item>
+/// <item>OIDC app Conflict → fail fast with <c>Zitadel.OidcAppExistsButSecretLost</c>
+/// (cannot reuse: client_secret is only returned at creation time).</item>
+/// </list>
+/// </remarks>
+public class ZitadelOrganizationIdentityProvisionerTests
+{
+    private const string OrgName = "acme";
+    private const string DisplayName = "ACME";
+    private const string ZitadelOrgId = "11111111";
+    private const string ProjectId = "22222222";
+    private const string AdminUserId = "33333333";
+    private const string AdminEmail = "admin@acme.test";
+
+    private static readonly OrganizationProvisioningRequest Request = new(
+        OrganizationId: "org-aggregate-id",
+        Name: OrgName,
+        DisplayName: DisplayName,
+        PlanId: "free",
+        AdminUser: new AdminUserProvisioningRequest(
+            Email: AdminEmail,
+            FirstName: "Ada",
+            LastName: "Lovelace",
+            Password: null,
+            PreferredLanguage: "en"));
+
+    [Fact]
+    public async Task ProvisionAsync_OrganizationConflict_ReusesExistingOrg()
+    {
+        // Arrange
+        var orgService = Substitute.For<IOrganizationService>();
+        var userService = Substitute.For<IIdentityUserService>();
+        var httpClient = CreateFakeHttpClient();
+
+        orgService
+            .CreateOrganizationAsync(Arg.Any<CreateOrganizationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<IdentityOrganization>(
+                Error.Conflict("Zitadel.Conflict", "Organization already exists")));
+        orgService
+            .GetOrganizationByNameAsync(DisplayName, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new IdentityOrganization
+            {
+                Id = ZitadelOrgId,
+                Name = DisplayName,
+                IsActive = true
+            }));
+        orgService
+            .AddMemberAsync(ZitadelOrgId, AdminUserId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+
+        httpClient
+            .CreateProjectAsync(Arg.Any<ZitadelCreateProjectRequest>(), ZitadelOrgId, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new ZitadelProject { Id = ProjectId, Name = $"nexus-{OrgName}" }));
+        httpClient
+            .CreateOidcApplicationAsync(ProjectId, Arg.Any<ZitadelCreateOidcAppRequest>(), ZitadelOrgId, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new ZitadelOidcApp
+            {
+                AppId = "app-1",
+                ClientId = "client-1",
+                ClientSecret = "secret-1"
+            }));
+
+        userService
+            .CreateUserAsync(Arg.Any<CreateUserRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new IdentityUser { Id = AdminUserId, Email = AdminEmail }));
+
+        var provisioner = CreateProvisioner(httpClient, orgService, userService);
+
+        // Act
+        var result = await provisioner.ProvisionAsync(Request);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExternalOrganizationId.Should().Be(ZitadelOrgId);
+        result.Value.ExternalProjectId.Should().Be(ProjectId);
+        result.Value.ClientSecret.Should().Be("secret-1");
+
+        await orgService.Received(1)
+            .GetOrganizationByNameAsync(DisplayName, Arg.Any<CancellationToken>());
+        await orgService.Received(1)
+            .AddMemberAsync(ZitadelOrgId, AdminUserId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_ProjectConflict_ReusesExistingProject()
+    {
+        // Arrange
+        var orgService = Substitute.For<IOrganizationService>();
+        var userService = Substitute.For<IIdentityUserService>();
+        var httpClient = CreateFakeHttpClient();
+
+        orgService
+            .CreateOrganizationAsync(Arg.Any<CreateOrganizationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new IdentityOrganization { Id = ZitadelOrgId, Name = DisplayName }));
+        orgService
+            .AddMemberAsync(ZitadelOrgId, AdminUserId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+
+        httpClient
+            .CreateProjectAsync(Arg.Any<ZitadelCreateProjectRequest>(), ZitadelOrgId, Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<ZitadelProject>(
+                Error.Conflict("Zitadel.Conflict", "Project name already taken in this org")));
+        httpClient
+            .GetProjectByNameAsync($"nexus-{OrgName}", ZitadelOrgId, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new ZitadelProject { Id = ProjectId, Name = $"nexus-{OrgName}" }));
+        httpClient
+            .CreateOidcApplicationAsync(ProjectId, Arg.Any<ZitadelCreateOidcAppRequest>(), ZitadelOrgId, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new ZitadelOidcApp
+            {
+                AppId = "app-1",
+                ClientId = "client-1",
+                ClientSecret = "secret-1"
+            }));
+
+        userService
+            .CreateUserAsync(Arg.Any<CreateUserRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new IdentityUser { Id = AdminUserId, Email = AdminEmail }));
+
+        var provisioner = CreateProvisioner(httpClient, orgService, userService);
+
+        // Act
+        var result = await provisioner.ProvisionAsync(Request);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExternalProjectId.Should().Be(ProjectId);
+        result.Value.ExternalOrganizationId.Should().Be(ZitadelOrgId);
+        result.Value.ClientSecret.Should().Be("secret-1");
+
+        await httpClient.Received(1)
+            .GetProjectByNameAsync($"nexus-{OrgName}", ZitadelOrgId, Arg.Any<CancellationToken>());
+        await orgService.Received(1)
+            .AddMemberAsync(ZitadelOrgId, AdminUserId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_OidcAppConflict_ReturnsClearError_AndDoesNotCleanUpEarlierResources()
+    {
+        // Arrange
+        var orgService = Substitute.For<IOrganizationService>();
+        var userService = Substitute.For<IIdentityUserService>();
+        var httpClient = CreateFakeHttpClient();
+
+        orgService
+            .CreateOrganizationAsync(Arg.Any<CreateOrganizationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new IdentityOrganization { Id = ZitadelOrgId, Name = DisplayName }));
+
+        httpClient
+            .CreateProjectAsync(Arg.Any<ZitadelCreateProjectRequest>(), ZitadelOrgId, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new ZitadelProject { Id = ProjectId, Name = $"nexus-{OrgName}" }));
+        httpClient
+            .CreateOidcApplicationAsync(ProjectId, Arg.Any<ZitadelCreateOidcAppRequest>(), ZitadelOrgId, Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<ZitadelOidcApp>(
+                Error.Conflict("Zitadel.Conflict", "OIDC app name already taken in project")));
+
+        var provisioner = CreateProvisioner(httpClient, orgService, userService);
+
+        // Act
+        var result = await provisioner.ProvisionAsync(Request);
+
+        // Assert: caller gets a clearly-named conflict error.
+        result.IsFailure.Should().BeTrue();
+        result.Error.Type.Should().Be(ErrorType.Conflict);
+        result.Error.Code.Should().Be("Zitadel.OidcAppExistsButSecretLost");
+        result.Error.Message.Should().Contain($"nexus-{OrgName}-app");
+        result.Error.Message.Should().Contain("client_secret");
+
+        // Provisioner does NOT compensate. Cleanup is the saga's job.
+        await orgService.DidNotReceiveWithAnyArgs()
+            .DeactivateOrganizationAsync(default!, default);
+        await orgService.DidNotReceiveWithAnyArgs()
+            .RemoveMemberAsync(default!, default!, default);
+
+        // The user step should not have run because we failed earlier in step 3.
+        await userService.DidNotReceiveWithAnyArgs()
+            .CreateUserAsync(default!, default);
+    }
+
+    private static ZitadelHttpClient CreateFakeHttpClient()
+    {
+        // ZitadelHttpClient is non-sealed with virtual methods; NSubstitute partial-mocks
+        // it so we can stub only the methods the provisioner calls. The base ctor still
+        // wants a real HttpClient and options, so we pass minimal stubs.
+        var httpClient = new HttpClient { BaseAddress = new Uri("https://zitadel.invalid/") };
+        var options = Options.Create(new ZitadelOptions { Authority = "https://zitadel.invalid" });
+        return Substitute.For<ZitadelHttpClient>(
+            httpClient,
+            options,
+            NullLogger<ZitadelHttpClient>.Instance);
+    }
+
+    private static ZitadelOrganizationIdentityProvisioner CreateProvisioner(
+        ZitadelHttpClient httpClient,
+        IOrganizationService orgService,
+        IIdentityUserService userService)
+    {
+        var options = Options.Create(new ZitadelOptions
+        {
+            Authority = "https://zitadel.invalid",
+            // Provisioner reads these to build the redirect URIs.
+            RedirectUriTemplate = $"https://{ZitadelOptions.OrganizationPlaceholder}.example.test/callback",
+            PostLogoutUriTemplate = $"https://{ZitadelOptions.OrganizationPlaceholder}.example.test/signed-out"
+        });
+        return new ZitadelOrganizationIdentityProvisioner(
+            httpClient,
+            orgService,
+            userService,
+            options,
+            NullLogger<ZitadelOrganizationIdentityProvisioner>.Instance);
+    }
+}


### PR DESCRIPTION
## Summary

Extends the "reuse on Conflict" pattern from PR #41 (user step) to the three other Zitadel resources the provisioner creates. Without this, every saga retry that gets past the user step but fails later leaks orphan Zitadel resources.

- **Organization Conflict** -> look up by name, reuse the existing id.
- **Project Conflict** -> look up by name within the parent org, reuse the existing id.
- **OIDC App Conflict** -> fail fast with `Zitadel.OidcAppExistsButSecretLost`. Zitadel only returns `client_secret` at creation time, so silent reuse would leave the saga unable to persist a valid secret. Operators must rotate the OIDC secret in Zitadel (or delete the app) and retry.

The user-conflict path is unchanged.

## Why fail-fast on OIDC

Choice between:
1. **Recommended (chosen)** -> return a clearly labelled `Conflict` error so an operator decides what to do. Preserves the principle that re-running a saga doesn't silently rotate live credentials.
2. Auto-regenerate via `_regenerate_clientsecret` -> rotates an active secret without explicit consent. Higher blast radius. Rejected.

Cleanup of any org/project created earlier in the saga is the saga's responsibility (compensation), not the provisioner's. Tests verify the provisioner does not emit deactivate/remove calls when bailing on the OIDC step.

## Implementation notes

- New port method `IOrganizationService.GetOrganizationByNameAsync` (Compendium.Abstractions.Identity surface) so any future identity adapter can implement the same idempotent pattern. Backed by Zitadel's `POST /v2/organizations/_search`.
- New methods on `ZitadelHttpClient`: `SearchOrganizationsByNameAsync`, `GetProjectByNameAsync`, `GetOidcApplicationByNameAsync`. The class is now non-sealed with virtual methods so unit tests can partial-mock it without spinning HTTP. A `DynamicProxyGenAssembly2` `InternalsVisibleTo` was added to let Castle DynamicProxy proxy the internal class for NSubstitute.
- New error helper `IdentityErrors.OrganizationNotFoundByName`.
- Provisioner changes mirror the existing user-step handling: Conflict goes to the lookup branch; everything else (validation, unauthorized, network) propagates as before.

## Tests

`tests/Unit/Compendium.Adapters.Zitadel.Tests/Services/ZitadelOrganizationIdentityProvisionerTests.cs` adds three facts:

- `ProvisionAsync_OrganizationConflict_ReusesExistingOrg`
- `ProvisionAsync_ProjectConflict_ReusesExistingProject`
- `ProvisionAsync_OidcAppConflict_ReturnsClearError_AndDoesNotCleanUpEarlierResources`

NSubstitute partial-mocks `ZitadelHttpClient` (now non-sealed, virtual methods), `IOrganizationService` and `IIdentityUserService` are interface-mocked. No HTTP is mocked; no real network calls.

## Test plan

- [x] `dotnet build Compendium.sln` -> 0 errors, 0 new warnings
- [x] `dotnet test tests/Unit/Compendium.Adapters.Zitadel.Tests` -> 23 passed, 0 failed (3 new + 20 pre-existing)
- [x] Full unit + arch test sweep across the solution -> all green, no regressions
- [ ] CI green
- [ ] Smoke-test in Nexus (downstream consumer) once a preview package is cut: provisioner saga retried after a forced project-step failure should no longer leak a Zitadel org

## Notes for reviewers

- The provisioner remains `internal sealed`; only `ZitadelHttpClient` was opened up (made non-sealed with selected virtual methods). Production behaviour is byte-identical for the success path.
- The OIDC fail-fast error code (`Zitadel.OidcAppExistsButSecretLost`) is intentionally distinct from the generic `Zitadel.Conflict` so the upstream saga can branch on it (e.g. surface a clear operator action in the platform UI). Worth a follow-up to wire that detection into the Nexus organization saga.

Closes the gap left by PR #41.