### PR TITLE
test(abstractions/identity): add unit tests for value objects + errors

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -113,6 +113,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.Shared.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Testing.Tests", "tests\Unit\Compendium.Testing.Tests\Compendium.Testing.Tests.csproj", "{E5232EFA-E06C-4975-B5A7-91A241D029CB}"
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.PostgreSQL.Tests", "tests\Unit\Compendium.Adapters.PostgreSQL.Tests\Compendium.Adapters.PostgreSQL.Tests.csproj", "{3E6C387D-A84B-43A8-AAF5-B7A9494C57CE}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Identity.Tests", "tests\Unit\Compendium.Abstractions.Identity.Tests\Compendium.Abstractions.Identity.Tests.csproj", "{0EDEE2DC-46FE-404B-9615-B6E3F756DF75}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -291,6 +292,10 @@ Global
 		{3E6C387D-A84B-43A8-AAF5-B7A9494C57CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E6C387D-A84B-43A8-AAF5-B7A9494C57CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E6C387D-A84B-43A8-AAF5-B7A9494C57CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0EDEE2DC-46FE-404B-9615-B6E3F756DF75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EDEE2DC-46FE-404B-9615-B6E3F756DF75}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0EDEE2DC-46FE-404B-9615-B6E3F756DF75}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0EDEE2DC-46FE-404B-9615-B6E3F756DF75}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -347,5 +352,6 @@ Global
 		{3BFB6A86-8972-4003-9C52-7DFD5D956BAF} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{E5232EFA-E06C-4975-B5A7-91A241D029CB} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{3E6C387D-A84B-43A8-AAF5-B7A9494C57CE} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{0EDEE2DC-46FE-404B-9615-B6E3F756DF75} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/Compendium.Abstractions.Identity.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/Compendium.Abstractions.Identity.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Identity.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Identity.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Identity\Compendium.Abstractions.Identity.csproj" />
