### PR TITLE
test(abstractions/billing): add unit tests for billing value objects + errors

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -114,6 +114,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Testing.Tests", "tests\Unit\Compendium.Testing.Tests\Compendium.Testing.Tests.csproj", "{E5232EFA-E06C-4975-B5A7-91A241D029CB}"
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.PostgreSQL.Tests", "tests\Unit\Compendium.Adapters.PostgreSQL.Tests\Compendium.Adapters.PostgreSQL.Tests.csproj", "{3E6C387D-A84B-43A8-AAF5-B7A9494C57CE}"
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Identity.Tests", "tests\Unit\Compendium.Abstractions.Identity.Tests\Compendium.Abstractions.Identity.Tests.csproj", "{0EDEE2DC-46FE-404B-9615-B6E3F756DF75}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Billing.Tests", "tests\Unit\Compendium.Abstractions.Billing.Tests\Compendium.Abstractions.Billing.Tests.csproj", "{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -296,6 +297,10 @@ Global
 		{0EDEE2DC-46FE-404B-9615-B6E3F756DF75}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0EDEE2DC-46FE-404B-9615-B6E3F756DF75}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0EDEE2DC-46FE-404B-9615-B6E3F756DF75}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -353,5 +358,6 @@ Global
 		{E5232EFA-E06C-4975-B5A7-91A241D029CB} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{3E6C387D-A84B-43A8-AAF5-B7A9494C57CE} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{0EDEE2DC-46FE-404B-9615-B6E3F756DF75} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/tests/Unit/Compendium.Abstractions.Billing.Tests/BillingErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Billing.Tests/BillingErrorsTests.cs
