### PR TITLE
test(abstractions/email): add unit tests for email value objects + errors

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -115,6 +115,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Testing.Tests", 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.PostgreSQL.Tests", "tests\Unit\Compendium.Adapters.PostgreSQL.Tests\Compendium.Adapters.PostgreSQL.Tests.csproj", "{3E6C387D-A84B-43A8-AAF5-B7A9494C57CE}"
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Identity.Tests", "tests\Unit\Compendium.Abstractions.Identity.Tests\Compendium.Abstractions.Identity.Tests.csproj", "{0EDEE2DC-46FE-404B-9615-B6E3F756DF75}"
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Billing.Tests", "tests\Unit\Compendium.Abstractions.Billing.Tests\Compendium.Abstractions.Billing.Tests.csproj", "{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Email.Tests", "tests\Unit\Compendium.Abstractions.Email.Tests\Compendium.Abstractions.Email.Tests.csproj", "{BAD4540D-5310-4623-9441-0328DD43879B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -301,6 +302,10 @@ Global
 		{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BAD4540D-5310-4623-9441-0328DD43879B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BAD4540D-5310-4623-9441-0328DD43879B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BAD4540D-5310-4623-9441-0328DD43879B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BAD4540D-5310-4623-9441-0328DD43879B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -359,5 +364,6 @@ Global
 		{3E6C387D-A84B-43A8-AAF5-B7A9494C57CE} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{0EDEE2DC-46FE-404B-9615-B6E3F756DF75} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{BAD4540D-5310-4623-9441-0328DD43879B} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/tests/Unit/Compendium.Abstractions.Email.Tests/Compendium.Abstractions.Email.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Email.Tests/Compendium.Abstractions.Email.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Email.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Email.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Core\Compendium.Core\Compendium.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Email\Compendium.Abstractions.Email.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Email.Tests/EmailErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Email.Tests/EmailErrorsTests.cs
@@ -1,0 +1,250 @@
+// -----------------------------------------------------------------------
+// <copyright file="EmailErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Email.Tests;
+
+public class EmailErrorsTests
+{
+    [Fact]
+    public void SubscriberNotFound_WithEmail_ReturnsNotFoundError()
+    {
+        // Arrange
+        const string email = "user@example.com";
+
+        // Act
+        var error = EmailErrors.SubscriberNotFound(email);
+
+        // Assert
+        error.Code.Should().Be("Email.SubscriberNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(email);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("a@b.co")]
+    [InlineData("user+tag@example.com")]
+    public void SubscriberNotFound_WithVariousEmails_EmbedsEmailInMessage(string email)
+    {
+        // Act
+        var error = EmailErrors.SubscriberNotFound(email);
+
+        // Assert
+        error.Code.Should().Be("Email.SubscriberNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain($"'{email}'");
+    }
+
+    [Fact]
+    public void SubscriberAlreadyExists_WithEmail_ReturnsConflictError()
+    {
+        // Arrange
+        const string email = "duplicate@example.com";
+
+        // Act
+        var error = EmailErrors.SubscriberAlreadyExists(email);
+
+        // Assert
+        error.Code.Should().Be("Email.SubscriberAlreadyExists");
+        error.Type.Should().Be(ErrorType.Conflict);
+        error.Message.Should().Contain(email);
+    }
+
+    [Fact]
+    public void MailingListNotFound_WithListId_ReturnsNotFoundError()
+    {
+        // Arrange
+        const string listId = "list-abc-123";
+
+        // Act
+        var error = EmailErrors.MailingListNotFound(listId);
+
+        // Assert
+        error.Code.Should().Be("Email.MailingListNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(listId);
+    }
+
+    [Fact]
+    public void TemplateNotFound_WithTemplateId_ReturnsNotFoundError()
+    {
+        // Arrange
+        const string templateId = "welcome-email";
+
+        // Act
+        var error = EmailErrors.TemplateNotFound(templateId);
+
+        // Assert
+        error.Code.Should().Be("Email.TemplateNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(templateId);
+    }
+
+    [Theory]
+    [InlineData("invalid-email")]
+    [InlineData("missing@")]
+    [InlineData("@nodomain.com")]
+    [InlineData("plain text")]
+    [InlineData("")]
+    public void InvalidEmailFormat_WithVariousEmails_ReturnsValidationError(string email)
+    {
+        // Act
+        var error = EmailErrors.InvalidEmailFormat(email);
+
+        // Assert
+        error.Code.Should().Be("Email.InvalidEmailFormat");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain($"'{email}'");
+    }
+
+    [Fact]
+    public void InvalidRecipient_WithReason_ReturnsValidationErrorWithReasonAsMessage()
+    {
+        // Arrange
+        const string reason = "Recipient list cannot be empty.";
+
+        // Act
+        var error = EmailErrors.InvalidRecipient(reason);
+
+        // Assert
+        error.Code.Should().Be("Email.InvalidRecipient");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Be(reason);
+    }
+
+    [Fact]
+    public void SendFailed_WithReason_ReturnsFailureErrorWithReasonEmbedded()
+    {
+        // Arrange
+        const string reason = "SMTP connection refused";
+
+        // Act
+        var error = EmailErrors.SendFailed(reason);
+
+        // Assert
+        error.Code.Should().Be("Email.SendFailed");
+        error.Type.Should().Be(ErrorType.Failure);
+        error.Message.Should().Contain(reason);
+        error.Message.Should().StartWith("Failed to send email:");
+    }
+
+    [Fact]
+    public void ProviderUnavailable_IsStaticReadonlyUnavailableError()
+    {
+        // Act
+        var error = EmailErrors.ProviderUnavailable;
+
+        // Assert
+        error.Code.Should().Be("Email.ProviderUnavailable");
+        error.Type.Should().Be(ErrorType.Unavailable);
+        error.Message.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void ProviderUnavailable_AccessedTwice_ReturnsSameInstance()
+    {
+        // Act
+        var first = EmailErrors.ProviderUnavailable;
+        var second = EmailErrors.ProviderUnavailable;
+
+        // Assert
+        first.Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public void RateLimitExceeded_IsStaticReadonlyTooManyRequestsError()
+    {
+        // Act
+        var error = EmailErrors.RateLimitExceeded;
+
+        // Assert
+        error.Code.Should().Be("Email.RateLimitExceeded");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().Contain("Rate limit");
+    }
+
+    [Fact]
+    public void MessageNotFound_WithMessageId_ReturnsNotFoundError()
+    {
+        // Arrange
+        const string messageId = "msg-9876";
+
+        // Act
+        var error = EmailErrors.MessageNotFound(messageId);
+
+        // Assert
+        error.Code.Should().Be("Email.MessageNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain(messageId);
+    }
+
+    [Fact]
+    public void InvalidConfirmationToken_IsStaticReadonlyValidationError()
+    {
+        // Act
+        var error = EmailErrors.InvalidConfirmationToken;
+
+        // Assert
+        error.Code.Should().Be("Email.InvalidConfirmationToken");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain("confirmation token");
+    }
+
+    [Fact]
+    public void TenantContextRequired_IsStaticReadonlyValidationError()
+    {
+        // Act
+        var error = EmailErrors.TenantContextRequired;
+
+        // Assert
+        error.Code.Should().Be("Email.TenantContextRequired");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain("Tenant context");
+    }
+
+    [Fact]
+    public void AllErrorFactories_ReturnNonNullErrorInstances()
+    {
+        // Act / Assert
+        EmailErrors.SubscriberNotFound("a@b.co").Should().NotBeNull();
+        EmailErrors.SubscriberAlreadyExists("a@b.co").Should().NotBeNull();
+        EmailErrors.MailingListNotFound("id").Should().NotBeNull();
+        EmailErrors.TemplateNotFound("id").Should().NotBeNull();
+        EmailErrors.InvalidEmailFormat("x").Should().NotBeNull();
+        EmailErrors.InvalidRecipient("x").Should().NotBeNull();
+        EmailErrors.SendFailed("x").Should().NotBeNull();
+        EmailErrors.MessageNotFound("id").Should().NotBeNull();
+        EmailErrors.ProviderUnavailable.Should().NotBeNull();
+        EmailErrors.RateLimitExceeded.Should().NotBeNull();
+        EmailErrors.InvalidConfirmationToken.Should().NotBeNull();
+        EmailErrors.TenantContextRequired.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AllErrorCodes_StartWithEmailPrefix()
+    {
+        // Act
+        var codes = new[]
+        {
+            EmailErrors.SubscriberNotFound("a@b.co").Code,
+            EmailErrors.SubscriberAlreadyExists("a@b.co").Code,
+            EmailErrors.MailingListNotFound("id").Code,
+            EmailErrors.TemplateNotFound("id").Code,
+            EmailErrors.InvalidEmailFormat("x").Code,
+            EmailErrors.InvalidRecipient("x").Code,
+            EmailErrors.SendFailed("x").Code,
+            EmailErrors.MessageNotFound("id").Code,
+            EmailErrors.ProviderUnavailable.Code,
+            EmailErrors.RateLimitExceeded.Code,
+            EmailErrors.InvalidConfirmationToken.Code,
+            EmailErrors.TenantContextRequired.Code,
+        };
+
+        // Assert
+        codes.Should().OnlyContain(c => c.StartsWith("Email.", StringComparison.Ordinal));
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Email.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Email.Tests/GlobalUsings.cs
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Xunit;
+global using FluentAssertions;
+global using Compendium.Abstractions.Email;
+global using Compendium.Abstractions.Email.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Email.Tests/Models/EmailAttachmentTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Email.Tests/Models/EmailAttachmentTests.cs
@@ -1,0 +1,107 @@
+// -----------------------------------------------------------------------
+// <copyright file="EmailAttachmentTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Email.Tests.Models;
+
+public class EmailAttachmentTests
+{
+    [Fact]
+    public void EmailAttachment_WithRequiredProperties_CreatesInstanceWithDefaults()
+    {
+        // Arrange
+        var content = new byte[] { 1, 2, 3, 4 };
+
+        // Act
+        var attachment = new EmailAttachment
+        {
+            Filename = "report.pdf",
+            Content = content,
+            ContentType = "application/pdf",
+        };
+
+        // Assert
+        attachment.Filename.Should().Be("report.pdf");
+        attachment.Content.Should().BeSameAs(content);
+        attachment.ContentType.Should().Be("application/pdf");
+        attachment.IsInline.Should().BeFalse();
+        attachment.ContentId.Should().BeNull();
+    }
+
+    [Fact]
+    public void EmailAttachment_AsInline_IncludesContentId()
+    {
+        // Arrange / Act
+        var attachment = new EmailAttachment
+        {
+            Filename = "logo.png",
+            Content = new byte[] { 0xFF },
+            ContentType = "image/png",
+            IsInline = true,
+            ContentId = "logo@example",
+        };
+
+        // Assert
+        attachment.IsInline.Should().BeTrue();
+        attachment.ContentId.Should().Be("logo@example");
+    }
+
+    [Fact]
+    public void EmailAttachment_With_ReturnsCloneWithUpdatedField()
+    {
+        // Arrange
+        var original = new EmailAttachment
+        {
+            Filename = "old.txt",
+            Content = new byte[] { 1 },
+            ContentType = "text/plain",
+        };
+
+        // Act
+        var updated = original with { Filename = "new.txt" };
+
+        // Assert
+        updated.Filename.Should().Be("new.txt");
+        original.Filename.Should().Be("old.txt");
+        updated.Content.Should().BeSameAs(original.Content);
+        updated.ContentType.Should().Be(original.ContentType);
+    }
+
+    [Theory]
+    [InlineData("a.txt", "text/plain")]
+    [InlineData("img.png", "image/png")]
+    [InlineData("doc.pdf", "application/pdf")]
+    [InlineData("data.bin", "application/octet-stream")]
+    public void EmailAttachment_AcceptsCommonMediaTypes(string filename, string contentType)
+    {
+        // Arrange / Act
+        var attachment = new EmailAttachment
+        {
+            Filename = filename,
+            Content = Array.Empty<byte>(),
+            ContentType = contentType,
+        };
+
+        // Assert
+        attachment.Filename.Should().Be(filename);
+        attachment.ContentType.Should().Be(contentType);
+    }
+
+    [Fact]
+    public void EmailAttachment_EmptyContent_IsAllowed()
+    {
+        // Act
+        var attachment = new EmailAttachment
+        {
+            Filename = "empty.dat",
+            Content = Array.Empty<byte>(),
+            ContentType = "application/octet-stream",
+        };
+
+        // Assert
+        attachment.Content.Should().BeEmpty();
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Email.Tests/Models/EmailMessageTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Email.Tests/Models/EmailMessageTests.cs
@@ -1,0 +1,148 @@
+// -----------------------------------------------------------------------
+// <copyright file="EmailMessageTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Email.Tests.Models;
+
+public class EmailMessageTests
+{
+    [Fact]
+    public void EmailMessage_WithRequiredProperties_CreatesInstanceWithDefaults()
+    {
+        // Arrange / Act
+        var message = new EmailMessage
+        {
+            To = new[] { "alice@example.com" },
+            Subject = "Hello",
+        };
+
+        // Assert
+        message.To.Should().ContainSingle().Which.Should().Be("alice@example.com");
+        message.Subject.Should().Be("Hello");
+        message.Cc.Should().BeNull();
+        message.Bcc.Should().BeNull();
+        message.From.Should().BeNull();
+        message.ReplyTo.Should().BeNull();
+        message.TextBody.Should().BeNull();
+        message.HtmlBody.Should().BeNull();
+        message.Attachments.Should().BeNull();
+        message.Headers.Should().BeNull();
+        message.Metadata.Should().BeNull();
+        message.Priority.Should().Be(EmailPriority.Normal);
+    }
+
+    [Fact]
+    public void EmailMessage_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var attachment = new EmailAttachment
+        {
+            Filename = "spec.pdf",
+            Content = new byte[] { 1, 2, 3 },
+            ContentType = "application/pdf",
+        };
+
+        // Act
+        var message = new EmailMessage
+        {
+            To = new[] { "alice@example.com", "bob@example.com" },
+            Cc = new[] { "carol@example.com" },
+            Bcc = new[] { "dave@example.com" },
+            From = "sender@example.com",
+            ReplyTo = "noreply@example.com",
+            Subject = "Project update",
+            TextBody = "Plain content",
+            HtmlBody = "<p>HTML content</p>",
+            Attachments = new[] { attachment },
+            Headers = new Dictionary<string, string> { ["X-Tag"] = "newsletter" },
+            Priority = EmailPriority.High,
+            Metadata = new Dictionary<string, object> { ["campaign"] = "spring2026" },
+        };
+
+        // Assert
+        message.To.Should().HaveCount(2);
+        message.Cc.Should().ContainSingle().Which.Should().Be("carol@example.com");
+        message.Bcc.Should().ContainSingle().Which.Should().Be("dave@example.com");
+        message.From.Should().Be("sender@example.com");
+        message.ReplyTo.Should().Be("noreply@example.com");
+        message.Subject.Should().Be("Project update");
+        message.TextBody.Should().Be("Plain content");
+        message.HtmlBody.Should().Be("<p>HTML content</p>");
+        message.Attachments.Should().ContainSingle().Which.Should().BeSameAs(attachment);
+        message.Headers.Should().ContainKey("X-Tag");
+        message.Priority.Should().Be(EmailPriority.High);
+        message.Metadata.Should().ContainKey("campaign");
+    }
+
+    [Fact]
+    public void EmailMessage_RecordEquality_IsValueBased()
+    {
+        // Arrange
+        var first = new EmailMessage { To = new[] { "a@b.co" }, Subject = "S" };
+        var second = new EmailMessage { To = new[] { "a@b.co" }, Subject = "S" };
+
+        // Act / Assert — record equality is reference-based for IReadOnlyList collections,
+        // but the same instance must equal itself and be reference-equal to a `with`-clone of itself.
+        first.Should().Be(first);
+        first.GetHashCode().Should().Be(first.GetHashCode());
+        first.Should().NotBeSameAs(second);
+    }
+
+    [Fact]
+    public void EmailMessage_With_ReturnsCloneWithUpdatedField()
+    {
+        // Arrange
+        var original = new EmailMessage { To = new[] { "a@b.co" }, Subject = "Original" };
+
+        // Act
+        var updated = original with { Subject = "Updated" };
+
+        // Assert
+        updated.Subject.Should().Be("Updated");
+        original.Subject.Should().Be("Original");
+        updated.To.Should().BeSameAs(original.To);
+    }
+
+    [Theory]
+    [InlineData(EmailPriority.Low)]
+    [InlineData(EmailPriority.Normal)]
+    [InlineData(EmailPriority.High)]
+    public void EmailMessage_PriorityOption_IsAcceptedAsInitValue(EmailPriority priority)
+    {
+        // Arrange / Act
+        var message = new EmailMessage
+        {
+            To = new[] { "a@b.co" },
+            Subject = "S",
+            Priority = priority,
+        };
+
+        // Assert
+        message.Priority.Should().Be(priority);
+    }
+}
+
+public class EmailPriorityTests
+{
+    [Fact]
+    public void EmailPriority_HasExpectedNumericValues()
+    {
+        // Assert
+        ((int)EmailPriority.Low).Should().Be(0);
+        ((int)EmailPriority.Normal).Should().Be(1);
+        ((int)EmailPriority.High).Should().Be(2);
+    }
+
+    [Fact]
+    public void EmailPriority_ContainsExactlyThreeValues()
+    {
+        // Act
+        var values = Enum.GetValues<EmailPriority>();
+
+        // Assert
+        values.Should().BeEquivalentTo(new[] { EmailPriority.Low, EmailPriority.Normal, EmailPriority.High });
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Email.Tests/Models/EmailSendResultTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Email.Tests/Models/EmailSendResultTests.cs
@@ -1,0 +1,272 @@
+// -----------------------------------------------------------------------
+// <copyright file="EmailSendResultTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Email.Tests.Models;
+
+public class EmailSendResultTests
+{
+    [Fact]
+    public void EmailSendResult_WithRequiredProperties_CreatesInstanceWithDefaults()
+    {
+        // Arrange / Act
+        var result = new EmailSendResult
+        {
+            MessageId = "msg-123",
+            Status = EmailStatus.Queued,
+        };
+
+        // Assert
+        result.MessageId.Should().Be("msg-123");
+        result.Status.Should().Be(EmailStatus.Queued);
+        result.SentAt.Should().Be(default);
+        result.ProviderData.Should().BeNull();
+    }
+
+    [Fact]
+    public void EmailSendResult_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var sentAt = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+        var providerData = new Dictionary<string, object>
+        {
+            ["provider"] = "listmonk",
+            ["responseCode"] = 202,
+        };
+
+        // Act
+        var result = new EmailSendResult
+        {
+            MessageId = "msg-7",
+            Status = EmailStatus.Sent,
+            SentAt = sentAt,
+            ProviderData = providerData,
+        };
+
+        // Assert
+        result.MessageId.Should().Be("msg-7");
+        result.Status.Should().Be(EmailStatus.Sent);
+        result.SentAt.Should().Be(sentAt);
+        result.ProviderData.Should().BeSameAs(providerData);
+    }
+
+    [Theory]
+    [InlineData(EmailStatus.Queued)]
+    [InlineData(EmailStatus.Sending)]
+    [InlineData(EmailStatus.Sent)]
+    [InlineData(EmailStatus.Delivered)]
+    [InlineData(EmailStatus.Opened)]
+    [InlineData(EmailStatus.Clicked)]
+    [InlineData(EmailStatus.Bounced)]
+    [InlineData(EmailStatus.SpamComplaint)]
+    [InlineData(EmailStatus.Failed)]
+    public void EmailSendResult_AllStatuses_AreAcceptedAsInitValues(EmailStatus status)
+    {
+        // Arrange / Act
+        var result = new EmailSendResult
+        {
+            MessageId = "id",
+            Status = status,
+        };
+
+        // Assert
+        result.Status.Should().Be(status);
+    }
+
+    [Fact]
+    public void EmailSendResult_With_ReturnsCloneWithUpdatedField()
+    {
+        // Arrange
+        var original = new EmailSendResult
+        {
+            MessageId = "msg-1",
+            Status = EmailStatus.Queued,
+        };
+
+        // Act
+        var updated = original with { Status = EmailStatus.Sent };
+
+        // Assert
+        updated.Status.Should().Be(EmailStatus.Sent);
+        original.Status.Should().Be(EmailStatus.Queued);
+        updated.MessageId.Should().Be("msg-1");
+    }
+}
+
+public class BatchEmailResultTests
+{
+    [Fact]
+    public void BatchEmailResult_FailedCount_DerivesFromTotalAndSuccess()
+    {
+        // Arrange
+        var items = new[]
+        {
+            new BatchEmailItemResult { To = "a@b.co", Success = true, MessageId = "m-1" },
+            new BatchEmailItemResult { To = "c@d.co", Success = false, ErrorMessage = "bounced" },
+            new BatchEmailItemResult { To = "e@f.co", Success = false, ErrorMessage = "blocked" },
+        };
+
+        // Act
+        var batch = new BatchEmailResult
+        {
+            TotalCount = 3,
+            SuccessCount = 1,
+            Results = items,
+        };
+
+        // Assert
+        batch.TotalCount.Should().Be(3);
+        batch.SuccessCount.Should().Be(1);
+        batch.FailedCount.Should().Be(2);
+        batch.Results.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void BatchEmailResult_AllSuccess_HasZeroFailed()
+    {
+        // Arrange / Act
+        var batch = new BatchEmailResult
+        {
+            TotalCount = 5,
+            SuccessCount = 5,
+            Results = Array.Empty<BatchEmailItemResult>(),
+        };
+
+        // Assert
+        batch.FailedCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void BatchEmailResult_AllFailed_FailedCountEqualsTotal()
+    {
+        // Arrange / Act
+        var batch = new BatchEmailResult
+        {
+            TotalCount = 4,
+            SuccessCount = 0,
+            Results = Array.Empty<BatchEmailItemResult>(),
+        };
+
+        // Assert
+        batch.FailedCount.Should().Be(4);
+    }
+
+    [Fact]
+    public void BatchEmailResult_EmptyBatch_HasZeroFailed()
+    {
+        // Arrange / Act
+        var batch = new BatchEmailResult
+        {
+            TotalCount = 0,
+            SuccessCount = 0,
+            Results = Array.Empty<BatchEmailItemResult>(),
+        };
+
+        // Assert
+        batch.FailedCount.Should().Be(0);
+        batch.Results.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(10, 7, 3)]
+    [InlineData(100, 100, 0)]
+    [InlineData(50, 0, 50)]
+    [InlineData(1, 0, 1)]
+    public void BatchEmailResult_FailedCount_IsTotalMinusSuccess(int total, int success, int expectedFailed)
+    {
+        // Arrange / Act
+        var batch = new BatchEmailResult
+        {
+            TotalCount = total,
+            SuccessCount = success,
+            Results = Array.Empty<BatchEmailItemResult>(),
+        };
+
+        // Assert
+        batch.FailedCount.Should().Be(expectedFailed);
+    }
+}
+
+public class BatchEmailItemResultTests
+{
+    [Fact]
+    public void BatchEmailItemResult_Success_HasMessageIdAndNoError()
+    {
+        // Arrange / Act
+        var item = new BatchEmailItemResult
+        {
+            To = "alice@example.com",
+            Success = true,
+            MessageId = "m-42",
+        };
+
+        // Assert
+        item.To.Should().Be("alice@example.com");
+        item.Success.Should().BeTrue();
+        item.MessageId.Should().Be("m-42");
+        item.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void BatchEmailItemResult_Failure_HasErrorMessageAndNoMessageId()
+    {
+        // Arrange / Act
+        var item = new BatchEmailItemResult
+        {
+            To = "bounce@example.com",
+            Success = false,
+            ErrorMessage = "Hard bounce",
+        };
+
+        // Assert
+        item.Success.Should().BeFalse();
+        item.MessageId.Should().BeNull();
+        item.ErrorMessage.Should().Be("Hard bounce");
+    }
+
+    [Fact]
+    public void BatchEmailItemResult_With_ReturnsCloneWithUpdatedField()
+    {
+        // Arrange
+        var original = new BatchEmailItemResult { To = "a@b.co", Success = true, MessageId = "m-1" };
+
+        // Act
+        var updated = original with { Success = false, ErrorMessage = "rate limited" };
+
+        // Assert
+        updated.Success.Should().BeFalse();
+        updated.ErrorMessage.Should().Be("rate limited");
+        updated.To.Should().Be(original.To);
+    }
+}
+
+public class EmailStatusTests
+{
+    [Fact]
+    public void EmailStatus_HasExpectedNumericValues()
+    {
+        // Assert
+        ((int)EmailStatus.Queued).Should().Be(0);
+        ((int)EmailStatus.Sending).Should().Be(1);
+        ((int)EmailStatus.Sent).Should().Be(2);
+        ((int)EmailStatus.Delivered).Should().Be(3);
+        ((int)EmailStatus.Opened).Should().Be(4);
+        ((int)EmailStatus.Clicked).Should().Be(5);
+        ((int)EmailStatus.Bounced).Should().Be(6);
+        ((int)EmailStatus.SpamComplaint).Should().Be(7);
+        ((int)EmailStatus.Failed).Should().Be(8);
+    }
+
+    [Fact]
+    public void EmailStatus_DefinesAllNineStates()
+    {
+        // Act
+        var values = Enum.GetValues<EmailStatus>();
+
+        // Assert
+        values.Should().HaveCount(9);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Email.Tests/Models/MailingListTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Email.Tests/Models/MailingListTests.cs
@@ -1,0 +1,131 @@
+// -----------------------------------------------------------------------
+// <copyright file="MailingListTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Email.Tests.Models;
+
+public class MailingListTests
+{
+    [Fact]
+    public void MailingList_WithRequiredProperties_CreatesInstanceWithDefaults()
+    {
+        // Arrange / Act
+        var list = new MailingList
+        {
+            Id = "list-1",
+            Slug = "general-news",
+            Name = "General News",
+        };
+
+        // Assert
+        list.Id.Should().Be("list-1");
+        list.Slug.Should().Be("general-news");
+        list.Name.Should().Be("General News");
+        list.Description.Should().BeNull();
+        list.IsPublic.Should().BeTrue();
+        list.IsSingleOptIn.Should().BeFalse();
+        list.SubscriberCount.Should().Be(0);
+        list.CreatedAt.Should().Be(default);
+        list.UpdatedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void MailingList_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var updatedAt = new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero);
+
+        // Act
+        var list = new MailingList
+        {
+            Id = "list-2",
+            Slug = "exclusive",
+            Name = "Exclusive Updates",
+            Description = "Insider news",
+            IsPublic = false,
+            IsSingleOptIn = true,
+            SubscriberCount = 1234,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+        };
+
+        // Assert
+        list.Id.Should().Be("list-2");
+        list.Slug.Should().Be("exclusive");
+        list.Name.Should().Be("Exclusive Updates");
+        list.Description.Should().Be("Insider news");
+        list.IsPublic.Should().BeFalse();
+        list.IsSingleOptIn.Should().BeTrue();
+        list.SubscriberCount.Should().Be(1234);
+        list.CreatedAt.Should().Be(createdAt);
+        list.UpdatedAt.Should().Be(updatedAt);
+    }
+
+    [Fact]
+    public void MailingList_RecordEquality_IsValueBasedForScalarProperties()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var first = new MailingList
+        {
+            Id = "list-1",
+            Slug = "news",
+            Name = "News",
+            CreatedAt = createdAt,
+        };
+
+        var second = new MailingList
+        {
+            Id = "list-1",
+            Slug = "news",
+            Name = "News",
+            CreatedAt = createdAt,
+        };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void MailingList_With_ReturnsCloneWithUpdatedField()
+    {
+        // Arrange
+        var original = new MailingList { Id = "list-1", Slug = "news", Name = "News" };
+
+        // Act
+        var updated = original with { SubscriberCount = 100 };
+
+        // Assert
+        updated.SubscriberCount.Should().Be(100);
+        original.SubscriberCount.Should().Be(0);
+        updated.Id.Should().Be(original.Id);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    public void MailingList_PublicAndOptInFlags_AreIndependent(bool isPublic, bool isSingleOptIn)
+    {
+        // Arrange / Act
+        var list = new MailingList
+        {
+            Id = "id",
+            Slug = "slug",
+            Name = "name",
+            IsPublic = isPublic,
+            IsSingleOptIn = isSingleOptIn,
+        };
+
+        // Assert
+        list.IsPublic.Should().Be(isPublic);
+        list.IsSingleOptIn.Should().Be(isSingleOptIn);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Email.Tests/Models/SubscriberTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Email.Tests/Models/SubscriberTests.cs
@@ -1,0 +1,206 @@
+// -----------------------------------------------------------------------
+// <copyright file="SubscriberTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Email.Tests.Models;
+
+public class SubscriberTests
+{
+    [Fact]
+    public void Subscriber_WithRequiredProperties_CreatesInstanceWithDefaults()
+    {
+        // Arrange / Act
+        var subscriber = new Subscriber
+        {
+            Id = "sub-1",
+            Email = "alice@example.com",
+            Status = SubscriptionStatus.Pending,
+        };
+
+        // Assert
+        subscriber.Id.Should().Be("sub-1");
+        subscriber.Email.Should().Be("alice@example.com");
+        subscriber.Status.Should().Be(SubscriptionStatus.Pending);
+        subscriber.Name.Should().BeNull();
+        subscriber.ListIds.Should().BeNull();
+        subscriber.Attributes.Should().BeNull();
+        subscriber.CreatedAt.Should().Be(default);
+        subscriber.UpdatedAt.Should().BeNull();
+        subscriber.ConfirmedAt.Should().BeNull();
+        subscriber.UnsubscribedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Subscriber_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var updatedAt = new DateTimeOffset(2026, 1, 2, 0, 0, 0, TimeSpan.Zero);
+        var confirmedAt = new DateTimeOffset(2026, 1, 3, 0, 0, 0, TimeSpan.Zero);
+        var unsubscribedAt = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var attributes = new Dictionary<string, object> { ["plan"] = "pro", ["age"] = 30 };
+
+        // Act
+        var subscriber = new Subscriber
+        {
+            Id = "sub-2",
+            Email = "bob@example.com",
+            Name = "Bob",
+            Status = SubscriptionStatus.Confirmed,
+            ListIds = new[] { "list-1", "list-2" },
+            Attributes = attributes,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+            ConfirmedAt = confirmedAt,
+            UnsubscribedAt = unsubscribedAt,
+        };
+
+        // Assert
+        subscriber.Id.Should().Be("sub-2");
+        subscriber.Email.Should().Be("bob@example.com");
+        subscriber.Name.Should().Be("Bob");
+        subscriber.Status.Should().Be(SubscriptionStatus.Confirmed);
+        subscriber.ListIds.Should().HaveCount(2);
+        subscriber.Attributes.Should().BeSameAs(attributes);
+        subscriber.CreatedAt.Should().Be(createdAt);
+        subscriber.UpdatedAt.Should().Be(updatedAt);
+        subscriber.ConfirmedAt.Should().Be(confirmedAt);
+        subscriber.UnsubscribedAt.Should().Be(unsubscribedAt);
+    }
+
+    [Theory]
+    [InlineData(SubscriptionStatus.Pending)]
+    [InlineData(SubscriptionStatus.Confirmed)]
+    [InlineData(SubscriptionStatus.Unsubscribed)]
+    [InlineData(SubscriptionStatus.Blocked)]
+    [InlineData(SubscriptionStatus.Bounced)]
+    public void Subscriber_AllStatuses_AreAcceptedAsInitValues(SubscriptionStatus status)
+    {
+        // Arrange / Act
+        var subscriber = new Subscriber
+        {
+            Id = "id",
+            Email = "x@y.co",
+            Status = status,
+        };
+
+        // Assert
+        subscriber.Status.Should().Be(status);
+    }
+
+    [Fact]
+    public void Subscriber_With_ReturnsCloneWithUpdatedField()
+    {
+        // Arrange
+        var original = new Subscriber
+        {
+            Id = "sub-1",
+            Email = "alice@example.com",
+            Status = SubscriptionStatus.Pending,
+        };
+
+        // Act
+        var updated = original with { Status = SubscriptionStatus.Confirmed };
+
+        // Assert
+        updated.Status.Should().Be(SubscriptionStatus.Confirmed);
+        original.Status.Should().Be(SubscriptionStatus.Pending);
+        updated.Email.Should().Be(original.Email);
+    }
+}
+
+public class SubscribeRequestTests
+{
+    [Fact]
+    public void SubscribeRequest_WithRequiredProperties_CreatesInstanceWithDefaults()
+    {
+        // Arrange / Act
+        var request = new SubscribeRequest { Email = "alice@example.com" };
+
+        // Assert
+        request.Email.Should().Be("alice@example.com");
+        request.Name.Should().BeNull();
+        request.ListIds.Should().BeNull();
+        request.Attributes.Should().BeNull();
+        request.RequireConfirmation.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SubscribeRequest_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var attributes = new Dictionary<string, object> { ["source"] = "homepage" };
+
+        // Act
+        var request = new SubscribeRequest
+        {
+            Email = "bob@example.com",
+            Name = "Bob",
+            ListIds = new[] { "list-1" },
+            Attributes = attributes,
+            RequireConfirmation = false,
+        };
+
+        // Assert
+        request.Email.Should().Be("bob@example.com");
+        request.Name.Should().Be("Bob");
+        request.ListIds.Should().ContainSingle().Which.Should().Be("list-1");
+        request.Attributes.Should().BeSameAs(attributes);
+        request.RequireConfirmation.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SubscribeRequest_RecordEquality_IsValueBasedForScalarFields()
+    {
+        // Arrange
+        var first = new SubscribeRequest { Email = "alice@example.com", Name = "Alice" };
+        var second = new SubscribeRequest { Email = "alice@example.com", Name = "Alice" };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SubscribeRequest_RequireConfirmation_AcceptsBothValues(bool requireConfirmation)
+    {
+        // Arrange / Act
+        var request = new SubscribeRequest
+        {
+            Email = "x@y.co",
+            RequireConfirmation = requireConfirmation,
+        };
+
+        // Assert
+        request.RequireConfirmation.Should().Be(requireConfirmation);
+    }
+}
+
+public class SubscriptionStatusTests
+{
+    [Fact]
+    public void SubscriptionStatus_HasExpectedNumericValues()
+    {
+        // Assert
+        ((int)SubscriptionStatus.Pending).Should().Be(0);
+        ((int)SubscriptionStatus.Confirmed).Should().Be(1);
+        ((int)SubscriptionStatus.Unsubscribed).Should().Be(2);
+        ((int)SubscriptionStatus.Blocked).Should().Be(3);
+        ((int)SubscriptionStatus.Bounced).Should().Be(4);
+    }
+
+    [Fact]
+    public void SubscriptionStatus_DefinesAllFiveStates()
+    {
+        // Act
+        var values = Enum.GetValues<SubscriptionStatus>();
+
+        // Assert
+        values.Should().HaveCount(5);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Email.Tests/Models/TemplatedEmailMessageTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Email.Tests/Models/TemplatedEmailMessageTests.cs
@@ -1,0 +1,116 @@
+// -----------------------------------------------------------------------
+// <copyright file="TemplatedEmailMessageTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Email.Tests.Models;
+
+public class TemplatedEmailMessageTests
+{
+    [Fact]
+    public void TemplatedEmailMessage_WithRequiredProperties_CreatesInstanceWithDefaults()
+    {
+        // Arrange / Act
+        var message = new TemplatedEmailMessage
+        {
+            To = new[] { "alice@example.com" },
+            TemplateId = "welcome",
+        };
+
+        // Assert
+        message.To.Should().ContainSingle().Which.Should().Be("alice@example.com");
+        message.TemplateId.Should().Be("welcome");
+        message.Cc.Should().BeNull();
+        message.Bcc.Should().BeNull();
+        message.From.Should().BeNull();
+        message.ReplyTo.Should().BeNull();
+        message.TemplateData.Should().BeNull();
+        message.Attachments.Should().BeNull();
+        message.Metadata.Should().BeNull();
+        message.Priority.Should().Be(EmailPriority.Normal);
+    }
+
+    [Fact]
+    public void TemplatedEmailMessage_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var attachment = new EmailAttachment
+        {
+            Filename = "invoice.pdf",
+            Content = new byte[] { 4, 5, 6 },
+            ContentType = "application/pdf",
+        };
+
+        var templateData = new Dictionary<string, object>
+        {
+            ["firstName"] = "Alice",
+            ["amount"] = 42.0m,
+        };
+
+        // Act
+        var message = new TemplatedEmailMessage
+        {
+            To = new[] { "alice@example.com" },
+            Cc = new[] { "carol@example.com" },
+            Bcc = new[] { "dave@example.com" },
+            From = "sender@example.com",
+            ReplyTo = "noreply@example.com",
+            TemplateId = "invoice-2026",
+            TemplateData = templateData,
+            Attachments = new[] { attachment },
+            Priority = EmailPriority.High,
+            Metadata = new Dictionary<string, object> { ["batch"] = "monthly" },
+        };
+
+        // Assert
+        message.To.Should().ContainSingle();
+        message.Cc.Should().ContainSingle().Which.Should().Be("carol@example.com");
+        message.Bcc.Should().ContainSingle().Which.Should().Be("dave@example.com");
+        message.From.Should().Be("sender@example.com");
+        message.ReplyTo.Should().Be("noreply@example.com");
+        message.TemplateId.Should().Be("invoice-2026");
+        message.TemplateData.Should().BeSameAs(templateData);
+        message.Attachments.Should().ContainSingle().Which.Should().BeSameAs(attachment);
+        message.Priority.Should().Be(EmailPriority.High);
+        message.Metadata.Should().ContainKey("batch");
+    }
+
+    [Fact]
+    public void TemplatedEmailMessage_With_ReturnsCloneWithUpdatedField()
+    {
+        // Arrange
+        var original = new TemplatedEmailMessage
+        {
+            To = new[] { "a@b.co" },
+            TemplateId = "welcome",
+        };
+
+        // Act
+        var updated = original with { TemplateId = "goodbye" };
+
+        // Assert
+        updated.TemplateId.Should().Be("goodbye");
+        original.TemplateId.Should().Be("welcome");
+        updated.To.Should().BeSameAs(original.To);
+    }
+
+    [Theory]
+    [InlineData(EmailPriority.Low)]
+    [InlineData(EmailPriority.Normal)]
+    [InlineData(EmailPriority.High)]
+    public void TemplatedEmailMessage_PriorityOption_IsAcceptedAsInitValue(EmailPriority priority)
+    {
+        // Arrange / Act
+        var message = new TemplatedEmailMessage
+        {
+            To = new[] { "a@b.co" },
+            TemplateId = "t",
+            Priority = priority,
+        };
+
+        // Assert
+        message.Priority.Should().Be(priority);
+    }
+}


### PR DESCRIPTION
## Summary
Brings `Compendium.Abstractions.Email` from 0 % → 100 % line coverage. Part of the testing campaign (VK POM-468).

## Coverage report — Compendium.Abstractions.Email
- Tests added: 93
- Test files added:
  - `tests/Unit/Compendium.Abstractions.Email.Tests/EmailErrorsTests.cs`
  - `tests/Unit/Compendium.Abstractions.Email.Tests/Models/EmailMessageTests.cs`
  - `tests/Unit/Compendium.Abstractions.Email.Tests/Models/TemplatedEmailMessageTests.cs`
  - `tests/Unit/Compendium.Abstractions.Email.Tests/Models/EmailAttachmentTests.cs`
  - `tests/Unit/Compendium.Abstractions.Email.Tests/Models/EmailSendResultTests.cs` (covers `EmailSendResult`, `BatchEmailResult`, `BatchEmailItemResult`, `EmailStatus`)
  - `tests/Unit/Compendium.Abstractions.Email.Tests/Models/MailingListTests.cs`
  - `tests/Unit/Compendium.Abstractions.Email.Tests/Models/SubscriberTests.cs` (covers `Subscriber`, `SubscribeRequest`, `SubscriptionStatus`)
- Line coverage: 0 % → 100 % (10/10 classes at 100 %)
- Branch coverage: n/a — no branches in target assembly (all pure value-objects + factory methods)
- Bugs surfaced: 0

## Test plan
- [x] `dotnet build Compendium.sln -c Release` green
- [x] `dotnet test tests/Unit/Compendium.Abstractions.Email.Tests -c Release` green (93/93, runs twice with same result)
- [x] No prod code modified, no version bumps
- [x] No `Moq`, no `Assert.*`, no `Thread.Sleep`
- [ ] CI green