+    <ProjectReference Include="..\..\..\src\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/GlobalUsings.cs
@@ -1,0 +1,13 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Abstractions.Identity;
+global using Compendium.Abstractions.Identity.Models;
+global using Compendium.Abstractions.Identity.Models.Requests;
+global using Compendium.Core.Results;
+global using FluentAssertions;
+global using Xunit;

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/IdentityErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/IdentityErrorsTests.cs
@@ -1,0 +1,289 @@
+// -----------------------------------------------------------------------
+// <copyright file="IdentityErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Identity.Tests;
+
+public class IdentityErrorsTests
+{
+    [Fact]
+    public void UserNotFound_WithUserId_ReturnsNotFoundErrorWithCodeAndMessage()
+    {
+        // Arrange
+        const string userId = "user-42";
+
+        // Act
+        var error = IdentityErrors.UserNotFound(userId);
+
+        // Assert
+        error.Code.Should().Be("Identity.UserNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(userId);
+    }
+
+    [Theory]
+    [InlineData("user-1")]
+    [InlineData("")]
+    [InlineData("a-very-long-user-id-1234567890")]
+    public void UserNotFound_AnyUserId_AlwaysReturnsNotFoundErrorType(string userId)
+    {
+        // Act
+        var error = IdentityErrors.UserNotFound(userId);
+
+        // Assert
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Code.Should().Be("Identity.UserNotFound");
+    }
+
+    [Fact]
+    public void UserNotFoundByEmail_WithEmail_ReturnsNotFoundErrorWithCodeAndMessage()
+    {
+        // Arrange
+        const string email = "user@example.com";
+
+        // Act
+        var error = IdentityErrors.UserNotFoundByEmail(email);
+
+        // Assert
+        error.Code.Should().Be("Identity.UserNotFoundByEmail");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(email);
+    }
+
+    [Fact]
+    public void UserAlreadyExists_WithEmail_ReturnsConflictErrorWithCodeAndMessage()
+    {
+        // Arrange
+        const string email = "duplicate@example.com";
+
+        // Act
+        var error = IdentityErrors.UserAlreadyExists(email);
+
+        // Assert
+        error.Code.Should().Be("Identity.UserAlreadyExists");
+        error.Type.Should().Be(ErrorType.Conflict);
+        error.Message.Should().Contain(email);
+    }
+
+    [Fact]
+    public void OrganizationNotFound_WithOrganizationId_ReturnsNotFoundErrorWithCodeAndMessage()
+    {
+        // Arrange
+        const string organizationId = "org-77";
+
+        // Act
+        var error = IdentityErrors.OrganizationNotFound(organizationId);
+
+        // Assert
+        error.Code.Should().Be("Identity.OrganizationNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(organizationId);
+    }
+
+    [Fact]
+    public void OrganizationNotFoundByName_WithName_ReturnsNotFoundErrorWithCodeAndMessage()
+    {
+        // Arrange
+        const string name = "Acme Inc.";
+
+        // Act
+        var error = IdentityErrors.OrganizationNotFoundByName(name);
+
+        // Assert
+        error.Code.Should().Be("Identity.OrganizationNotFoundByName");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(name);
+    }
+
+    [Fact]
+    public void OrganizationAlreadyExists_WithName_ReturnsConflictErrorWithCodeAndMessage()
+    {
+        // Arrange
+        const string name = "Globex";
+
+        // Act
+        var error = IdentityErrors.OrganizationAlreadyExists(name);
+
+        // Assert
+        error.Code.Should().Be("Identity.OrganizationAlreadyExists");
+        error.Type.Should().Be(ErrorType.Conflict);
+        error.Message.Should().Contain(name);
+    }
+
+    [Fact]
+    public void UserAlreadyMember_WithUserAndOrganization_ReturnsConflictErrorWithBothIds()
+    {
+        // Arrange
+        const string userId = "user-1";
+        const string organizationId = "org-1";
+
+        // Act
+        var error = IdentityErrors.UserAlreadyMember(userId, organizationId);
+
+        // Assert
+        error.Code.Should().Be("Identity.UserAlreadyMember");
+        error.Type.Should().Be(ErrorType.Conflict);
+        error.Message.Should().Contain(userId);
+        error.Message.Should().Contain(organizationId);
+    }
+
+    [Fact]
+    public void UserNotMember_WithUserAndOrganization_ReturnsNotFoundErrorWithBothIds()
+    {
+        // Arrange
+        const string userId = "user-1";
+        const string organizationId = "org-1";
+
+        // Act
+        var error = IdentityErrors.UserNotMember(userId, organizationId);
+
+        // Assert
+        error.Code.Should().Be("Identity.UserNotMember");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(userId);
+        error.Message.Should().Contain(organizationId);
+    }
+
+    [Fact]
+    public void InvalidToken_IsUnauthorizedErrorWithExpectedCodeAndMessage()
+    {
+        // Act
+        var error = IdentityErrors.InvalidToken;
+
+        // Assert
+        error.Code.Should().Be("Identity.InvalidToken");
+        error.Type.Should().Be(ErrorType.Unauthorized);
+        error.Message.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TokenExpired_IsUnauthorizedErrorWithExpectedCodeAndMessage()
+    {
+        // Act
+        var error = IdentityErrors.TokenExpired;
+
+        // Assert
+        error.Code.Should().Be("Identity.TokenExpired");
+        error.Type.Should().Be(ErrorType.Unauthorized);
+        error.Message.Should().Contain("expired");
+    }
+
+    [Fact]
+    public void TokenRevoked_IsUnauthorizedErrorWithExpectedCodeAndMessage()
+    {
+        // Act
+        var error = IdentityErrors.TokenRevoked;
+
+        // Assert
+        error.Code.Should().Be("Identity.TokenRevoked");
+        error.Type.Should().Be(ErrorType.Unauthorized);
+        error.Message.Should().Contain("revoked");
+    }
+
+    [Fact]
+    public void ProviderUnavailable_IsUnavailableErrorWithExpectedCodeAndMessage()
+    {
+        // Act
+        var error = IdentityErrors.ProviderUnavailable;
+
+        // Assert
+        error.Code.Should().Be("Identity.ProviderUnavailable");
+        error.Type.Should().Be(ErrorType.Unavailable);
+        error.Message.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void RateLimitExceeded_IsTooManyRequestsErrorWithExpectedCodeAndMessage()
+    {
+        // Act
+        var error = IdentityErrors.RateLimitExceeded;
+
+        // Assert
+        error.Code.Should().Be("Identity.RateLimitExceeded");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void InvalidEmail_WithEmail_ReturnsValidationErrorWithCodeAndMessage()
+    {
+        // Arrange
+        const string email = "not-an-email";
+
+        // Act
+        var error = IdentityErrors.InvalidEmail(email);
+
+        // Assert
+        error.Code.Should().Be("Identity.InvalidEmail");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain(email);
+    }
+
+    [Fact]
+    public void TenantContextRequired_IsValidationErrorWithExpectedCodeAndMessage()
+    {
+        // Act
+        var error = IdentityErrors.TenantContextRequired;
+
+        // Assert
+        error.Code.Should().Be("Identity.TenantContextRequired");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain("Tenant");
+    }
+
+    [Fact]
+    public void StaticErrors_AreSingletonInstancesAcrossCalls()
+    {
+        // Act
+        var first = IdentityErrors.InvalidToken;
+        var second = IdentityErrors.InvalidToken;
+
+        // Assert
+        ReferenceEquals(first, second).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AllFactoryErrors_HaveDistinctCodes()
+    {
+        // Arrange / Act
+        var codes = new[]
+        {
+            IdentityErrors.UserNotFound("u").Code,
+            IdentityErrors.UserNotFoundByEmail("e").Code,
+            IdentityErrors.UserAlreadyExists("e").Code,
+            IdentityErrors.OrganizationNotFound("o").Code,
+            IdentityErrors.OrganizationNotFoundByName("o").Code,
+            IdentityErrors.OrganizationAlreadyExists("o").Code,
+            IdentityErrors.UserAlreadyMember("u", "o").Code,
+            IdentityErrors.UserNotMember("u", "o").Code,
+            IdentityErrors.InvalidToken.Code,
+            IdentityErrors.TokenExpired.Code,
+            IdentityErrors.TokenRevoked.Code,
+            IdentityErrors.ProviderUnavailable.Code,
+            IdentityErrors.RateLimitExceeded.Code,
+            IdentityErrors.InvalidEmail("e").Code,
+            IdentityErrors.TenantContextRequired.Code,
+        };
+
+        // Assert
+        codes.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void Errors_CanBeWrappedInResultFailure_PreservingErrorIdentity()
+    {
+        // Arrange
+        var error = IdentityErrors.UserNotFound("u-1");
+
+        // Act
+        var result = Result.Failure<IdentityUser>(error);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(error);
+        result.Error.Code.Should().Be("Identity.UserNotFound");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/IdentityOrganizationTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/IdentityOrganizationTests.cs
@@ -1,0 +1,179 @@
+// -----------------------------------------------------------------------
+// <copyright file="IdentityOrganizationTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Identity.Tests.Models;
+
+public class IdentityOrganizationTests
+{
+    [Fact]
+    public void IdentityOrganization_WithRequiredProperties_InitializesSuccessfully()
+    {
+        // Arrange / Act
+        var org = new IdentityOrganization
+        {
+            Id = "org-1",
+            Name = "Acme"
+        };
+
+        // Assert
+        org.Id.Should().Be("org-1");
+        org.Name.Should().Be("Acme");
+    }
+
+    [Fact]
+    public void IdentityOrganization_DefaultIsActive_IsTrue()
+    {
+        // Arrange / Act
+        var org = new IdentityOrganization
+        {
+            Id = "org-1",
+            Name = "Acme"
+        };
+
+        // Assert
+        org.IsActive.Should().BeTrue();
+        org.Domain.Should().BeNull();
+        org.Metadata.Should().BeNull();
+        org.UpdatedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void IdentityOrganization_FullyPopulated_RoundTripsAllProperties()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow;
+        var updatedAt = createdAt.AddMinutes(1);
+        var metadata = new Dictionary<string, object> { ["industry"] = "tech" };
+
+        // Act
+        var org = new IdentityOrganization
+        {
+            Id = "org-1",
+            Name = "Acme",
+            Domain = "acme.com",
+            IsActive = false,
+            Metadata = metadata,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt
+        };
+
+        // Assert
+        org.Id.Should().Be("org-1");
+        org.Name.Should().Be("Acme");
+        org.Domain.Should().Be("acme.com");
+        org.IsActive.Should().BeFalse();
+        org.Metadata.Should().BeSameAs(metadata);
+        org.CreatedAt.Should().Be(createdAt);
+        org.UpdatedAt.Should().Be(updatedAt);
+    }
+
+    [Fact]
+    public void IdentityOrganization_TwoInstancesWithSameValues_AreEqual()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow;
+        var first = new IdentityOrganization { Id = "org-1", Name = "Acme", CreatedAt = createdAt };
+        var second = new IdentityOrganization { Id = "org-1", Name = "Acme", CreatedAt = createdAt };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void IdentityOrganization_TwoInstancesWithDifferentNames_AreNotEqual()
+    {
+        // Arrange
+        var first = new IdentityOrganization { Id = "org-1", Name = "Acme" };
+        var second = new IdentityOrganization { Id = "org-1", Name = "Globex" };
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+}
+
+public class OrganizationMemberTests
+{
+    [Fact]
+    public void OrganizationMember_WithRequiredProperties_InitializesSuccessfully()
+    {
+        // Arrange / Act
+        var member = new OrganizationMember
+        {
+            UserId = "user-1",
+            Email = "u@example.com",
+            Roles = new[] { "owner" }
+        };
+
+        // Assert
+        member.UserId.Should().Be("user-1");
+        member.Email.Should().Be("u@example.com");
+        member.Roles.Should().ContainSingle().Which.Should().Be("owner");
+    }
+
+    [Fact]
+    public void OrganizationMember_DefaultIsActive_IsTrue()
+    {
+        // Arrange / Act
+        var member = new OrganizationMember
+        {
+            UserId = "u-1",
+            Email = "u@example.com",
+            Roles = Array.Empty<string>()
+        };
+
+        // Assert
+        member.IsActive.Should().BeTrue();
+        member.DisplayName.Should().BeNull();
+    }
+
+    [Fact]
+    public void OrganizationMember_FullyPopulated_RoundTripsAllProperties()
+    {
+        // Arrange
+        var joinedAt = DateTimeOffset.UtcNow;
+        var roles = new[] { "admin", "billing" };
+
+        // Act
+        var member = new OrganizationMember
+        {
+            UserId = "u-1",
+            Email = "u@example.com",
+            DisplayName = "Test User",
+            Roles = roles,
+            JoinedAt = joinedAt,
+            IsActive = false
+        };
+
+        // Assert
+        member.UserId.Should().Be("u-1");
+        member.Email.Should().Be("u@example.com");
+        member.DisplayName.Should().Be("Test User");
+        member.Roles.Should().BeEquivalentTo(roles);
+        member.JoinedAt.Should().Be(joinedAt);
+        member.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OrganizationMember_RecordEquality_IgnoresReferenceIdentity()
+    {
+        // Arrange
+        var joinedAt = DateTimeOffset.UtcNow;
+        var first = new OrganizationMember
+        {
+            UserId = "u-1",
+            Email = "u@example.com",
+            Roles = new[] { "admin" },
+            JoinedAt = joinedAt
+        };
+        var second = first with { };
+
+        // Act / Assert
+        first.Should().Be(second);
+        ReferenceEquals(first, second).Should().BeFalse();
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/IdentityUserTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/IdentityUserTests.cs
@@ -1,0 +1,179 @@
+// -----------------------------------------------------------------------
+// <copyright file="IdentityUserTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Identity.Tests.Models;
+
+public class IdentityUserTests
+{
+    [Fact]
+    public void IdentityUser_WithRequiredProperties_InitializesSuccessfully()
+    {
+        // Arrange / Act
+        var user = new IdentityUser
+        {
+            Id = "user-1",
+            Email = "user@example.com"
+        };
+
+        // Assert
+        user.Id.Should().Be("user-1");
+        user.Email.Should().Be("user@example.com");
+    }
+
+    [Fact]
+    public void IdentityUser_DefaultIsActive_IsTrue()
+    {
+        // Arrange / Act
+        var user = new IdentityUser
+        {
+            Id = "user-1",
+            Email = "user@example.com"
+        };
+
+        // Assert
+        user.IsActive.Should().BeTrue();
+        user.EmailVerified.Should().BeFalse();
+        user.PhoneVerified.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IdentityUser_OptionalProperties_AreNullByDefault()
+    {
+        // Arrange / Act
+        var user = new IdentityUser
+        {
+            Id = "user-1",
+            Email = "user@example.com"
+        };
+
+        // Assert
+        user.Username.Should().BeNull();
+        user.FirstName.Should().BeNull();
+        user.LastName.Should().BeNull();
+        user.DisplayName.Should().BeNull();
+        user.PhoneNumber.Should().BeNull();
+        user.PreferredLanguage.Should().BeNull();
+        user.Timezone.Should().BeNull();
+        user.ProfilePictureUrl.Should().BeNull();
+        user.Metadata.Should().BeNull();
+        user.UpdatedAt.Should().BeNull();
+        user.LastLoginAt.Should().BeNull();
+        user.OrganizationId.Should().BeNull();
+        user.Roles.Should().BeNull();
+    }
+
+    [Fact]
+    public void IdentityUser_FullyPopulated_RoundTripsAllProperties()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow;
+        var updatedAt = createdAt.AddMinutes(5);
+        var lastLoginAt = createdAt.AddMinutes(10);
+        var metadata = new Dictionary<string, object> { ["plan"] = "pro" };
+        var roles = new[] { "admin", "user" };
+
+        // Act
+        var user = new IdentityUser
+        {
+            Id = "u-1",
+            Email = "u@example.com",
+            Username = "uname",
+            FirstName = "First",
+            LastName = "Last",
+            DisplayName = "First Last",
+            PhoneNumber = "+15551234567",
+            EmailVerified = true,
+            PhoneVerified = true,
+            IsActive = false,
+            PreferredLanguage = "en",
+            Timezone = "UTC",
+            ProfilePictureUrl = "https://example.com/me.png",
+            Metadata = metadata,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+            LastLoginAt = lastLoginAt,
+            OrganizationId = "org-1",
+            Roles = roles
+        };
+
+        // Assert
+        user.Id.Should().Be("u-1");
+        user.Email.Should().Be("u@example.com");
+        user.Username.Should().Be("uname");
+        user.FirstName.Should().Be("First");
+        user.LastName.Should().Be("Last");
+        user.DisplayName.Should().Be("First Last");
+        user.PhoneNumber.Should().Be("+15551234567");
+        user.EmailVerified.Should().BeTrue();
+        user.PhoneVerified.Should().BeTrue();
+        user.IsActive.Should().BeFalse();
+        user.PreferredLanguage.Should().Be("en");
+        user.Timezone.Should().Be("UTC");
+        user.ProfilePictureUrl.Should().Be("https://example.com/me.png");
+        user.Metadata.Should().BeSameAs(metadata);
+        user.CreatedAt.Should().Be(createdAt);
+        user.UpdatedAt.Should().Be(updatedAt);
+        user.LastLoginAt.Should().Be(lastLoginAt);
+        user.OrganizationId.Should().Be("org-1");
+        user.Roles.Should().BeEquivalentTo(roles);
+    }
+
+    [Fact]
+    public void IdentityUser_TwoInstancesWithSameValues_AreEqual()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow;
+        var first = new IdentityUser
+        {
+            Id = "user-1",
+            Email = "user@example.com",
+            CreatedAt = createdAt
+        };
+        var second = new IdentityUser
+        {
+            Id = "user-1",
+            Email = "user@example.com",
+            CreatedAt = createdAt
+        };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void IdentityUser_TwoInstancesWithDifferentIds_AreNotEqual()
+    {
+        // Arrange
+        var first = new IdentityUser { Id = "u-1", Email = "u@example.com" };
+        var second = new IdentityUser { Id = "u-2", Email = "u@example.com" };
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void IdentityUser_With_ReturnsCopyWithUpdatedProperty()
+    {
+        // Arrange
+        var original = new IdentityUser
+        {
+            Id = "u-1",
+            Email = "u@example.com",
+            FirstName = "Old"
+        };
+
+        // Act
+        var updated = original with { FirstName = "New" };
+
+        // Assert
+        original.FirstName.Should().Be("Old");
+        updated.FirstName.Should().Be("New");
+        updated.Id.Should().Be("u-1");
+        updated.Email.Should().Be("u@example.com");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/PagedResultTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/PagedResultTests.cs
@@ -1,0 +1,150 @@
+// -----------------------------------------------------------------------
+// <copyright file="PagedResultTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Identity.Tests.Models;
+
+public class PagedResultTests
+{
+    [Fact]
+    public void PagedResult_WithRequiredProperties_InitializesSuccessfully()
+    {
+        // Arrange / Act
+        var paged = new PagedResult<string>
+        {
+            Items = new[] { "a", "b", "c" },
+            TotalCount = 3,
+            Page = 1,
+            PageSize = 20
+        };
+
+        // Assert
+        paged.Items.Should().HaveCount(3);
+        paged.TotalCount.Should().Be(3);
+        paged.Page.Should().Be(1);
+        paged.PageSize.Should().Be(20);
+    }
+
+    [Theory]
+    [InlineData(0, 20, 0)]   // 0 / 20 = 0 pages
+    [InlineData(1, 20, 1)]   // 1 / 20 → 1 page
+    [InlineData(20, 20, 1)]  // 20 / 20 → 1 page
+    [InlineData(21, 20, 2)]  // 21 / 20 → 2 pages
+    [InlineData(100, 20, 5)]
+    [InlineData(101, 20, 6)]
+    public void TotalPages_ReturnsCeiling_OfTotalCountOverPageSize(int totalCount, int pageSize, int expected)
+    {
+        // Arrange
+        var paged = new PagedResult<int>
+        {
+            Items = Array.Empty<int>(),
+            TotalCount = totalCount,
+            Page = 1,
+            PageSize = pageSize
+        };
+
+        // Act
+        var totalPages = paged.TotalPages;
+
+        // Assert
+        totalPages.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1, false)]
+    [InlineData(2, true)]
+    [InlineData(5, true)]
+    public void HasPreviousPage_IsTrue_WhenPageGreaterThanOne(int page, bool expected)
+    {
+        // Arrange
+        var paged = new PagedResult<int>
+        {
+            Items = Array.Empty<int>(),
+            TotalCount = 100,
+            Page = page,
+            PageSize = 10
+        };
+
+        // Act / Assert
+        paged.HasPreviousPage.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1, 100, 10, true)]   // 10 pages, on page 1 → next exists
+    [InlineData(5, 100, 10, true)]   // 10 pages, on page 5 → next exists
+    [InlineData(10, 100, 10, false)] // last page
+    [InlineData(11, 100, 10, false)] // beyond last page
+    [InlineData(1, 0, 10, false)]    // empty result
+    public void HasNextPage_IsTrue_WhenPageLessThanTotalPages(int page, int totalCount, int pageSize, bool expected)
+    {
+        // Arrange
+        var paged = new PagedResult<int>
+        {
+            Items = Array.Empty<int>(),
+            TotalCount = totalCount,
+            Page = page,
+            PageSize = pageSize
+        };
+
+        // Act / Assert
+        paged.HasNextPage.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Empty_DefaultParameters_ReturnsEmptyPagedResultWithDefaults()
+    {
+        // Act
+        var paged = PagedResult<string>.Empty();
+
+        // Assert
+        paged.Items.Should().BeEmpty();
+        paged.TotalCount.Should().Be(0);
+        paged.Page.Should().Be(1);
+        paged.PageSize.Should().Be(20);
+        paged.HasPreviousPage.Should().BeFalse();
+        paged.HasNextPage.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Empty_WithCustomParameters_ReturnsEmptyPagedResultWithSpecifiedValues()
+    {
+        // Act
+        var paged = PagedResult<int>.Empty(page: 7, pageSize: 50);
+
+        // Assert
+        paged.Items.Should().BeEmpty();
+        paged.TotalCount.Should().Be(0);
+        paged.Page.Should().Be(7);
+        paged.PageSize.Should().Be(50);
+    }
+
+    [Fact]
+    public void PagedResult_IsRecord_HasValueEquality()
+    {
+        // Arrange
+        var first = new PagedResult<int>
+        {
+            Items = new[] { 1, 2, 3 },
+            TotalCount = 3,
+            Page = 1,
+            PageSize = 20
+        };
+        var second = new PagedResult<int>
+        {
+            Items = new[] { 1, 2, 3 },
+            TotalCount = 3,
+            Page = 1,
+            PageSize = 20
+        };
+
+        // Act / Assert
+        // Records compare items by reference equality unless we use structural collections;
+        // equality without comparing collection identity is asserted via individual props.
+        first.TotalCount.Should().Be(second.TotalCount);
+        first.Page.Should().Be(second.Page);
+        first.PageSize.Should().Be(second.PageSize);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/ProvisioningRequestsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/ProvisioningRequestsTests.cs
@@ -1,0 +1,272 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProvisioningRequestsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Identity.Tests.Models;
+
+public class OrganizationProvisioningRequestTests
+{
+    [Fact]
+    public void OrganizationProvisioningRequest_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var admin = new AdminUserProvisioningRequest("admin@acme.com", "First", "Last", "p@ss", "en");
+
+        // Act
+        var request = new OrganizationProvisioningRequest(
+            OrganizationId: "org-1",
+            Name: "Acme",
+            DisplayName: "Acme Corp",
+            PlanId: "pro",
+            AdminUser: admin);
+
+        // Assert
+        request.OrganizationId.Should().Be("org-1");
+        request.Name.Should().Be("Acme");
+        request.DisplayName.Should().Be("Acme Corp");
+        request.PlanId.Should().Be("pro");
+        request.AdminUser.Should().BeSameAs(admin);
+    }
+
+    [Fact]
+    public void OrganizationProvisioningRequest_AcceptsNullDisplayName()
+    {
+        // Arrange
+        var admin = new AdminUserProvisioningRequest("admin@acme.com", "F", "L", null, null);
+
+        // Act
+        var request = new OrganizationProvisioningRequest("org-1", "Acme", null, "free", admin);
+
+        // Assert
+        request.DisplayName.Should().BeNull();
+    }
+
+    [Fact]
+    public void OrganizationProvisioningRequest_RecordEquality_IsValueBased()
+    {
+        // Arrange
+        var admin = new AdminUserProvisioningRequest("a@b.com", "F", "L", null, null);
+        var first = new OrganizationProvisioningRequest("org-1", "Acme", "Acme Corp", "pro", admin);
+        var second = new OrganizationProvisioningRequest("org-1", "Acme", "Acme Corp", "pro", admin);
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void OrganizationProvisioningRequest_Deconstruct_YieldsAllArguments()
+    {
+        // Arrange
+        var admin = new AdminUserProvisioningRequest("a@b.com", "F", "L", null, null);
+        var request = new OrganizationProvisioningRequest("org-1", "Acme", "Acme Corp", "pro", admin);
+
+        // Act
+        var (orgId, name, displayName, planId, adminUser) = request;
+
+        // Assert
+        orgId.Should().Be("org-1");
+        name.Should().Be("Acme");
+        displayName.Should().Be("Acme Corp");
+        planId.Should().Be("pro");
+        adminUser.Should().BeSameAs(admin);
+    }
+}
+
+public class AdminUserProvisioningRequestTests
+{
+    [Fact]
+    public void AdminUserProvisioningRequest_Constructor_SetsAllProperties()
+    {
+        // Arrange / Act
+        var admin = new AdminUserProvisioningRequest(
+            Email: "admin@acme.com",
+            FirstName: "Jane",
+            LastName: "Doe",
+            Password: "secret",
+            PreferredLanguage: "en");
+
+        // Assert
+        admin.Email.Should().Be("admin@acme.com");
+        admin.FirstName.Should().Be("Jane");
+        admin.LastName.Should().Be("Doe");
+        admin.Password.Should().Be("secret");
+        admin.PreferredLanguage.Should().Be("en");
+    }
+
+    [Fact]
+    public void AdminUserProvisioningRequest_AcceptsNullPasswordAndLanguage()
+    {
+        // Arrange / Act
+        var admin = new AdminUserProvisioningRequest("admin@acme.com", "Jane", "Doe", null, null);
+
+        // Assert
+        admin.Password.Should().BeNull();
+        admin.PreferredLanguage.Should().BeNull();
+    }
+
+    [Fact]
+    public void AdminUserProvisioningRequest_With_ProducesUpdatedCopy()
+    {
+        // Arrange
+        var original = new AdminUserProvisioningRequest("a@b.com", "F", "L", "p", "en");
+
+        // Act
+        var updated = original with { Password = "new-pass" };
+
+        // Assert
+        original.Password.Should().Be("p");
+        updated.Password.Should().Be("new-pass");
+        updated.Email.Should().Be("a@b.com");
+    }
+}
+
+public class ProjectProvisioningRequestTests
+{
+    [Fact]
+    public void ProjectProvisioningRequest_Constructor_SetsAllProperties()
+    {
+        // Arrange / Act
+        var request = new ProjectProvisioningRequest(
+            ProjectId: "p-1",
+            OrganizationId: "org-1",
+            ExternalOrganizationId: "ext-org-1",
+            ProjectName: "Project One");
+
+        // Assert
+        request.ProjectId.Should().Be("p-1");
+        request.OrganizationId.Should().Be("org-1");
+        request.ExternalOrganizationId.Should().Be("ext-org-1");
+        request.ProjectName.Should().Be("Project One");
+    }
+
+    [Fact]
+    public void ProjectProvisioningRequest_RecordEquality_IsValueBased()
+    {
+        // Arrange
+        var first = new ProjectProvisioningRequest("p-1", "o", "ext", "name");
+        var second = new ProjectProvisioningRequest("p-1", "o", "ext", "name");
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+}
+
+public class OidcAppProvisioningRequestTests
+{
+    [Fact]
+    public void OidcAppProvisioningRequest_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var redirects = new[] { "https://app.example.com/callback" };
+        var postLogout = new[] { "https://app.example.com/" };
+
+        // Act
+        var request = new OidcAppProvisioningRequest(
+            ExternalProjectId: "ext-p-1",
+            ExternalOrganizationId: "ext-o-1",
+            AppName: "Web",
+            RedirectUris: redirects,
+            PostLogoutRedirectUris: postLogout);
+
+        // Assert
+        request.ExternalProjectId.Should().Be("ext-p-1");
+        request.ExternalOrganizationId.Should().Be("ext-o-1");
+        request.AppName.Should().Be("Web");
+        request.RedirectUris.Should().BeSameAs(redirects);
+        request.PostLogoutRedirectUris.Should().BeSameAs(postLogout);
+    }
+
+    [Fact]
+    public void OidcAppProvisioningRequest_AcceptsEmptyUriLists()
+    {
+        // Arrange / Act
+        var request = new OidcAppProvisioningRequest(
+            "ext-p-1",
+            "ext-o-1",
+            "Web",
+            Array.Empty<string>(),
+            Array.Empty<string>());
+
+        // Assert
+        request.RedirectUris.Should().BeEmpty();
+        request.PostLogoutRedirectUris.Should().BeEmpty();
+    }
+}
+
+public class OidcAppUpdateRequestTests
+{
+    [Fact]
+    public void OidcAppUpdateRequest_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var redirects = new[] { "https://x" };
+        var postLogout = new[] { "https://y" };
+
+        // Act
+        var request = new OidcAppUpdateRequest(
+            ExternalProjectId: "ext-p",
+            ExternalAppId: "ext-app",
+            ExternalOrganizationId: "ext-o",
+            RedirectUris: redirects,
+            PostLogoutRedirectUris: postLogout);
+
+        // Assert
+        request.ExternalProjectId.Should().Be("ext-p");
+        request.ExternalAppId.Should().Be("ext-app");
+        request.ExternalOrganizationId.Should().Be("ext-o");
+        request.RedirectUris.Should().BeSameAs(redirects);
+        request.PostLogoutRedirectUris.Should().BeSameAs(postLogout);
+    }
+}
+
+public class OidcAppDeleteRequestTests
+{
+    [Fact]
+    public void OidcAppDeleteRequest_Constructor_SetsAllProperties()
+    {
+        // Arrange / Act
+        var request = new OidcAppDeleteRequest(
+            ExternalProjectId: "ext-p",
+            ExternalAppId: "ext-app",
+            ExternalOrganizationId: "ext-o");
+
+        // Assert
+        request.ExternalProjectId.Should().Be("ext-p");
+        request.ExternalAppId.Should().Be("ext-app");
+        request.ExternalOrganizationId.Should().Be("ext-o");
+    }
+
+    [Fact]
+    public void OidcAppDeleteRequest_RecordEquality_IsValueBased()
+    {
+        // Arrange
+        var first = new OidcAppDeleteRequest("p", "a", "o");
+        var second = new OidcAppDeleteRequest("p", "a", "o");
+
+        // Act / Assert
+        first.Should().Be(second);
+    }
+}
+
+public class OidcAppSecretRotationRequestTests
+{
+    [Fact]
+    public void OidcAppSecretRotationRequest_Constructor_SetsAllProperties()
+    {
+        // Arrange / Act
+        var request = new OidcAppSecretRotationRequest(
+            ExternalProjectId: "ext-p",
+            ExternalAppId: "ext-app",
+            ExternalOrganizationId: "ext-o");
+
+        // Assert
+        request.ExternalProjectId.Should().Be("ext-p");
+        request.ExternalAppId.Should().Be("ext-app");
+        request.ExternalOrganizationId.Should().Be("ext-o");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/ProvisioningResultsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/ProvisioningResultsTests.cs
@@ -1,0 +1,151 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProvisioningResultsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Identity.Tests.Models;
+
+public class OrganizationProvisioningResultTests
+{
+    [Fact]
+    public void OrganizationProvisioningResult_Constructor_SetsAllProperties()
+    {
+        // Arrange / Act
+        var result = new OrganizationProvisioningResult(
+            ExternalOrganizationId: "ext-org-1",
+            ExternalProjectId: "ext-proj-1",
+            ClientId: "client-1",
+            ClientSecret: "secret",
+            AdminUserId: "admin-1");
+
+        // Assert
+        result.ExternalOrganizationId.Should().Be("ext-org-1");
+        result.ExternalProjectId.Should().Be("ext-proj-1");
+        result.ClientId.Should().Be("client-1");
+        result.ClientSecret.Should().Be("secret");
+        result.AdminUserId.Should().Be("admin-1");
+    }
+
+    [Fact]
+    public void OrganizationProvisioningResult_Deconstruct_YieldsAllArguments()
+    {
+        // Arrange
+        var result = new OrganizationProvisioningResult("o", "p", "c", "s", "a");
+
+        // Act
+        var (extOrg, extProj, clientId, clientSecret, adminId) = result;
+
+        // Assert
+        extOrg.Should().Be("o");
+        extProj.Should().Be("p");
+        clientId.Should().Be("c");
+        clientSecret.Should().Be("s");
+        adminId.Should().Be("a");
+    }
+
+    [Fact]
+    public void OrganizationProvisioningResult_RecordEquality_IsValueBased()
+    {
+        // Arrange
+        var first = new OrganizationProvisioningResult("o", "p", "c", "s", "a");
+        var second = new OrganizationProvisioningResult("o", "p", "c", "s", "a");
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+}
+
+public class ProjectProvisioningResultTests
+{
+    [Fact]
+    public void ProjectProvisioningResult_Constructor_SetsExternalProjectId()
+    {
+        // Arrange / Act
+        var result = new ProjectProvisioningResult(ExternalProjectId: "ext-p-1");
+
+        // Assert
+        result.ExternalProjectId.Should().Be("ext-p-1");
+    }
+
+    [Fact]
+    public void ProjectProvisioningResult_RecordEquality_IsValueBased()
+    {
+        // Arrange / Act
+        var first = new ProjectProvisioningResult("p");
+        var second = new ProjectProvisioningResult("p");
+
+        // Assert
+        first.Should().Be(second);
+    }
+}
+
+public class OidcAppProvisioningResultTests
+{
+    [Fact]
+    public void OidcAppProvisioningResult_Constructor_SetsAllProperties()
+    {
+        // Arrange / Act
+        var result = new OidcAppProvisioningResult(
+            ClientId: "client-1",
+            ClientSecret: "secret",
+            ExternalAppId: "ext-app-1");
+
+        // Assert
+        result.ClientId.Should().Be("client-1");
+        result.ClientSecret.Should().Be("secret");
+        result.ExternalAppId.Should().Be("ext-app-1");
+    }
+
+    [Fact]
+    public void OidcAppProvisioningResult_AcceptsNullExternalAppId()
+    {
+        // Arrange / Act
+        var result = new OidcAppProvisioningResult("client-1", "secret", null);
+
+        // Assert
+        result.ExternalAppId.Should().BeNull();
+    }
+
+    [Fact]
+    public void OidcAppProvisioningResult_With_ProducesUpdatedCopy()
+    {
+        // Arrange
+        var original = new OidcAppProvisioningResult("c", "s", "a");
+
+        // Act
+        var rotated = original with { ClientSecret = "new-secret" };
+
+        // Assert
+        original.ClientSecret.Should().Be("s");
+        rotated.ClientSecret.Should().Be("new-secret");
+        rotated.ClientId.Should().Be("c");
+    }
+}
+
+public class OidcAppSecretRotationResultTests
+{
+    [Fact]
+    public void OidcAppSecretRotationResult_Constructor_SetsClientSecret()
+    {
+        // Arrange / Act
+        var result = new OidcAppSecretRotationResult(ClientSecret: "rotated-secret");
+
+        // Assert
+        result.ClientSecret.Should().Be("rotated-secret");
+    }
+
+    [Fact]
+    public void OidcAppSecretRotationResult_RecordEquality_IsValueBased()
+    {
+        // Arrange
+        var first = new OidcAppSecretRotationResult("rotated");
+        var second = new OidcAppSecretRotationResult("rotated");
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/Requests/CreateOrganizationRequestTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/Requests/CreateOrganizationRequestTests.cs
@@ -1,0 +1,69 @@
+// -----------------------------------------------------------------------
+// <copyright file="CreateOrganizationRequestTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Identity.Tests.Models.Requests;
+
+public class CreateOrganizationRequestTests
+{
+    [Fact]
+    public void CreateOrganizationRequest_WithRequiredName_InitializesSuccessfully()
+    {
+        // Arrange / Act
+        var request = new CreateOrganizationRequest { Name = "Acme" };
+
+        // Assert
+        request.Name.Should().Be("Acme");
+        request.Domain.Should().BeNull();
+        request.Metadata.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateOrganizationRequest_FullyPopulated_RoundTripsAllProperties()
+    {
+        // Arrange
+        var metadata = new Dictionary<string, object> { ["plan"] = "pro" };
+
+        // Act
+        var request = new CreateOrganizationRequest
+        {
+            Name = "Acme",
+            Domain = "acme.com",
+            Metadata = metadata
+        };
+
+        // Assert
+        request.Name.Should().Be("Acme");
+        request.Domain.Should().Be("acme.com");
+        request.Metadata.Should().BeSameAs(metadata);
+    }
+
+    [Fact]
+    public void CreateOrganizationRequest_RecordEquality_IsValueBased()
+    {
+        // Arrange
+        var first = new CreateOrganizationRequest { Name = "Acme", Domain = "acme.com" };
+        var second = new CreateOrganizationRequest { Name = "Acme", Domain = "acme.com" };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void CreateOrganizationRequest_With_ProducesUpdatedCopy()
+    {
+        // Arrange
+        var original = new CreateOrganizationRequest { Name = "Acme" };
+
+        // Act
+        var updated = original with { Name = "Globex" };
+
+        // Assert
+        original.Name.Should().Be("Acme");
+        updated.Name.Should().Be("Globex");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/Requests/CreateUserRequestTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/Requests/CreateUserRequestTests.cs
@@ -1,0 +1,119 @@
+// -----------------------------------------------------------------------
+// <copyright file="CreateUserRequestTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Identity.Tests.Models.Requests;
+
+public class CreateUserRequestTests
+{
+    [Fact]
+    public void CreateUserRequest_WithRequiredEmail_InitializesSuccessfully()
+    {
+        // Arrange / Act
+        var request = new CreateUserRequest { Email = "u@example.com" };
+
+        // Assert
+        request.Email.Should().Be("u@example.com");
+    }
+
+    [Fact]
+    public void CreateUserRequest_DefaultSendVerificationEmail_IsTrue()
+    {
+        // Arrange / Act
+        var request = new CreateUserRequest { Email = "u@example.com" };
+
+        // Assert
+        request.SendVerificationEmail.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreateUserRequest_OptionalProperties_AreNullByDefault()
+    {
+        // Arrange / Act
+        var request = new CreateUserRequest { Email = "u@example.com" };
+
+        // Assert
+        request.Username.Should().BeNull();
+        request.FirstName.Should().BeNull();
+        request.LastName.Should().BeNull();
+        request.DisplayName.Should().BeNull();
+        request.PhoneNumber.Should().BeNull();
+        request.Password.Should().BeNull();
+        request.PreferredLanguage.Should().BeNull();
+        request.Timezone.Should().BeNull();
+        request.OrganizationId.Should().BeNull();
+        request.Roles.Should().BeNull();
+        request.Metadata.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateUserRequest_FullyPopulated_RoundTripsAllProperties()
+    {
+        // Arrange
+        var roles = new[] { "admin" };
+        var metadata = new Dictionary<string, object> { ["k"] = "v" };
+
+        // Act
+        var request = new CreateUserRequest
+        {
+            Email = "u@example.com",
+            Username = "uname",
+            FirstName = "First",
+            LastName = "Last",
+            DisplayName = "Display",
+            PhoneNumber = "+15551234567",
+            Password = "p@ss",
+            PreferredLanguage = "en",
+            Timezone = "UTC",
+            OrganizationId = "org-1",
+            Roles = roles,
+            Metadata = metadata,
+            SendVerificationEmail = false
+        };
+
+        // Assert
+        request.Email.Should().Be("u@example.com");
+        request.Username.Should().Be("uname");
+        request.FirstName.Should().Be("First");
+        request.LastName.Should().Be("Last");
+        request.DisplayName.Should().Be("Display");
+        request.PhoneNumber.Should().Be("+15551234567");
+        request.Password.Should().Be("p@ss");
+        request.PreferredLanguage.Should().Be("en");
+        request.Timezone.Should().Be("UTC");
+        request.OrganizationId.Should().Be("org-1");
+        request.Roles.Should().BeEquivalentTo(roles);
+        request.Metadata.Should().BeSameAs(metadata);
+        request.SendVerificationEmail.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CreateUserRequest_RecordEquality_IsValueBased()
+    {
+        // Arrange
+        var first = new CreateUserRequest { Email = "u@example.com" };
+        var second = new CreateUserRequest { Email = "u@example.com" };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void CreateUserRequest_With_ProducesUpdatedCopy()
+    {
+        // Arrange
+        var original = new CreateUserRequest { Email = "u@example.com", Username = "u" };
+
+        // Act
+        var updated = original with { Username = "v" };
+
+        // Assert
+        original.Username.Should().Be("u");
+        updated.Username.Should().Be("v");
+        updated.Email.Should().Be("u@example.com");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/Requests/ListUsersRequestTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/Requests/ListUsersRequestTests.cs
@@ -1,0 +1,79 @@
+// -----------------------------------------------------------------------
+// <copyright file="ListUsersRequestTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Identity.Tests.Models.Requests;
+
+public class ListUsersRequestTests
+{
+    [Fact]
+    public void ListUsersRequest_Defaults_HaveExpectedValues()
+    {
+        // Arrange / Act
+        var request = new ListUsersRequest();
+
+        // Assert
+        request.Page.Should().Be(1);
+        request.PageSize.Should().Be(20);
+        request.SearchQuery.Should().BeNull();
+        request.OrganizationId.Should().BeNull();
+        request.Role.Should().BeNull();
+        request.IsActive.Should().BeNull();
+        request.SortBy.Should().Be("email");
+        request.SortDescending.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ListUsersRequest_FullyPopulated_RoundTripsAllProperties()
+    {
+        // Arrange / Act
+        var request = new ListUsersRequest
+        {
+            Page = 5,
+            PageSize = 100,
+            SearchQuery = "alice",
+            OrganizationId = "org-1",
+            Role = "admin",
+            IsActive = true,
+            SortBy = "createdAt",
+            SortDescending = true
+        };
+
+        // Assert
+        request.Page.Should().Be(5);
+        request.PageSize.Should().Be(100);
+        request.SearchQuery.Should().Be("alice");
+        request.OrganizationId.Should().Be("org-1");
+        request.Role.Should().Be("admin");
+        request.IsActive.Should().BeTrue();
+        request.SortBy.Should().Be("createdAt");
+        request.SortDescending.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ListUsersRequest_IsActive_AcceptsBothBooleanValues(bool isActive)
+    {
+        // Arrange / Act
+        var request = new ListUsersRequest { IsActive = isActive };
+
+        // Assert
+        request.IsActive.Should().Be(isActive);
+    }
+
+    [Fact]
+    public void ListUsersRequest_RecordEquality_IsValueBased()
+    {
+        // Arrange
+        var first = new ListUsersRequest { Page = 2, PageSize = 50 };
+        var second = new ListUsersRequest { Page = 2, PageSize = 50 };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/Requests/UpdateUserRequestTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/Requests/UpdateUserRequestTests.cs
@@ -1,0 +1,91 @@
+// -----------------------------------------------------------------------
+// <copyright file="UpdateUserRequestTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Identity.Tests.Models.Requests;
+
+public class UpdateUserRequestTests
+{
+    [Fact]
+    public void UpdateUserRequest_DefaultConstruction_AllPropertiesAreNull()
+    {
+        // Arrange / Act
+        var request = new UpdateUserRequest();
+
+        // Assert
+        request.Username.Should().BeNull();
+        request.FirstName.Should().BeNull();
+        request.LastName.Should().BeNull();
+        request.DisplayName.Should().BeNull();
+        request.PhoneNumber.Should().BeNull();
+        request.PreferredLanguage.Should().BeNull();
+        request.Timezone.Should().BeNull();
+        request.ProfilePictureUrl.Should().BeNull();
+        request.Roles.Should().BeNull();
+        request.Metadata.Should().BeNull();
+    }
+
+    [Fact]
+    public void UpdateUserRequest_FullyPopulated_RoundTripsAllProperties()
+    {
+        // Arrange
+        var roles = new[] { "user" };
+        var metadata = new Dictionary<string, object> { ["k"] = "v" };
+
+        // Act
+        var request = new UpdateUserRequest
+        {
+            Username = "u",
+            FirstName = "F",
+            LastName = "L",
+            DisplayName = "D",
+            PhoneNumber = "+15551112222",
+            PreferredLanguage = "fr",
+            Timezone = "Europe/Paris",
+            ProfilePictureUrl = "https://x/pic.png",
+            Roles = roles,
+            Metadata = metadata
+        };
+
+        // Assert
+        request.Username.Should().Be("u");
+        request.FirstName.Should().Be("F");
+        request.LastName.Should().Be("L");
+        request.DisplayName.Should().Be("D");
+        request.PhoneNumber.Should().Be("+15551112222");
+        request.PreferredLanguage.Should().Be("fr");
+        request.Timezone.Should().Be("Europe/Paris");
+        request.ProfilePictureUrl.Should().Be("https://x/pic.png");
+        request.Roles.Should().BeEquivalentTo(roles);
+        request.Metadata.Should().BeSameAs(metadata);
+    }
+
+    [Fact]
+    public void UpdateUserRequest_RecordEquality_IsValueBased()
+    {
+        // Arrange
+        var first = new UpdateUserRequest { Username = "u", FirstName = "F" };
+        var second = new UpdateUserRequest { Username = "u", FirstName = "F" };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void UpdateUserRequest_With_ProducesUpdatedCopy()
+    {
+        // Arrange
+        var original = new UpdateUserRequest { FirstName = "Old" };
+
+        // Act
+        var updated = original with { FirstName = "New" };
+
+        // Assert
+        original.FirstName.Should().Be("Old");
+        updated.FirstName.Should().Be("New");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/TokenInfoTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Identity.Tests/Models/TokenInfoTests.cs
@@ -1,0 +1,235 @@
+// -----------------------------------------------------------------------
+// <copyright file="TokenInfoTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Identity.Tests.Models;
+
+public class TokenInfoTests
+{
+    [Fact]
+    public void TokenInfo_WithRequiredProperties_InitializesSuccessfully()
+    {
+        // Arrange / Act
+        var token = new TokenInfo
+        {
+            Subject = "user-1",
+            Issuer = "https://issuer.example.com"
+        };
+
+        // Assert
+        token.Subject.Should().Be("user-1");
+        token.Issuer.Should().Be("https://issuer.example.com");
+    }
+
+    [Fact]
+    public void TokenInfo_OptionalProperties_AreNullByDefault()
+    {
+        // Arrange / Act
+        var token = new TokenInfo
+        {
+            Subject = "user-1",
+            Issuer = "https://issuer.example.com"
+        };
+
+        // Assert
+        token.Audience.Should().BeNull();
+        token.Email.Should().BeNull();
+        token.EmailVerified.Should().BeNull();
+        token.Name.Should().BeNull();
+        token.OrganizationId.Should().BeNull();
+        token.Roles.Should().BeNull();
+        token.Scopes.Should().BeNull();
+        token.Claims.Should().BeNull();
+    }
+
+    [Fact]
+    public void IsExpired_WhenExpiresAtInPast_ReturnsTrue()
+    {
+        // Arrange
+        var token = new TokenInfo
+        {
+            Subject = "u-1",
+            Issuer = "iss",
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1)
+        };
+
+        // Act / Assert
+        token.IsExpired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsExpired_WhenExpiresAtInFuture_ReturnsFalse()
+    {
+        // Arrange
+        var token = new TokenInfo
+        {
+            Subject = "u-1",
+            Issuer = "iss",
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        // Act / Assert
+        token.IsExpired.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_WhenExpiresAtIsDefault_ReturnsTrue()
+    {
+        // Arrange
+        var token = new TokenInfo
+        {
+            Subject = "u-1",
+            Issuer = "iss"
+        };
+
+        // Act / Assert
+        token.IsExpired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TokenInfo_FullyPopulated_RoundTripsAllProperties()
+    {
+        // Arrange
+        var issuedAt = DateTimeOffset.UtcNow;
+        var expiresAt = issuedAt.AddHours(1);
+        var audience = new[] { "api", "web" };
+        var roles = new[] { "admin" };
+        var scopes = new[] { "openid", "profile" };
+        var claims = new Dictionary<string, object> { ["custom"] = "val" };
+
+        // Act
+        var token = new TokenInfo
+        {
+            Subject = "u-1",
+            Issuer = "https://iss",
+            Audience = audience,
+            IssuedAt = issuedAt,
+            ExpiresAt = expiresAt,
+            Email = "u@example.com",
+            EmailVerified = true,
+            Name = "Test",
+            OrganizationId = "org-1",
+            Roles = roles,
+            Scopes = scopes,
+            Claims = claims
+        };
+
+        // Assert
+        token.Subject.Should().Be("u-1");
+        token.Issuer.Should().Be("https://iss");
+        token.Audience.Should().BeEquivalentTo(audience);
+        token.IssuedAt.Should().Be(issuedAt);
+        token.ExpiresAt.Should().Be(expiresAt);
+        token.Email.Should().Be("u@example.com");
+        token.EmailVerified.Should().BeTrue();
+        token.Name.Should().Be("Test");
+        token.OrganizationId.Should().Be("org-1");
+        token.Roles.Should().BeEquivalentTo(roles);
+        token.Scopes.Should().BeEquivalentTo(scopes);
+        token.Claims.Should().BeSameAs(claims);
+    }
+
+    [Fact]
+    public void TokenInfo_RecordEquality_OnSameValues_IsTrue()
+    {
+        // Arrange
+        var issuedAt = DateTimeOffset.UtcNow;
+        var expiresAt = issuedAt.AddHours(1);
+        var first = new TokenInfo
+        {
+            Subject = "u-1",
+            Issuer = "iss",
+            IssuedAt = issuedAt,
+            ExpiresAt = expiresAt
+        };
+        var second = new TokenInfo
+        {
+            Subject = "u-1",
+            Issuer = "iss",
+            IssuedAt = issuedAt,
+            ExpiresAt = expiresAt
+        };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+}
+
+public class TokenIntrospectionResultTests
+{
+    [Fact]
+    public void TokenIntrospectionResult_WithRequiredActiveProperty_InitializesSuccessfully()
+    {
+        // Arrange / Act
+        var result = new TokenIntrospectionResult { Active = true };
+
+        // Assert
+        result.Active.Should().BeTrue();
+        result.TokenInfo.Should().BeNull();
+        result.TokenType.Should().BeNull();
+        result.ClientId.Should().BeNull();
+        result.InactiveReason.Should().BeNull();
+    }
+
+    [Fact]
+    public void TokenIntrospectionResult_Active_WithTokenInfo_RoundTripsAllProperties()
+    {
+        // Arrange
+        var token = new TokenInfo
+        {
+            Subject = "u-1",
+            Issuer = "iss",
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(15)
+        };
+
+        // Act
+        var result = new TokenIntrospectionResult
+        {
+            Active = true,
+            TokenInfo = token,
+            TokenType = "Bearer",
+            ClientId = "client-1"
+        };
+
+        // Assert
+        result.Active.Should().BeTrue();
+        result.TokenInfo.Should().BeSameAs(token);
+        result.TokenType.Should().Be("Bearer");
+        result.ClientId.Should().Be("client-1");
+    }
+
+    [Fact]
+    public void TokenIntrospectionResult_Inactive_CarriesInactiveReason()
+    {
+        // Arrange / Act
+        var result = new TokenIntrospectionResult
+        {
+            Active = false,
+            InactiveReason = "Token revoked"
+        };
+
+        // Assert
+        result.Active.Should().BeFalse();
+        result.InactiveReason.Should().Be("Token revoked");
+    }
+
+    [Fact]
+    public void TokenIntrospectionResult_With_ReturnsCopyWithUpdatedProperty()
+    {
+        // Arrange
+        var original = new TokenIntrospectionResult { Active = true, TokenType = "Bearer" };
+
+        // Act
+        var updated = original with { Active = false, InactiveReason = "expired" };
+
+        // Assert
+        original.Active.Should().BeTrue();
+        updated.Active.Should().BeFalse();
+        updated.InactiveReason.Should().Be("expired");
+        updated.TokenType.Should().Be("Bearer");
+    }
+}


### PR DESCRIPTION
## Summary
Brings `Compendium.Abstractions.Identity` from 17 % → 100 % line coverage. Part of the testing campaign (VK POM-466).

## Coverage report — Compendium.Abstractions.Identity
- Tests added: 110
- Test files added: `IdentityErrorsTests`, `Models/IdentityUserTests`, `Models/IdentityOrganizationTests` (covers `IdentityOrganization` + `OrganizationMember`), `Models/PagedResultTests`, `Models/TokenInfoTests` (covers `TokenInfo` + `TokenIntrospectionResult`), `Models/ProvisioningRequestsTests`, `Models/ProvisioningResultsTests`, `Models/Requests/CreateUserRequestTests`, `Models/Requests/UpdateUserRequestTests`, `Models/Requests/ListUsersRequestTests`, `Models/Requests/CreateOrganizationRequestTests`
- Line coverage: 17 % → 100 %
- Branch coverage: full (no conditional logic outside `PagedResult` derived properties, all branches covered)
- Bugs surfaced: 0

## Test plan
- [x] `dotnet build Compendium.sln -c Release` green
- [x] `dotnet test tests/Unit/Compendium.Abstractions.Identity.Tests -c Release` green (110/110 passing)
- [x] No prod code modified, no version bumps
- [ ] CI green