@@ -1,0 +1,338 @@
+// -----------------------------------------------------------------------
+// <copyright file="BillingErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Billing.Tests;
+
+public class BillingErrorsTests
+{
+    [Fact]
+    public void CustomerNotFound_WithCustomerId_ReturnsNotFoundErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string customerId = "cust-42";
+
+        // Act
+        var error = BillingErrors.CustomerNotFound(customerId);
+
+        // Assert
+        error.Code.Should().Be("Billing.CustomerNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(customerId);
+    }
+
+    [Fact]
+    public void CustomerNotFoundByEmail_WithEmail_ReturnsNotFoundErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string email = "user@example.com";
+
+        // Act
+        var error = BillingErrors.CustomerNotFoundByEmail(email);
+
+        // Assert
+        error.Code.Should().Be("Billing.CustomerNotFoundByEmail");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(email);
+    }
+
+    [Fact]
+    public void SubscriptionNotFound_WithSubscriptionId_ReturnsNotFoundErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string subscriptionId = "sub-1";
+
+        // Act
+        var error = BillingErrors.SubscriptionNotFound(subscriptionId);
+
+        // Assert
+        error.Code.Should().Be("Billing.SubscriptionNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(subscriptionId);
+    }
+
+    [Fact]
+    public void NoActiveSubscription_WithCustomerId_ReturnsNotFoundErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string customerId = "cust-77";
+
+        // Act
+        var error = BillingErrors.NoActiveSubscription(customerId);
+
+        // Assert
+        error.Code.Should().Be("Billing.NoActiveSubscription");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(customerId);
+    }
+
+    [Fact]
+    public void SubscriptionAlreadyCanceled_WithSubscriptionId_ReturnsConflictErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string subscriptionId = "sub-99";
+
+        // Act
+        var error = BillingErrors.SubscriptionAlreadyCanceled(subscriptionId);
+
+        // Assert
+        error.Code.Should().Be("Billing.SubscriptionAlreadyCanceled");
+        error.Type.Should().Be(ErrorType.Conflict);
+        error.Message.Should().Contain(subscriptionId);
+    }
+
+    [Fact]
+    public void SubscriptionNotPausable_WithSubscriptionId_ReturnsConflictErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string subscriptionId = "sub-12";
+
+        // Act
+        var error = BillingErrors.SubscriptionNotPausable(subscriptionId);
+
+        // Assert
+        error.Code.Should().Be("Billing.SubscriptionNotPausable");
+        error.Type.Should().Be(ErrorType.Conflict);
+        error.Message.Should().Contain(subscriptionId);
+    }
+
+    [Fact]
+    public void SubscriptionNotPaused_WithSubscriptionId_ReturnsConflictErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string subscriptionId = "sub-13";
+
+        // Act
+        var error = BillingErrors.SubscriptionNotPaused(subscriptionId);
+
+        // Assert
+        error.Code.Should().Be("Billing.SubscriptionNotPaused");
+        error.Type.Should().Be(ErrorType.Conflict);
+        error.Message.Should().Contain(subscriptionId);
+    }
+
+    [Fact]
+    public void InvalidLicense_WithLicenseKey_ReturnsValidationErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string licenseKey = "LIC-ABCD";
+
+        // Act
+        var error = BillingErrors.InvalidLicense(licenseKey);
+
+        // Assert
+        error.Code.Should().Be("Billing.InvalidLicense");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain(licenseKey);
+    }
+
+    [Fact]
+    public void LicenseExpired_WithLicenseKey_ReturnsValidationErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string licenseKey = "LIC-EXP";
+
+        // Act
+        var error = BillingErrors.LicenseExpired(licenseKey);
+
+        // Assert
+        error.Code.Should().Be("Billing.LicenseExpired");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain(licenseKey);
+    }
+
+    [Fact]
+    public void LicenseActivationLimitReached_WithLicenseKey_ReturnsConflictErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string licenseKey = "LIC-LIMIT";
+
+        // Act
+        var error = BillingErrors.LicenseActivationLimitReached(licenseKey);
+
+        // Assert
+        error.Code.Should().Be("Billing.LicenseActivationLimitReached");
+        error.Type.Should().Be(ErrorType.Conflict);
+        error.Message.Should().Contain(licenseKey);
+    }
+
+    [Fact]
+    public void LicenseInstanceNotFound_WithInstanceId_ReturnsNotFoundErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string instanceId = "inst-1";
+
+        // Act
+        var error = BillingErrors.LicenseInstanceNotFound(instanceId);
+
+        // Assert
+        error.Code.Should().Be("Billing.LicenseInstanceNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(instanceId);
+    }
+
+    [Fact]
+    public void VariantNotFound_WithVariantId_ReturnsNotFoundErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string variantId = "var-1";
+
+        // Act
+        var error = BillingErrors.VariantNotFound(variantId);
+
+        // Assert
+        error.Code.Should().Be("Billing.VariantNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(variantId);
+    }
+
+    [Fact]
+    public void InvalidWebhookSignature_StaticInstance_IsUnauthorizedErrorWithCorrectCode()
+    {
+        // Act
+        var error = BillingErrors.InvalidWebhookSignature;
+
+        // Assert
+        error.Code.Should().Be("Billing.InvalidWebhookSignature");
+        error.Type.Should().Be(ErrorType.Unauthorized);
+        error.Message.Should().Contain("signature");
+    }
+
+    [Fact]
+    public void WebhookProcessingFailed_WithReason_ReturnsFailureErrorWithCorrectCodeAndMessage()
+    {
+        // Arrange
+        const string reason = "Bad payload";
+
+        // Act
+        var error = BillingErrors.WebhookProcessingFailed(reason);
+
+        // Assert
+        error.Code.Should().Be("Billing.WebhookProcessingFailed");
+        error.Type.Should().Be(ErrorType.Failure);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Fact]
+    public void ProviderUnavailable_StaticInstance_IsUnavailableErrorWithCorrectCode()
+    {
+        // Act
+        var error = BillingErrors.ProviderUnavailable;
+
+        // Assert
+        error.Code.Should().Be("Billing.ProviderUnavailable");
+        error.Type.Should().Be(ErrorType.Unavailable);
+        error.Message.Should().Contain("unavailable");
+    }
+
+    [Fact]
+    public void RateLimitExceeded_StaticInstance_IsTooManyRequestsErrorWithCorrectCode()
+    {
+        // Act
+        var error = BillingErrors.RateLimitExceeded;
+
+        // Assert
+        error.Code.Should().Be("Billing.RateLimitExceeded");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().Contain("Rate limit");
+    }
+
+    [Fact]
+    public void TenantContextRequired_StaticInstance_IsValidationErrorWithCorrectCode()
+    {
+        // Act
+        var error = BillingErrors.TenantContextRequired;
+
+        // Assert
+        error.Code.Should().Be("Billing.TenantContextRequired");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain("Tenant");
+    }
+
+    [Theory]
+    [InlineData("with-special-chars-!@#$")]
+    [InlineData("very-long-id-1234567890-abcdefghij")]
+    [InlineData("a")]
+    public void CustomerNotFound_WithVariousIds_AlwaysIncludesIdInMessage(string customerId)
+    {
+        // Act
+        var error = BillingErrors.CustomerNotFound(customerId);
+
+        // Assert
+        error.Code.Should().Be("Billing.CustomerNotFound");
+        error.Message.Should().Contain(customerId);
+    }
+
+    [Fact]
+    public void CustomerNotFound_WithEmptyId_StillReturnsCorrectErrorCode()
+    {
+        // Act
+        var error = BillingErrors.CustomerNotFound(string.Empty);
+
+        // Assert
+        error.Code.Should().Be("Billing.CustomerNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public void StaticReadonlyErrors_AreReferenceEqualOnRepeatedAccess()
+    {
+        // Act
+        var first = BillingErrors.InvalidWebhookSignature;
+        var second = BillingErrors.InvalidWebhookSignature;
+
+        // Assert
+        ReferenceEquals(first, second).Should().BeTrue();
+    }
+
+    [Fact]
+    public void StaticReadonlyErrors_TenantContextRequired_AreReferenceEqualOnRepeatedAccess()
+    {
+        // Act
+        var first = BillingErrors.TenantContextRequired;
+        var second = BillingErrors.TenantContextRequired;
+
+        // Assert
+        ReferenceEquals(first, second).Should().BeTrue();
+    }
+
+    [Fact]
+    public void StaticReadonlyErrors_ProviderUnavailable_AreReferenceEqualOnRepeatedAccess()
+    {
+        // Act
+        var first = BillingErrors.ProviderUnavailable;
+        var second = BillingErrors.ProviderUnavailable;
+
+        // Assert
+        ReferenceEquals(first, second).Should().BeTrue();
+    }
+
+    [Fact]
+    public void StaticReadonlyErrors_RateLimitExceeded_AreReferenceEqualOnRepeatedAccess()
+    {
+        // Act
+        var first = BillingErrors.RateLimitExceeded;
+        var second = BillingErrors.RateLimitExceeded;
+
+        // Assert
+        ReferenceEquals(first, second).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Result_FromBillingError_FlowsThroughResultPattern()
+    {
+        // Arrange
+        var error = BillingErrors.SubscriptionNotFound("sub-x");
+
+        // Act
+        Result result = Result.Failure(error);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeSameAs(error);
+        result.Error.Type.Should().Be(ErrorType.NotFound);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Billing.Tests/Compendium.Abstractions.Billing.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Billing.Tests/Compendium.Abstractions.Billing.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Billing.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Billing.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Billing\Compendium.Abstractions.Billing.csproj" />
+    <ProjectReference Include="..\..\..\src\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Billing.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Billing.Tests/GlobalUsings.cs
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Xunit;
+global using FluentAssertions;
+global using Compendium.Abstractions.Billing;
+global using Compendium.Abstractions.Billing.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Billing.Tests/Models/BillingCustomerTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Billing.Tests/Models/BillingCustomerTests.cs
@@ -1,0 +1,197 @@
+// -----------------------------------------------------------------------
+// <copyright file="BillingCustomerTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Billing.Tests.Models;
+
+public class BillingCustomerTests
+{
+    [Fact]
+    public void BillingCustomer_WithRequiredProperties_CreatesInstanceSuccessfully()
+    {
+        // Arrange & Act
+        var customer = new BillingCustomer
+        {
+            Id = "cust-1",
+            Email = "user@example.com"
+        };
+
+        // Assert
+        customer.Id.Should().Be("cust-1");
+        customer.Email.Should().Be("user@example.com");
+        customer.StoreId.Should().BeNull();
+        customer.Name.Should().BeNull();
+        customer.City.Should().BeNull();
+        customer.Region.Should().BeNull();
+        customer.Country.Should().BeNull();
+        customer.TotalRevenueCents.Should().BeNull();
+        customer.Currency.Should().BeNull();
+        customer.TenantId.Should().BeNull();
+        customer.UserId.Should().BeNull();
+        customer.CustomData.Should().BeNull();
+        customer.UpdatedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void BillingCustomer_WithAllProperties_PreservesAllValues()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow.AddDays(-10);
+        var updatedAt = DateTimeOffset.UtcNow.AddDays(-1);
+        var customData = new Dictionary<string, object> { ["plan"] = "pro" };
+
+        // Act
+        var customer = new BillingCustomer
+        {
+            Id = "cust-2",
+            StoreId = "store-1",
+            Name = "Alice",
+            Email = "alice@example.com",
+            City = "Paris",
+            Region = "IDF",
+            Country = "FR",
+            TotalRevenueCents = 12500,
+            Currency = "EUR",
+            TenantId = "tenant-1",
+            UserId = "user-1",
+            CustomData = customData,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt
+        };
+
+        // Assert
+        customer.Id.Should().Be("cust-2");
+        customer.StoreId.Should().Be("store-1");
+        customer.Name.Should().Be("Alice");
+        customer.Email.Should().Be("alice@example.com");
+        customer.City.Should().Be("Paris");
+        customer.Region.Should().Be("IDF");
+        customer.Country.Should().Be("FR");
+        customer.TotalRevenueCents.Should().Be(12500);
+        customer.Currency.Should().Be("EUR");
+        customer.TenantId.Should().Be("tenant-1");
+        customer.UserId.Should().Be("user-1");
+        customer.CustomData.Should().BeSameAs(customData);
+        customer.CreatedAt.Should().Be(createdAt);
+        customer.UpdatedAt.Should().Be(updatedAt);
+    }
+
+    [Fact]
+    public void BillingCustomer_TwoInstancesWithSameValues_AreEqual()
+    {
+        // Arrange
+        var first = new BillingCustomer { Id = "cust-1", Email = "u@e.com" };
+        var second = new BillingCustomer { Id = "cust-1", Email = "u@e.com" };
+
+        // Act & Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void BillingCustomer_TwoInstancesWithDifferentIds_AreNotEqual()
+    {
+        // Arrange
+        var first = new BillingCustomer { Id = "cust-1", Email = "u@e.com" };
+        var second = new BillingCustomer { Id = "cust-2", Email = "u@e.com" };
+
+        // Act & Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void BillingCustomer_WithExpression_ProducesNewInstanceWithUpdatedValue()
+    {
+        // Arrange
+        var original = new BillingCustomer { Id = "cust-1", Email = "old@e.com" };
+
+        // Act
+        var modified = original with { Email = "new@e.com" };
+
+        // Assert
+        modified.Should().NotBeSameAs(original);
+        modified.Email.Should().Be("new@e.com");
+        original.Email.Should().Be("old@e.com");
+    }
+}
+
+public class UpsertCustomerRequestTests
+{
+    [Fact]
+    public void UpsertCustomerRequest_WithRequiredProperties_CreatesInstanceSuccessfully()
+    {
+        // Arrange & Act
+        var request = new UpsertCustomerRequest
+        {
+            Email = "user@example.com"
+        };
+
+        // Assert
+        request.Email.Should().Be("user@example.com");
+        request.Name.Should().BeNull();
+        request.City.Should().BeNull();
+        request.Region.Should().BeNull();
+        request.Country.Should().BeNull();
+        request.TenantId.Should().BeNull();
+        request.UserId.Should().BeNull();
+        request.CustomData.Should().BeNull();
+    }
+
+    [Fact]
+    public void UpsertCustomerRequest_WithAllProperties_PreservesAllValues()
+    {
+        // Arrange
+        var customData = new Dictionary<string, object> { ["source"] = "app" };
+
+        // Act
+        var request = new UpsertCustomerRequest
+        {
+            Email = "alice@example.com",
+            Name = "Alice",
+            City = "Paris",
+            Region = "IDF",
+            Country = "FR",
+            TenantId = "tenant-1",
+            UserId = "user-1",
+            CustomData = customData
+        };
+
+        // Assert
+        request.Email.Should().Be("alice@example.com");
+        request.Name.Should().Be("Alice");
+        request.City.Should().Be("Paris");
+        request.Region.Should().Be("IDF");
+        request.Country.Should().Be("FR");
+        request.TenantId.Should().Be("tenant-1");
+        request.UserId.Should().Be("user-1");
+        request.CustomData.Should().BeSameAs(customData);
+    }
+
+    [Fact]
+    public void UpsertCustomerRequest_TwoIdenticalInstances_AreEqualByValue()
+    {
+        // Arrange
+        var first = new UpsertCustomerRequest { Email = "u@e.com", Name = "U" };
+        var second = new UpsertCustomerRequest { Email = "u@e.com", Name = "U" };
+
+        // Act & Assert
+        first.Should().Be(second);
+    }
+
+    [Fact]
+    public void UpsertCustomerRequest_WithExpression_ProducesNewInstanceWithUpdatedValue()
+    {
+        // Arrange
+        var original = new UpsertCustomerRequest { Email = "old@e.com" };
+
+        // Act
+        var modified = original with { Email = "new@e.com" };
+
+        // Assert
+        modified.Email.Should().Be("new@e.com");
+        original.Email.Should().Be("old@e.com");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Billing.Tests/Models/CheckoutSessionTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Billing.Tests/Models/CheckoutSessionTests.cs
@@ -1,0 +1,180 @@
+// -----------------------------------------------------------------------
+// <copyright file="CheckoutSessionTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Billing.Tests.Models;
+
+public class CheckoutSessionTests
+{
+    [Fact]
+    public void CheckoutSession_WithRequiredProperties_CreatesInstanceSuccessfully()
+    {
+        // Arrange & Act
+        var session = new CheckoutSession
+        {
+            Id = "ck-1",
+            CheckoutUrl = "https://checkout.example/pay/ck-1"
+        };
+
+        // Assert
+        session.Id.Should().Be("ck-1");
+        session.CheckoutUrl.Should().Be("https://checkout.example/pay/ck-1");
+        session.StoreId.Should().BeNull();
+        session.VariantId.Should().BeNull();
+        session.ExpiresAt.Should().BeNull();
+        session.CustomData.Should().BeNull();
+    }
+
+    [Fact]
+    public void CheckoutSession_WithAllProperties_PreservesAllValues()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow;
+        var expiresAt = createdAt.AddHours(1);
+        var customData = new Dictionary<string, object> { ["referrer"] = "newsletter" };
+
+        // Act
+        var session = new CheckoutSession
+        {
+            Id = "ck-2",
+            CheckoutUrl = "https://checkout.example/pay/ck-2",
+            StoreId = "store-1",
+            VariantId = "var-1",
+            CreatedAt = createdAt,
+            ExpiresAt = expiresAt,
+            CustomData = customData
+        };
+
+        // Assert
+        session.Id.Should().Be("ck-2");
+        session.StoreId.Should().Be("store-1");
+        session.VariantId.Should().Be("var-1");
+        session.CreatedAt.Should().Be(createdAt);
+        session.ExpiresAt.Should().Be(expiresAt);
+        session.CustomData.Should().BeSameAs(customData);
+    }
+
+    [Fact]
+    public void CheckoutSession_TwoIdenticalInstances_AreEqualByValue()
+    {
+        // Arrange
+        var first = new CheckoutSession { Id = "ck-1", CheckoutUrl = "https://x" };
+        var second = new CheckoutSession { Id = "ck-1", CheckoutUrl = "https://x" };
+
+        // Act & Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void CheckoutSession_WithExpression_ProducesNewInstanceWithUpdatedValue()
+    {
+        // Arrange
+        var original = new CheckoutSession { Id = "ck-1", CheckoutUrl = "https://old" };
+
+        // Act
+        var modified = original with { CheckoutUrl = "https://new" };
+
+        // Assert
+        modified.CheckoutUrl.Should().Be("https://new");
+        original.CheckoutUrl.Should().Be("https://old");
+    }
+}
+
+public class CreateCheckoutRequestTests
+{
+    [Fact]
+    public void CreateCheckoutRequest_WithRequiredProperties_CreatesInstanceSuccessfully()
+    {
+        // Arrange & Act
+        var request = new CreateCheckoutRequest
+        {
+            VariantId = "var-1"
+        };
+
+        // Assert
+        request.VariantId.Should().Be("var-1");
+        request.Email.Should().BeNull();
+        request.Name.Should().BeNull();
+        request.SuccessUrl.Should().BeNull();
+        request.CancelUrl.Should().BeNull();
+        request.Embed.Should().BeNull();
+        request.DiscountCode.Should().BeNull();
+        request.UserId.Should().BeNull();
+        request.CustomData.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateCheckoutRequest_WithAllProperties_PreservesAllValues()
+    {
+        // Arrange
+        var customData = new Dictionary<string, object> { ["promo"] = "summer" };
+
+        // Act
+        var request = new CreateCheckoutRequest
+        {
+            VariantId = "var-1",
+            Email = "buyer@example.com",
+            Name = "Buyer",
+            SuccessUrl = "https://app/success",
+            CancelUrl = "https://app/cancel",
+            Embed = true,
+            DiscountCode = "SUMMER20",
+            UserId = "user-99",
+            CustomData = customData
+        };
+
+        // Assert
+        request.VariantId.Should().Be("var-1");
+        request.Email.Should().Be("buyer@example.com");
+        request.Name.Should().Be("Buyer");
+        request.SuccessUrl.Should().Be("https://app/success");
+        request.CancelUrl.Should().Be("https://app/cancel");
+        request.Embed.Should().BeTrue();
+        request.DiscountCode.Should().Be("SUMMER20");
+        request.UserId.Should().Be("user-99");
+        request.CustomData.Should().BeSameAs(customData);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    [InlineData(null)]
+    public void CreateCheckoutRequest_EmbedFlag_AcceptsAllNullableBoolValues(bool? embed)
+    {
+        // Arrange & Act
+        var request = new CreateCheckoutRequest
+        {
+            VariantId = "var-1",
+            Embed = embed
+        };
+
+        // Assert
+        request.Embed.Should().Be(embed);
+    }
+
+    [Fact]
+    public void CreateCheckoutRequest_TwoIdenticalInstances_AreEqualByValue()
+    {
+        // Arrange
+        var first = new CreateCheckoutRequest { VariantId = "v-1", Email = "e@x" };
+        var second = new CreateCheckoutRequest { VariantId = "v-1", Email = "e@x" };
+
+        // Act & Assert
+        first.Should().Be(second);
+    }
+
+    [Fact]
+    public void CreateCheckoutRequest_TwoInstancesDifferingByVariant_AreNotEqual()
+    {
+        // Arrange
+        var first = new CreateCheckoutRequest { VariantId = "v-1" };
+        var second = new CreateCheckoutRequest { VariantId = "v-2" };
+
+        // Act & Assert
+        first.Should().NotBe(second);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Billing.Tests/Models/LicenseTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Billing.Tests/Models/LicenseTests.cs
@@ -1,0 +1,391 @@
+// -----------------------------------------------------------------------
+// <copyright file="LicenseTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Billing.Tests.Models;
+
+public class LicenseValidationResultTests
+{
+    [Fact]
+    public void LicenseValidationResult_WithRequiredProperties_CreatesInstanceSuccessfully()
+    {
+        // Arrange & Act
+        var result = new LicenseValidationResult
+        {
+            IsValid = true,
+            LicenseKey = "LIC-1",
+            Status = LicenseStatus.Active
+        };
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.LicenseKey.Should().Be("LIC-1");
+        result.Status.Should().Be(LicenseStatus.Active);
+        result.ErrorMessage.Should().BeNull();
+        result.License.Should().BeNull();
+        result.Instance.Should().BeNull();
+        result.Meta.Should().BeNull();
+    }
+
+    [Fact]
+    public void LicenseValidationResult_FailedValidation_CapturesErrorMessage()
+    {
+        // Arrange & Act
+        var result = new LicenseValidationResult
+        {
+            IsValid = false,
+            LicenseKey = "LIC-BAD",
+            Status = LicenseStatus.Disabled,
+            ErrorMessage = "License is disabled"
+        };
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Status.Should().Be(LicenseStatus.Disabled);
+        result.ErrorMessage.Should().Be("License is disabled");
+    }
+
+    [Fact]
+    public void LicenseValidationResult_WithLicenseAndInstance_PreservesNestedDetails()
+    {
+        // Arrange
+        var details = new LicenseDetails
+        {
+            Id = "lic-det-1",
+            Key = "LIC-1",
+            Status = LicenseStatus.Active
+        };
+        var instance = new LicenseInstance
+        {
+            Id = "inst-1",
+            Name = "Workstation",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        var meta = new Dictionary<string, object> { ["source"] = "api" };
+
+        // Act
+        var result = new LicenseValidationResult
+        {
+            IsValid = true,
+            LicenseKey = "LIC-1",
+            Status = LicenseStatus.Active,
+            License = details,
+            Instance = instance,
+            Meta = meta
+        };
+
+        // Assert
+        result.License.Should().BeSameAs(details);
+        result.Instance.Should().BeSameAs(instance);
+        result.Meta.Should().BeSameAs(meta);
+    }
+
+    [Fact]
+    public void LicenseValidationResult_TwoIdenticalInstances_AreEqualByValue()
+    {
+        // Arrange
+        var first = new LicenseValidationResult
+        {
+            IsValid = true,
+            LicenseKey = "LIC-1",
+            Status = LicenseStatus.Active
+        };
+        var second = new LicenseValidationResult
+        {
+            IsValid = true,
+            LicenseKey = "LIC-1",
+            Status = LicenseStatus.Active
+        };
+
+        // Act & Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+}
+
+public class LicenseDetailsTests
+{
+    private static LicenseDetails Build(
+        string id = "lic-1",
+        string key = "LIC-1",
+        LicenseStatus status = LicenseStatus.Active,
+        DateTimeOffset? expiresAt = null) =>
+        new()
+        {
+            Id = id,
+            Key = key,
+            Status = status,
+            ExpiresAt = expiresAt
+        };
+
+    [Fact]
+    public void LicenseDetails_WithRequiredProperties_CreatesInstanceSuccessfully()
+    {
+        // Arrange & Act
+        var details = Build();
+
+        // Assert
+        details.Id.Should().Be("lic-1");
+        details.Key.Should().Be("LIC-1");
+        details.Status.Should().Be(LicenseStatus.Active);
+        details.StoreId.Should().BeNull();
+        details.OrderId.Should().BeNull();
+        details.OrderItemId.Should().BeNull();
+        details.ProductId.Should().BeNull();
+        details.CustomerName.Should().BeNull();
+        details.CustomerEmail.Should().BeNull();
+        details.ActivationLimit.Should().BeNull();
+        details.ActivationCount.Should().BeNull();
+        details.ExpiresAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void LicenseDetails_WithAllProperties_PreservesAllValues()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow.AddDays(-30);
+        var expiresAt = DateTimeOffset.UtcNow.AddDays(30);
+
+        // Act
+        var details = new LicenseDetails
+        {
+            Id = "lic-2",
+            Key = "LIC-2",
+            StoreId = "store-1",
+            OrderId = "ord-1",
+            OrderItemId = "item-1",
+            ProductId = "prod-1",
+            CustomerName = "Alice",
+            CustomerEmail = "alice@example.com",
+            Status = LicenseStatus.Active,
+            ActivationLimit = 5,
+            ActivationCount = 2,
+            CreatedAt = createdAt,
+            ExpiresAt = expiresAt
+        };
+
+        // Assert
+        details.StoreId.Should().Be("store-1");
+        details.OrderId.Should().Be("ord-1");
+        details.OrderItemId.Should().Be("item-1");
+        details.ProductId.Should().Be("prod-1");
+        details.CustomerName.Should().Be("Alice");
+        details.CustomerEmail.Should().Be("alice@example.com");
+        details.ActivationLimit.Should().Be(5);
+        details.ActivationCount.Should().Be(2);
+        details.CreatedAt.Should().Be(createdAt);
+        details.ExpiresAt.Should().Be(expiresAt);
+    }
+
+    [Fact]
+    public void IsExpired_WhenExpiresAtIsNull_ReturnsFalse()
+    {
+        // Arrange
+        var details = Build(expiresAt: null);
+
+        // Act & Assert
+        details.IsExpired.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_WhenExpiresAtInTheFuture_ReturnsFalse()
+    {
+        // Arrange
+        var details = Build(expiresAt: DateTimeOffset.UtcNow.AddDays(7));
+
+        // Act & Assert
+        details.IsExpired.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_WhenExpiresAtInThePast_ReturnsTrue()
+    {
+        // Arrange
+        var details = Build(expiresAt: DateTimeOffset.UtcNow.AddDays(-1));
+
+        // Act & Assert
+        details.IsExpired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LicenseDetails_TwoIdenticalInstances_AreEqualByValue()
+    {
+        // Arrange
+        var first = Build();
+        var second = Build();
+
+        // Act & Assert
+        first.Should().Be(second);
+    }
+
+    [Fact]
+    public void LicenseDetails_WithExpression_ProducesNewInstanceWithUpdatedValue()
+    {
+        // Arrange
+        var original = Build(status: LicenseStatus.Active);
+
+        // Act
+        var disabled = original with { Status = LicenseStatus.Disabled };
+
+        // Assert
+        disabled.Status.Should().Be(LicenseStatus.Disabled);
+        original.Status.Should().Be(LicenseStatus.Active);
+    }
+}
+
+public class LicenseInstanceTests
+{
+    [Fact]
+    public void LicenseInstance_WithRequiredProperties_CreatesInstanceSuccessfully()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var instance = new LicenseInstance
+        {
+            Id = "inst-1",
+            Name = "Workstation",
+            CreatedAt = createdAt
+        };
+
+        // Assert
+        instance.Id.Should().Be("inst-1");
+        instance.Name.Should().Be("Workstation");
+        instance.CreatedAt.Should().Be(createdAt);
+    }
+
+    [Fact]
+    public void LicenseInstance_TwoIdenticalInstances_AreEqualByValue()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow;
+        var first = new LicenseInstance { Id = "inst-1", Name = "Wks", CreatedAt = createdAt };
+        var second = new LicenseInstance { Id = "inst-1", Name = "Wks", CreatedAt = createdAt };
+
+        // Act & Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void LicenseInstance_TwoInstancesDifferingById_AreNotEqual()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow;
+        var first = new LicenseInstance { Id = "inst-1", Name = "Wks", CreatedAt = createdAt };
+        var second = new LicenseInstance { Id = "inst-2", Name = "Wks", CreatedAt = createdAt };
+
+        // Act & Assert
+        first.Should().NotBe(second);
+    }
+}
+
+public class LicenseActivationTests
+{
+    [Fact]
+    public void LicenseActivation_WithRequiredProperty_CreatesInstanceSuccessfully()
+    {
+        // Arrange & Act
+        var activation = new LicenseActivation { Activated = true };
+
+        // Assert
+        activation.Activated.Should().BeTrue();
+        activation.Instance.Should().BeNull();
+        activation.License.Should().BeNull();
+        activation.ErrorMessage.Should().BeNull();
+        activation.Meta.Should().BeNull();
+    }
+
+    [Fact]
+    public void LicenseActivation_FailedActivation_CapturesErrorMessage()
+    {
+        // Arrange & Act
+        var activation = new LicenseActivation
+        {
+            Activated = false,
+            ErrorMessage = "Activation limit reached"
+        };
+
+        // Assert
+        activation.Activated.Should().BeFalse();
+        activation.ErrorMessage.Should().Be("Activation limit reached");
+    }
+
+    [Fact]
+    public void LicenseActivation_WithInstanceLicenseAndMeta_PreservesNestedDetails()
+    {
+        // Arrange
+        var instance = new LicenseInstance
+        {
+            Id = "inst-1",
+            Name = "Wks",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        var details = new LicenseDetails
+        {
+            Id = "lic-1",
+            Key = "LIC-1",
+            Status = LicenseStatus.Active
+        };
+        var meta = new Dictionary<string, object> { ["activated_via"] = "api" };
+
+        // Act
+        var activation = new LicenseActivation
+        {
+            Activated = true,
+            Instance = instance,
+            License = details,
+            Meta = meta
+        };
+
+        // Assert
+        activation.Instance.Should().BeSameAs(instance);
+        activation.License.Should().BeSameAs(details);
+        activation.Meta.Should().BeSameAs(meta);
+    }
+
+    [Fact]
+    public void LicenseActivation_TwoIdenticalInstances_AreEqualByValue()
+    {
+        // Arrange
+        var first = new LicenseActivation { Activated = true };
+        var second = new LicenseActivation { Activated = true };
+
+        // Act & Assert
+        first.Should().Be(second);
+    }
+}
+
+public class LicenseStatusTests
+{
+    [Fact]
+    public void LicenseStatus_DeclaresAllExpectedValues()
+    {
+        // Act
+        var values = Enum.GetValues<LicenseStatus>();
+
+        // Assert
+        values.Should().Contain(new[]
+        {
+            LicenseStatus.Inactive,
+            LicenseStatus.Active,
+            LicenseStatus.Expired,
+            LicenseStatus.Disabled
+        });
+    }
+
+    [Theory]
+    [InlineData(LicenseStatus.Inactive, 0)]
+    [InlineData(LicenseStatus.Active, 1)]
+    [InlineData(LicenseStatus.Expired, 2)]
+    [InlineData(LicenseStatus.Disabled, 3)]
+    public void LicenseStatus_NumericValues_AreStable(LicenseStatus status, int expected)
+    {
+        // Act & Assert
+        ((int)status).Should().Be(expected);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Billing.Tests/Models/SubscriptionTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Billing.Tests/Models/SubscriptionTests.cs
@@ -1,0 +1,229 @@
+// -----------------------------------------------------------------------
+// <copyright file="SubscriptionTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Billing.Tests.Models;
+
+public class SubscriptionTests
+{
+    private static Subscription Build(
+        string id = "sub-1",
+        string customerId = "cust-1",
+        string productId = "prod-1",
+        string variantId = "var-1",
+        BillingSubscriptionStatus status = BillingSubscriptionStatus.Active,
+        DateTimeOffset? trialEndsAt = null) =>
+        new()
+        {
+            Id = id,
+            CustomerId = customerId,
+            ProductId = productId,
+            VariantId = variantId,
+            Status = status,
+            TrialEndsAt = trialEndsAt
+        };
+
+    [Fact]
+    public void Subscription_WithRequiredProperties_CreatesInstanceSuccessfully()
+    {
+        // Arrange & Act
+        var subscription = Build();
+
+        // Assert
+        subscription.Id.Should().Be("sub-1");
+        subscription.CustomerId.Should().Be("cust-1");
+        subscription.ProductId.Should().Be("prod-1");
+        subscription.VariantId.Should().Be("var-1");
+        subscription.Status.Should().Be(BillingSubscriptionStatus.Active);
+        subscription.ProductName.Should().BeNull();
+        subscription.VariantName.Should().BeNull();
+        subscription.BillingInterval.Should().BeNull();
+        subscription.BillingIntervalCount.Should().BeNull();
+        subscription.PriceAmountCents.Should().BeNull();
+        subscription.Currency.Should().BeNull();
+        subscription.TenantId.Should().BeNull();
+        subscription.CustomData.Should().BeNull();
+    }
+
+    [Fact]
+    public void Subscription_WithAllProperties_PreservesAllValues()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow.AddDays(-30);
+        var customData = new Dictionary<string, object> { ["plan_tier"] = "gold" };
+
+        // Act
+        var subscription = new Subscription
+        {
+            Id = "sub-2",
+            CustomerId = "cust-2",
+            ProductId = "prod-2",
+            VariantId = "var-2",
+            ProductName = "Gold Plan",
+            VariantName = "Annual",
+            Status = BillingSubscriptionStatus.OnTrial,
+            BillingInterval = "year",
+            BillingIntervalCount = 1,
+            PriceAmountCents = 9900,
+            Currency = "EUR",
+            TenantId = "tenant-2",
+            CustomData = customData,
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt.AddDays(1),
+            CurrentPeriodStart = createdAt,
+            CurrentPeriodEnd = createdAt.AddYears(1),
+            CancelAt = createdAt.AddYears(1),
+            CanceledAt = createdAt.AddDays(2),
+            EndedAt = createdAt.AddDays(3),
+            TrialEndsAt = createdAt.AddDays(14),
+            PausedAt = createdAt.AddDays(4),
+            ResumesAt = createdAt.AddDays(20)
+        };
+
+        // Assert
+        subscription.ProductName.Should().Be("Gold Plan");
+        subscription.VariantName.Should().Be("Annual");
+        subscription.Status.Should().Be(BillingSubscriptionStatus.OnTrial);
+        subscription.BillingInterval.Should().Be("year");
+        subscription.BillingIntervalCount.Should().Be(1);
+        subscription.PriceAmountCents.Should().Be(9900);
+        subscription.Currency.Should().Be("EUR");
+        subscription.TenantId.Should().Be("tenant-2");
+        subscription.CustomData.Should().BeSameAs(customData);
+        subscription.CreatedAt.Should().Be(createdAt);
+        subscription.UpdatedAt.Should().Be(createdAt.AddDays(1));
+        subscription.CurrentPeriodStart.Should().Be(createdAt);
+        subscription.CurrentPeriodEnd.Should().Be(createdAt.AddYears(1));
+        subscription.CancelAt.Should().Be(createdAt.AddYears(1));
+        subscription.CanceledAt.Should().Be(createdAt.AddDays(2));
+        subscription.EndedAt.Should().Be(createdAt.AddDays(3));
+        subscription.PausedAt.Should().Be(createdAt.AddDays(4));
+        subscription.ResumesAt.Should().Be(createdAt.AddDays(20));
+    }
+
+    [Fact]
+    public void IsInTrial_WhenTrialEndsAtIsNull_ReturnsFalse()
+    {
+        // Arrange
+        var subscription = Build(trialEndsAt: null);
+
+        // Act & Assert
+        subscription.IsInTrial.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsInTrial_WhenTrialEndsAtInTheFuture_ReturnsTrue()
+    {
+        // Arrange
+        var subscription = Build(trialEndsAt: DateTimeOffset.UtcNow.AddDays(7));
+
+        // Act & Assert
+        subscription.IsInTrial.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsInTrial_WhenTrialEndsAtInThePast_ReturnsFalse()
+    {
+        // Arrange
+        var subscription = Build(trialEndsAt: DateTimeOffset.UtcNow.AddDays(-1));
+
+        // Act & Assert
+        subscription.IsInTrial.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(BillingSubscriptionStatus.Active, true)]
+    [InlineData(BillingSubscriptionStatus.OnTrial, true)]
+    [InlineData(BillingSubscriptionStatus.Paused, false)]
+    [InlineData(BillingSubscriptionStatus.PastDue, false)]
+    [InlineData(BillingSubscriptionStatus.Unpaid, false)]
+    [InlineData(BillingSubscriptionStatus.Cancelled, false)]
+    [InlineData(BillingSubscriptionStatus.Expired, false)]
+    public void IsActive_ForEachStatus_ReturnsExpected(BillingSubscriptionStatus status, bool expected)
+    {
+        // Arrange
+        var subscription = Build(status: status);
+
+        // Act
+        var actual = subscription.IsActive;
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Subscription_TwoIdenticalInstances_AreEqualByValue()
+    {
+        // Arrange
+        var first = Build();
+        var second = Build();
+
+        // Act & Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void Subscription_TwoInstancesDifferingByStatus_AreNotEqual()
+    {
+        // Arrange
+        var first = Build(status: BillingSubscriptionStatus.Active);
+        var second = Build(status: BillingSubscriptionStatus.Paused);
+
+        // Act & Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void Subscription_WithExpression_ProducesNewInstanceWithUpdatedValue()
+    {
+        // Arrange
+        var original = Build(status: BillingSubscriptionStatus.Active);
+
+        // Act
+        var canceled = original with { Status = BillingSubscriptionStatus.Cancelled };
+
+        // Assert
+        canceled.Status.Should().Be(BillingSubscriptionStatus.Cancelled);
+        original.Status.Should().Be(BillingSubscriptionStatus.Active);
+    }
+}
+
+public class BillingSubscriptionStatusTests
+{
+    [Fact]
+    public void BillingSubscriptionStatus_DeclaresAllExpectedValues()
+    {
+        // Act
+        var values = Enum.GetValues<BillingSubscriptionStatus>();
+
+        // Assert
+        values.Should().Contain(new[]
+        {
+            BillingSubscriptionStatus.Active,
+            BillingSubscriptionStatus.OnTrial,
+            BillingSubscriptionStatus.Paused,
+            BillingSubscriptionStatus.PastDue,
+            BillingSubscriptionStatus.Unpaid,
+            BillingSubscriptionStatus.Cancelled,
+            BillingSubscriptionStatus.Expired
+        });
+    }
+
+    [Theory]
+    [InlineData(BillingSubscriptionStatus.Active, 0)]
+    [InlineData(BillingSubscriptionStatus.OnTrial, 1)]
+    [InlineData(BillingSubscriptionStatus.Paused, 2)]
+    [InlineData(BillingSubscriptionStatus.PastDue, 3)]
+    [InlineData(BillingSubscriptionStatus.Unpaid, 4)]
+    [InlineData(BillingSubscriptionStatus.Cancelled, 5)]
+    [InlineData(BillingSubscriptionStatus.Expired, 6)]
+    public void BillingSubscriptionStatus_NumericValues_AreStable(BillingSubscriptionStatus status, int expected)
+    {
+        // Act & Assert
+        ((int)status).Should().Be(expected);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Billing.Tests/Models/WebhookProcessingResultTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Billing.Tests/Models/WebhookProcessingResultTests.cs
@@ -1,0 +1,176 @@
+// -----------------------------------------------------------------------
+// <copyright file="WebhookProcessingResultTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Billing.Tests.Models;
+
+public class WebhookProcessingResultTests
+{
+    [Fact]
+    public void WebhookProcessingResult_WithRequiredProperty_CreatesInstanceSuccessfully()
+    {
+        // Arrange & Act
+        var result = new WebhookProcessingResult { Processed = true };
+
+        // Assert
+        result.Processed.Should().BeTrue();
+        result.EventType.Should().BeNull();
+        result.EventId.Should().BeNull();
+        result.ResourceType.Should().BeNull();
+        result.ResourceId.Should().BeNull();
+        result.TenantId.Should().BeNull();
+        result.WasDuplicate.Should().BeFalse();
+        result.ExtractedData.Should().BeNull();
+        result.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void WebhookProcessingResult_WithAllProperties_PreservesAllValues()
+    {
+        // Arrange
+        var extracted = new Dictionary<string, object> { ["amount"] = 1000 };
+
+        // Act
+        var result = new WebhookProcessingResult
+        {
+            Processed = true,
+            EventType = "subscription.created",
+            EventId = "evt-1",
+            ResourceType = "subscription",
+            ResourceId = "sub-1",
+            TenantId = "tenant-1",
+            WasDuplicate = false,
+            ExtractedData = extracted,
+            ErrorMessage = null
+        };
+
+        // Assert
+        result.EventType.Should().Be("subscription.created");
+        result.EventId.Should().Be("evt-1");
+        result.ResourceType.Should().Be("subscription");
+        result.ResourceId.Should().Be("sub-1");
+        result.TenantId.Should().Be("tenant-1");
+        result.ExtractedData.Should().BeSameAs(extracted);
+    }
+
+    [Fact]
+    public void Success_WithEventTypeOnly_ReturnsProcessedResultWithEventType()
+    {
+        // Act
+        var result = WebhookProcessingResult.Success("order.created");
+
+        // Assert
+        result.Processed.Should().BeTrue();
+        result.WasDuplicate.Should().BeFalse();
+        result.EventType.Should().Be("order.created");
+        result.EventId.Should().BeNull();
+        result.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void Success_WithEventTypeAndId_ReturnsProcessedResultWithBoth()
+    {
+        // Act
+        var result = WebhookProcessingResult.Success("order.created", "evt-42");
+
+        // Assert
+        result.Processed.Should().BeTrue();
+        result.WasDuplicate.Should().BeFalse();
+        result.EventType.Should().Be("order.created");
+        result.EventId.Should().Be("evt-42");
+    }
+
+    [Fact]
+    public void Duplicate_WithEventTypeOnly_ReturnsProcessedDuplicateResult()
+    {
+        // Act
+        var result = WebhookProcessingResult.Duplicate("order.created");
+
+        // Assert
+        result.Processed.Should().BeTrue();
+        result.WasDuplicate.Should().BeTrue();
+        result.EventType.Should().Be("order.created");
+        result.EventId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Duplicate_WithEventTypeAndId_ReturnsProcessedDuplicateResultWithBoth()
+    {
+        // Act
+        var result = WebhookProcessingResult.Duplicate("order.created", "evt-99");
+
+        // Assert
+        result.Processed.Should().BeTrue();
+        result.WasDuplicate.Should().BeTrue();
+        result.EventType.Should().Be("order.created");
+        result.EventId.Should().Be("evt-99");
+    }
+
+    [Fact]
+    public void Failure_WithErrorMessage_ReturnsUnprocessedResultWithError()
+    {
+        // Act
+        var result = WebhookProcessingResult.Failure("Bad signature");
+
+        // Assert
+        result.Processed.Should().BeFalse();
+        result.WasDuplicate.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Bad signature");
+        result.EventType.Should().BeNull();
+        result.EventId.Should().BeNull();
+    }
+
+    [Fact]
+    public void WebhookProcessingResult_TwoIdenticalInstances_AreEqualByValue()
+    {
+        // Arrange
+        var first = WebhookProcessingResult.Success("e", "id");
+        var second = WebhookProcessingResult.Success("e", "id");
+
+        // Act & Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void WebhookProcessingResult_SuccessVsDuplicate_AreNotEqual()
+    {
+        // Arrange
+        var success = WebhookProcessingResult.Success("e");
+        var duplicate = WebhookProcessingResult.Duplicate("e");
+
+        // Act & Assert
+        success.Should().NotBe(duplicate);
+    }
+
+    [Fact]
+    public void WebhookProcessingResult_WithExpression_ProducesNewInstanceWithUpdatedValue()
+    {
+        // Arrange
+        var original = WebhookProcessingResult.Success("e1");
+
+        // Act
+        var modified = original with { EventType = "e2" };
+
+        // Assert
+        modified.EventType.Should().Be("e2");
+        original.EventType.Should().Be("e1");
+    }
+
+    [Theory]
+    [InlineData("subscription.created")]
+    [InlineData("invoice.paid")]
+    [InlineData("order.refunded")]
+    public void Success_AcceptsArbitraryEventTypes(string eventType)
+    {
+        // Act
+        var result = WebhookProcessingResult.Success(eventType);
+
+        // Assert
+        result.Processed.Should().BeTrue();
+        result.EventType.Should().Be(eventType);
+    }
+}


### PR DESCRIPTION
## Summary
Brings `Compendium.Abstractions.Billing` from 12.1 % → **100 %** line coverage. Part of the testing campaign (VK POM-467).

## Coverage report — Compendium.Abstractions.Billing
- Tests added: **105**
- Test files added:
  - `tests/Unit/Compendium.Abstractions.Billing.Tests/BillingErrorsTests.cs`
  - `tests/Unit/Compendium.Abstractions.Billing.Tests/Models/BillingCustomerTests.cs`
  - `tests/Unit/Compendium.Abstractions.Billing.Tests/Models/CheckoutSessionTests.cs`
  - `tests/Unit/Compendium.Abstractions.Billing.Tests/Models/LicenseTests.cs`
  - `tests/Unit/Compendium.Abstractions.Billing.Tests/Models/SubscriptionTests.cs`
  - `tests/Unit/Compendium.Abstractions.Billing.Tests/Models/WebhookProcessingResultTests.cs`
- Line coverage: 12.1 % → **100 %** (every type in the assembly)
- Branch coverage: covers every `if`/`?:` (e.g. `Subscription.IsInTrial`, `Subscription.IsActive`, `LicenseDetails.IsExpired`)
- Bugs surfaced: 0

### Per-class coverage

| Class | Coverage |
|---|---|
| `BillingErrors` | 100 % |
| `BillingCustomer` | 100 % |
| `UpsertCustomerRequest` | 100 % |
| `CheckoutSession` | 100 % |
| `CreateCheckoutRequest` | 100 % |
| `Subscription` (+`BillingSubscriptionStatus`) | 100 % |
| `LicenseValidationResult` | 100 % |
| `LicenseDetails` | 100 % |
| `LicenseInstance` | 100 % |
| `LicenseActivation` | 100 % |
| `LicenseStatus` | 100 % |
| `WebhookProcessingResult` (+ `Success`/`Duplicate`/`Failure` factories) | 100 % |

### What's covered
- Every `BillingErrors.*` factory (`CustomerNotFound`, `SubscriptionNotFound`, `InvalidLicense`, `InvalidWebhookSignature`, …) — code, message contains arg, error type matches.
- Every `[Theory]` for `BillingSubscriptionStatus` × `IsActive`, `LicenseStatus` numeric stability, embed nullable bool, etc.
- Record equality, `with`-expression immutability, hash-code stability.
- Static readonly errors are reference-equal across calls (cached).
- Result-pattern integration: `Result.Failure(BillingErrors.SubscriptionNotFound("x"))` flows correctly.

## Test plan
- [x] `dotnet build Compendium.sln -c Release` green (0 errors)
- [x] `dotnet test tests/Unit/Compendium.Abstractions.Billing.Tests -c Release` green — 105 passed, 0 failed, 0 skipped
- [x] Tests run twice with identical results (no flakiness)
- [x] No prod code modified
- [x] No version bumps in `Directory.Packages.props`
- [x] No `Moq`, no `Assert.*`, no `Thread.Sleep` in test sources
- [ ] CI green