### PR TITLE
test(adapters/lemonsqueezy): top up coverage to 90%

### DIFF
--- a/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Compendium.Adapters.LemonSqueezy.Tests.csproj
+++ b/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Compendium.Adapters.LemonSqueezy.Tests.csproj
@@ -26,11 +26,13 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="RichardSzalay.MockHttp" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Helpers/LemonSqueezyTestHelpers.cs
+++ b/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Helpers/LemonSqueezyTestHelpers.cs
@@ -1,0 +1,160 @@
+// -----------------------------------------------------------------------
+// <copyright file="LemonSqueezyTestHelpers.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using Compendium.Abstractions.Billing;
+using Compendium.Adapters.LemonSqueezy.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Compendium.Adapters.LemonSqueezy.Tests.Helpers;
+
+/// <summary>
+/// Reflection helpers for instantiating internal types of the LemonSqueezy adapter
+/// (the adapter exposes only interfaces; concrete implementations are <c>internal sealed</c>).
+/// </summary>
+internal static class LemonSqueezyTestHelpers
+{
+    private static readonly Assembly AdapterAssembly = typeof(LemonSqueezyOptions).Assembly;
+
+    private static readonly Type HttpClientType = AdapterAssembly.GetType(
+        "Compendium.Adapters.LemonSqueezy.Http.LemonSqueezyHttpClient",
+        throwOnError: true)!;
+
+    private static readonly Type BillingServiceType = AdapterAssembly.GetType(
+        "Compendium.Adapters.LemonSqueezy.Services.LemonSqueezyBillingService",
+        throwOnError: true)!;
+
+    private static readonly Type SubscriptionServiceType = AdapterAssembly.GetType(
+        "Compendium.Adapters.LemonSqueezy.Services.LemonSqueezySubscriptionService",
+        throwOnError: true)!;
+
+    private static readonly Type LicenseServiceType = AdapterAssembly.GetType(
+        "Compendium.Adapters.LemonSqueezy.Services.LemonSqueezyLicenseService",
+        throwOnError: true)!;
+
+    private static readonly Type WebhookHandlerType = AdapterAssembly.GetType(
+        "Compendium.Adapters.LemonSqueezy.Webhooks.LemonSqueezyWebhookHandler",
+        throwOnError: true)!;
+
+    /// <summary>
+    /// Creates the internal <c>LemonSqueezyHttpClient</c> from a <see cref="HttpMessageHandler"/>
+    /// (typically a <see cref="RichardSzalay.MockHttp.MockHttpMessageHandler"/>).
+    /// </summary>
+    public static object CreateHttpClient(
+        HttpMessageHandler handler,
+        LemonSqueezyOptions options)
+    {
+        var http = new HttpClient(handler)
+        {
+            BaseAddress = new Uri(options.BaseUrl.TrimEnd('/') + "/")
+        };
+
+        var optionsWrapper = Options.Create(options);
+        var logger = CreateNullLogger(HttpClientType);
+
+        return Activator.CreateInstance(
+            HttpClientType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new object[] { http, optionsWrapper, logger },
+            culture: null)!;
+    }
+
+    /// <summary>
+    /// Creates the <see cref="IBillingService"/> implementation backed by a mock HTTP handler.
+    /// </summary>
+    public static IBillingService CreateBillingService(
+        HttpMessageHandler handler,
+        LemonSqueezyOptions options)
+    {
+        var httpClient = CreateHttpClient(handler, options);
+        var optionsWrapper = Options.Create(options);
+        var logger = CreateNullLogger(BillingServiceType);
+
+        return (IBillingService)Activator.CreateInstance(
+            BillingServiceType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new[] { httpClient, optionsWrapper, logger },
+            culture: null)!;
+    }
+
+    /// <summary>
+    /// Creates the <see cref="ISubscriptionService"/> implementation backed by a mock HTTP handler.
+    /// </summary>
+    public static ISubscriptionService CreateSubscriptionService(
+        HttpMessageHandler handler,
+        LemonSqueezyOptions options)
+    {
+        var httpClient = CreateHttpClient(handler, options);
+        var optionsWrapper = Options.Create(options);
+        var logger = CreateNullLogger(SubscriptionServiceType);
+
+        return (ISubscriptionService)Activator.CreateInstance(
+            SubscriptionServiceType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new[] { httpClient, optionsWrapper, logger },
+            culture: null)!;
+    }
+
+    /// <summary>
+    /// Creates the <see cref="ILicenseService"/> implementation backed by a mock HTTP handler.
+    /// </summary>
+    public static ILicenseService CreateLicenseService(
+        HttpMessageHandler handler,
+        LemonSqueezyOptions options)
+    {
+        var httpClient = CreateHttpClient(handler, options);
+        var optionsWrapper = Options.Create(options);
+        var logger = CreateNullLogger(LicenseServiceType);
+
+        return (ILicenseService)Activator.CreateInstance(
+            LicenseServiceType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new[] { httpClient, optionsWrapper, logger },
+            culture: null)!;
+    }
+
+    /// <summary>
+    /// Creates the <see cref="IPaymentWebhookHandler"/> implementation. The webhook handler
+    /// does not perform HTTP I/O and only requires options + logger.
+    /// </summary>
+    public static IPaymentWebhookHandler CreateWebhookHandler(LemonSqueezyOptions options)
+    {
+        var optionsWrapper = Options.Create(options);
+        var logger = CreateNullLogger(WebhookHandlerType);
+
+        return (IPaymentWebhookHandler)Activator.CreateInstance(
+            WebhookHandlerType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new object[] { optionsWrapper, logger },
+            culture: null)!;
+    }
+
+    /// <summary>
+    /// Computes the lowercase hex HMAC-SHA256 LemonSqueezy webhook signature for the given payload.
+    /// </summary>
+    public static string ComputeWebhookSignature(string secret, string payload)
+    {
+        using var hmac = new System.Security.Cryptography.HMACSHA256(
+            System.Text.Encoding.UTF8.GetBytes(secret));
+        var hash = hmac.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payload));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static object CreateNullLogger(Type forType)
+    {
+        var loggerType = typeof(NullLogger<>).MakeGenericType(forType);
+        return loggerType.GetField("Instance", BindingFlags.Public | BindingFlags.Static)!
+            .GetValue(null)!;
+    }
+}

--- a/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Http/LemonSqueezyApiModelsTests.cs
+++ b/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Http/LemonSqueezyApiModelsTests.cs
@@ -1,0 +1,395 @@
+// -----------------------------------------------------------------------
+// <copyright file="LemonSqueezyApiModelsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using Compendium.Adapters.LemonSqueezy.Configuration;
+using Compendium.Adapters.LemonSqueezy.Tests.Helpers;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+
+namespace Compendium.Adapters.LemonSqueezy.Tests.Http;
+
+/// <summary>
+/// Coverage of internal JSON:API DTO records used by the adapter. These are exercised by
+/// driving JSON deserialization through the real http client with payloads that populate
+/// every field; this gives the records' compiler-generated property accessors hits.
+/// </summary>
+public class LemonSqueezyApiModelsTests
+{
+    private const string BaseUrl = "https://api.lemonsqueezy.com/v1/";
+
+    private static (object client, MockHttpMessageHandler mock) CreateClient()
+    {
+        var mock = new MockHttpMessageHandler();
+        var client = LemonSqueezyTestHelpers.CreateHttpClient(mock,
+            new LemonSqueezyOptions { ApiKey = "k", StoreId = "s", BaseUrl = BaseUrl });
+        return (client, mock);
+    }
+
+    [Fact]
+    public async Task FullCustomerPayload_DeserializesAllAttributes()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var responseJson = """
+        {
+          "jsonapi": { "version": "1.0" },
+          "links": {
+            "self": "https://api/v1/customers/1",
+            "first": "https://api/v1/customers?p=1",
+            "last": "https://api/v1/customers?p=2",
+            "next": "https://api/v1/customers?p=2",
+            "prev": null
+          },
+          "meta": { "test_mode": true },
+          "data": {
+            "type": "customers",
+            "id": "cust-1",
+            "attributes": {
+              "store_id": 1,
+              "name": "Alice",
+              "email": "alice@example.com",
+              "status": "active",
+              "city": "Paris",
+              "region": "IDF",
+              "country": "FR",
+              "total_revenue_currency": 100,
+              "mrr": 1000,
+              "status_formatted": "Active",
+              "country_formatted": "France",
+              "total_revenue_currency_formatted": "$1.00",
+              "mrr_formatted": "$10.00",
+              "created_at": "2026-01-01T00:00:00Z",
+              "updated_at": "2026-02-01T00:00:00Z",
+              "test_mode": false
+            },
+            "relationships": {
+              "store": { "links": { "self": "/stores/1" } }
+            },
+            "links": { "self": "/customers/1" }
+          }
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "customers/cust-1")
+            .Respond("application/vnd.api+json", responseJson);
+
+        // Act
+        var task = (Task)sut.GetType()
+            .GetMethod("GetCustomerAsync", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(sut, new object?[] { "cust-1", CancellationToken.None })!;
+        await task;
+        var result = task.GetType().GetProperty("Result")!.GetValue(task)!;
+
+        // Assert
+        ((bool)result.GetType().GetProperty("IsSuccess")!.GetValue(result)!).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FullSubscriptionPayload_DeserializesAllAttributes()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var responseJson = """
+        {
+          "data": {
+            "type": "subscriptions",
+            "id": "sub-1",
+            "attributes": {
+              "store_id": 1,
+              "customer_id": 2,
+              "order_id": 3,
+              "order_item_id": 4,
+              "product_id": 5,
+              "variant_id": 6,
+              "product_name": "Pro",
+              "variant_name": "Monthly",
+              "user_name": "Alice",
+              "user_email": "alice@example.com",
+              "status": "active",
+              "status_formatted": "Active",
+              "card_brand": "visa",
+              "card_last_four": "4242",
+              "pause": { "mode": "void", "resumes_at": "2026-12-31T00:00:00Z" },
+              "cancelled": false,
+              "trial_ends_at": "2026-02-15T00:00:00Z",
+              "billing_anchor": 15,
+              "first_subscription_item": {
+                "id": 7,
+                "subscription_id": 1,
+                "price_id": 8,
+                "quantity": 2,
+                "is_usage_based": false,
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-02T00:00:00Z"
+              },
+              "urls": {
+                "update_payment_method": "https://example.com/payment",
+                "customer_portal": "https://example.com/portal"
+              },
+              "renews_at": "2026-12-01T00:00:00Z",
+              "ends_at": "2026-12-31T00:00:00Z",
+              "created_at": "2026-01-01T00:00:00Z",
+              "updated_at": "2026-02-01T00:00:00Z",
+              "test_mode": false
+            }
+          }
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/sub-1")
+            .Respond("application/vnd.api+json", responseJson);
+
+        // Act
+        var task = (Task)sut.GetType()
+            .GetMethod("GetSubscriptionAsync", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(sut, new object?[] { "sub-1", CancellationToken.None })!;
+        await task;
+        var result = task.GetType().GetProperty("Result")!.GetValue(task)!;
+
+        // Assert
+        ((bool)result.GetType().GetProperty("IsSuccess")!.GetValue(result)!).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FullCheckoutPayload_DeserializesAllNestedAttributes()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var responseJson = """
+        {
+          "data": {
+            "type": "checkouts",
+            "id": "ck-1",
+            "attributes": {
+              "store_id": 1,
+              "variant_id": 2,
+              "custom_price": 5000,
+              "product_options": {
+                "name": "Pro",
+                "description": "desc",
+                "media": ["m1.png", "m2.png"],
+                "redirect_url": "https://example.com/ok",
+                "receipt_button_text": "Done",
+                "receipt_link_url": "https://example.com",
+                "receipt_thank_you_note": "thanks",
+                "enabled_variants": [1, 2]
+              },
+              "checkout_options": {
+                "embed": true,
+                "media": true,
+                "logo": true,
+                "desc": true,
+                "discount": true,
+                "dark": false,
+                "subscription_preview": true,
+                "button_color": "#ff0000"
+              },
+              "checkout_data": {
+                "email": "e@example.com",
+                "name": "Alice",
+                "billing_address": { "country": "FR", "zip": "75000" },
+                "tax_number": "TAX-123",
+                "discount_code": "DISC",
+                "custom": { "tenant_id": "t-1" },
+                "variant_quantities": [ { "variant_id": 1, "quantity": 2 } ]
+              },
+              "preview": {
+                "currency": "USD",
+                "currency_rate": 1.0,
+                "subtotal": 1000,
+                "discount_total": 100,
+                "tax": 50,
+                "total": 950,
+                "subtotal_usd": 1000,
+                "discount_total_usd": 100,
+                "tax_usd": 50,
+                "total_usd": 950,
+                "subtotal_formatted": "$10.00",
+                "discount_total_formatted": "$1.00",
+                "tax_formatted": "$0.50",
+                "total_formatted": "$9.50"
+              },
+              "expires_at": "2026-02-01T00:00:00Z",
+              "created_at": "2026-01-01T00:00:00Z",
+              "updated_at": "2026-01-02T00:00:00Z",
+              "test_mode": false,
+              "url": "https://example.com/checkout"
+            }
+          }
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "checkouts/ck-1")
+            .Respond("application/vnd.api+json", responseJson);
+
+        // Act
+        var task = (Task)sut.GetType()
+            .GetMethod("GetCheckoutAsync", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(sut, new object?[] { "ck-1", CancellationToken.None })!;
+        await task;
+        var result = task.GetType().GetProperty("Result")!.GetValue(task)!;
+
+        // Assert
+        ((bool)result.GetType().GetProperty("IsSuccess")!.GetValue(result)!).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FullLicenseKeyPayload_DeserializesAllAttributes()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var responseJson = """
+        {
+          "data": {
+            "type": "license-keys",
+            "id": "lk-1",
+            "attributes": {
+              "store_id": 1,
+              "customer_id": 2,
+              "order_id": 3,
+              "order_item_id": 4,
+              "product_id": 5,
+              "user_name": "Alice",
+              "user_email": "alice@example.com",
+              "key": "AAA-BBB-CCC",
+              "key_short": "AAA",
+              "activation_limit": 5,
+              "instances_count": 1,
+              "disabled": false,
+              "status": "active",
+              "status_formatted": "Active",
+              "expires_at": "2026-12-31T00:00:00Z",
+              "created_at": "2026-01-01T00:00:00Z",
+              "updated_at": "2026-01-02T00:00:00Z",
+              "test_mode": false
+            }
+          }
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "license-keys/lk-1")
+            .Respond("application/vnd.api+json", responseJson);
+
+        // Act
+        var task = (Task)sut.GetType()
+            .GetMethod("GetLicenseKeyAsync", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(sut, new object?[] { "lk-1", CancellationToken.None })!;
+        await task;
+        var result = task.GetType().GetProperty("Result")!.GetValue(task)!;
+
+        // Assert
+        ((bool)result.GetType().GetProperty("IsSuccess")!.GetValue(result)!).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FullLicenseKeyInstancesPayload_DeserializesCollection()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var responseJson = """
+        {
+          "meta": { "page": { "currentPage": 1, "from": 1, "lastPage": 1, "perPage": 10, "to": 1, "total": 1 } },
+          "data": [
+            {
+              "type": "license-key-instances",
+              "id": "i-1",
+              "attributes": {
+                "license_key_id": 1,
+                "identifier": "id-1",
+                "name": "host-1",
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-02T00:00:00Z"
+              }
+            }
+          ]
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "license-key-instances*")
+            .Respond("application/vnd.api+json", responseJson);
+
+        // Act
+        var task = (Task)sut.GetType()
+            .GetMethod("ListLicenseKeyInstancesAsync", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(sut, new object?[] { "lk-1", CancellationToken.None })!;
+        await task;
+        var result = task.GetType().GetProperty("Result")!.GetValue(task)!;
+
+        // Assert
+        ((bool)result.GetType().GetProperty("IsSuccess")!.GetValue(result)!).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LicenseValidatePayload_DeserializesAllNestedFields()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var responseJson = """
+        {
+          "valid": true,
+          "license_key": {
+            "id": 1,
+            "status": "active",
+            "key": "K",
+            "activation_limit": 5,
+            "activation_usage": 1,
+            "created_at": "2026-01-01T00:00:00Z",
+            "expires_at": "2026-12-31T00:00:00Z",
+            "test_mode": false
+          },
+          "instance": {
+            "id": "inst-1",
+            "name": "host",
+            "created_at": "2026-01-01T00:00:00Z"
+          },
+          "meta": { "store_id": 1 }
+        }
+        """;
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/validate")
+            .Respond("application/json", responseJson);
+
+        var requestType = typeof(LemonSqueezyOptions).Assembly.GetType(
+            "Compendium.Adapters.LemonSqueezy.Http.Models.LsValidateLicenseRequest")!;
+        var request = Activator.CreateInstance(requestType)!;
+
+        // Act
+        var task = (Task)sut.GetType()
+            .GetMethod("ValidateLicenseAsync", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(sut, new object?[] { request, CancellationToken.None })!;
+        await task;
+        var result = task.GetType().GetProperty("Result")!.GetValue(task)!;
+
+        // Assert
+        ((bool)result.GetType().GetProperty("IsSuccess")!.GetValue(result)!).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeactivateLicensePayload_DeserializesAllFields()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var responseJson = """
+        {
+          "deactivated": true,
+          "error": null,
+          "meta": { "store_id": 1 }
+        }
+        """;
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/deactivate")
+            .Respond("application/json", responseJson);
+
+        var requestType = typeof(LemonSqueezyOptions).Assembly.GetType(
+            "Compendium.Adapters.LemonSqueezy.Http.Models.LsDeactivateLicenseRequest")!;
+        var request = Activator.CreateInstance(requestType)!;
+
+        // Act
+        var task = (Task)sut.GetType()
+            .GetMethod("DeactivateLicenseAsync", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(sut, new object?[] { request, CancellationToken.None })!;
+        await task;
+        var result = task.GetType().GetProperty("Result")!.GetValue(task)!;
+
+        // Assert
+        ((bool)result.GetType().GetProperty("IsSuccess")!.GetValue(result)!).Should().BeTrue();
+    }
+}

--- a/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Http/LemonSqueezyHttpClientTests.cs
+++ b/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Http/LemonSqueezyHttpClientTests.cs
@@ -1,0 +1,473 @@
+// -----------------------------------------------------------------------
+// <copyright file="LemonSqueezyHttpClientTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using System.Reflection;
+using Compendium.Adapters.LemonSqueezy.Configuration;
+using Compendium.Adapters.LemonSqueezy.Tests.Helpers;
+using Compendium.Core.Results;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+
+namespace Compendium.Adapters.LemonSqueezy.Tests.Http;
+
+/// <summary>
+/// Unit tests for the internal <c>LemonSqueezyHttpClient</c>. Reflection is used to invoke
+/// methods that are not exposed through the public services (e.g. GetCheckoutAsync, license
+/// key endpoints) and to exercise the HttpRequestException error paths in each helper.
+/// </summary>
+public class LemonSqueezyHttpClientTests
+{
+    private const string BaseUrl = "https://api.lemonsqueezy.com/v1/";
+
+    private static LemonSqueezyOptions CreateOptions(string storeId = "store-1") => new()
+    {
+        ApiKey = "sk_test_http_client",
+        StoreId = storeId,
+        BaseUrl = BaseUrl
+    };
+
+    private static (object client, MockHttpMessageHandler mock) CreateClient(
+        LemonSqueezyOptions? options = null)
+    {
+        var mock = new MockHttpMessageHandler();
+        var client = LemonSqueezyTestHelpers.CreateHttpClient(mock, options ?? CreateOptions());
+        return (client, mock);
+    }
+
+    private static async Task<object> InvokeAsync(object instance, string methodName, params object?[] args)
+    {
+        var method = instance.GetType().GetMethod(
+            methodName,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var task = (Task)method.Invoke(instance, args)!;
+        await task.ConfigureAwait(false);
+        return task.GetType().GetProperty("Result")!.GetValue(task)!;
+    }
+
+    private static bool GetIsSuccess(object result) =>
+        (bool)result.GetType().GetProperty("IsSuccess")!.GetValue(result)!;
+
+    private static bool GetIsFailure(object result) =>
+        (bool)result.GetType().GetProperty("IsFailure")!.GetValue(result)!;
+
+    private static Error GetError(object result) =>
+        (Error)result.GetType().GetProperty("Error")!.GetValue(result)!;
+
+    // ============================================================================
+    // GetCheckoutAsync — exposed only on the http client, not the service
+    // ============================================================================
+
+    [Fact]
+    public async Task GetCheckoutAsync_WhenFound_ReturnsResource()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var responseJson = """
+        {
+          "data": {
+            "type": "checkouts",
+            "id": "ck-1",
+            "attributes": { "url": "https://store.lemonsqueezy.com/checkout/ck-1" }
+          }
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "checkouts/ck-1")
+            .Respond("application/vnd.api+json", responseJson);
+
+        // Act
+        var result = await InvokeAsync(sut, "GetCheckoutAsync", "ck-1", CancellationToken.None);
+
+        // Assert
+        GetIsSuccess(result).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetCheckoutAsync_WhenNotFound_ReturnsNotFoundError()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Get, BaseUrl + "checkouts/missing")
+            .Respond(HttpStatusCode.NotFound, "text/plain", "missing");
+
+        // Act
+        var result = await InvokeAsync(sut, "GetCheckoutAsync", "missing", CancellationToken.None);
+
+        // Assert
+        GetIsFailure(result).Should().BeTrue();
+        GetError(result).Code.Should().Be("LemonSqueezy.NotFound");
+    }
+
+    // ============================================================================
+    // GetLicenseKeyAsync / ListLicenseKeyInstancesAsync — only on the http client
+    // ============================================================================
+
+    [Fact]
+    public async Task GetLicenseKeyAsync_WhenFound_ReturnsResource()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var responseJson = """
+        {
+          "data": {
+            "type": "license-keys",
+            "id": "lk-1",
+            "attributes": { "key": "AAA-BBB", "status": "active" }
+          }
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "license-keys/lk-1")
+            .Respond("application/vnd.api+json", responseJson);
+
+        // Act
+        var result = await InvokeAsync(sut, "GetLicenseKeyAsync", "lk-1", CancellationToken.None);
+
+        // Assert
+        GetIsSuccess(result).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ListLicenseKeyInstancesAsync_WhenInstancesExist_ReturnsCollection()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var responseJson = """
+        {
+          "data": [
+            { "type": "license-key-instances", "id": "i-1", "attributes": { "name": "host-1" } },
+            { "type": "license-key-instances", "id": "i-2", "attributes": { "name": "host-2" } }
+          ]
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "license-key-instances*")
+            .Respond("application/vnd.api+json", responseJson);
+
+        // Act
+        var result = await InvokeAsync(sut, "ListLicenseKeyInstancesAsync", "lk-1", CancellationToken.None);
+
+        // Assert
+        GetIsSuccess(result).Should().BeTrue();
+    }
+
+    // ============================================================================
+    // ListCustomersAsync — without and with email filter
+    // ============================================================================
+
+    [Fact]
+    public async Task ListCustomersAsync_WhenEmailNull_RequestsCustomersWithoutFilter()
+    {
+        // Arrange — no filter[email] in URL because email argument is null
+        var (sut, mock) = CreateClient();
+        var responseJson = "{\"data\":[]}";
+        mock.When(HttpMethod.Get, BaseUrl + "customers")
+            .Respond("application/vnd.api+json", responseJson);
+
+        // Act
+        var result = await InvokeAsync(sut, "ListCustomersAsync", (string?)null, CancellationToken.None);
+
+        // Assert
+        GetIsSuccess(result).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ListCustomersAsync_WhenEmailProvided_AppendsFilterToUrl()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var responseJson = "{\"data\":[]}";
+        mock.When(HttpMethod.Get, BaseUrl + "customers?filter%5Bemail%5D=alice%40example.com")
+            .Respond("application/vnd.api+json", responseJson);
+
+        // Act
+        var result = await InvokeAsync(sut, "ListCustomersAsync", "alice@example.com", CancellationToken.None);
+
+        // Assert
+        GetIsSuccess(result).Should().BeTrue();
+    }
+
+    // ============================================================================
+    // ListSubscriptionsAsync filter combinations
+    // ============================================================================
+
+    [Fact]
+    public async Task ListSubscriptionsAsync_WhenAllFiltersNull_RequestsBaseUrlWithStoreId()
+    {
+        // Arrange — store id always added; the call should still succeed
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions*")
+            .Respond("application/vnd.api+json", "{\"data\":[]}");
+
+        // Act
+        var result = await InvokeAsync(
+            sut, "ListSubscriptionsAsync", (string?)null, (string?)null, CancellationToken.None);
+
+        // Assert
+        GetIsSuccess(result).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ListSubscriptionsAsync_WithoutStoreId_DoesNotAddStoreFilter()
+    {
+        // Arrange — empty StoreId means the store-id branch is skipped
+        var (sut, mock) = CreateClient(new LemonSqueezyOptions { ApiKey = "k", StoreId = string.Empty, BaseUrl = BaseUrl });
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions")
+            .Respond("application/vnd.api+json", "{\"data\":[]}");
+
+        // Act
+        var result = await InvokeAsync(
+            sut, "ListSubscriptionsAsync", (string?)null, (string?)null, CancellationToken.None);
+
+        // Assert
+        GetIsSuccess(result).Should().BeTrue();
+    }
+
+    // ============================================================================
+    // Error mapping coverage — the exhaustive switch in HandleErrorResponseAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task GetCustomerAsync_OnTooManyRequests_ReturnsRateLimitExceeded()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Get, BaseUrl + "customers/x")
+            .Respond(HttpStatusCode.TooManyRequests, "text/plain", "rate");
+
+        // Act
+        var result = await InvokeAsync(sut, "GetCustomerAsync", "x", CancellationToken.None);
+
+        // Assert
+        GetIsFailure(result).Should().BeTrue();
+        GetError(result).Code.Should().Be("Billing.RateLimitExceeded");
+    }
+
+    [Fact]
+    public async Task GetCustomerAsync_OnServiceUnavailable_ReturnsProviderUnavailable()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Get, BaseUrl + "customers/x")
+            .Respond(HttpStatusCode.ServiceUnavailable, "text/plain", "down");
+
+        // Act
+        var result = await InvokeAsync(sut, "GetCustomerAsync", "x", CancellationToken.None);
+
+        // Assert
+        GetIsFailure(result).Should().BeTrue();
+        GetError(result).Code.Should().Be("Billing.ProviderUnavailable");
+    }
+
+    [Fact]
+    public async Task GetCustomerAsync_OnConflict_ReturnsConflictError()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Get, BaseUrl + "customers/x")
+            .Respond(HttpStatusCode.Conflict, "text/plain", "conflict");
+
+        // Act
+        var result = await InvokeAsync(sut, "GetCustomerAsync", "x", CancellationToken.None);
+
+        // Assert
+        GetIsFailure(result).Should().BeTrue();
+        GetError(result).Code.Should().Be("LemonSqueezy.Conflict");
+    }
+
+    [Fact]
+    public async Task GetCustomerAsync_OnEmptyErrorBody_FallsBackToReasonPhrase()
+    {
+        // Arrange — empty body forces HandleErrorResponseAsync to use ReasonPhrase
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Get, BaseUrl + "customers/x")
+            .Respond(req =>
+            {
+                var resp = new HttpResponseMessage(HttpStatusCode.BadGateway)
+                {
+                    ReasonPhrase = "Bad Gateway",
+                    Content = new StringContent(string.Empty)
+                };
+                return resp;
+            });
+
+        // Act
+        var result = await InvokeAsync(sut, "GetCustomerAsync", "x", CancellationToken.None);
+
+        // Assert
+        GetIsFailure(result).Should().BeTrue();
+        GetError(result).Code.Should().Be("LemonSqueezy.Error");
+        GetError(result).Message.Should().NotBeNullOrEmpty();
+    }
+
+    // ============================================================================
+    // HttpRequestException paths — every helper has its own catch block
+    // ============================================================================
+
+    [Fact]
+    public async Task GetCollectionAsync_OnHttpRequestException_ReturnsHttpError()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Get, BaseUrl + "customers*")
+            .Throw(new HttpRequestException("connection lost"));
+
+        // Act
+        var result = await InvokeAsync(sut, "ListCustomersAsync", "alice@example.com", CancellationToken.None);
+
+        // Assert
+        GetIsFailure(result).Should().BeTrue();
+        GetError(result).Code.Should().Be("LemonSqueezy.HttpError");
+    }
+
+    [Fact]
+    public async Task DeleteSubscriptionAsync_OnHttpRequestException_ReturnsHttpError()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Delete, BaseUrl + "subscriptions/sub-x")
+            .Throw(new HttpRequestException("network error"));
+
+        // Act
+        var result = await InvokeAsync(sut, "DeleteSubscriptionAsync", "sub-x", CancellationToken.None);
+
+        // Assert
+        GetIsFailure(result).Should().BeTrue();
+        GetError(result).Code.Should().Be("LemonSqueezy.HttpError");
+    }
+
+    [Fact]
+    public async Task UpdateSubscriptionAsync_OnHttpRequestException_ReturnsHttpError()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Patch, BaseUrl + "subscriptions/sub-x")
+            .Throw(new HttpRequestException("patch failed"));
+
+        var requestType = typeof(LemonSqueezyOptions).Assembly.GetType(
+            "Compendium.Adapters.LemonSqueezy.Http.Models.LsUpdateSubscriptionRequest")!;
+        var request = Activator.CreateInstance(requestType)!;
+
+        // Act
+        var result = await InvokeAsync(sut, "UpdateSubscriptionAsync", "sub-x", request, CancellationToken.None);
+
+        // Assert
+        GetIsFailure(result).Should().BeTrue();
+        GetError(result).Code.Should().Be("LemonSqueezy.HttpError");
+    }
+
+    [Fact]
+    public async Task ValidateLicenseAsync_OnHttpRequestException_ReturnsHttpError()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/validate")
+            .Throw(new HttpRequestException("fail"));
+
+        var requestType = typeof(LemonSqueezyOptions).Assembly.GetType(
+            "Compendium.Adapters.LemonSqueezy.Http.Models.LsValidateLicenseRequest")!;
+        var request = Activator.CreateInstance(requestType)!;
+
+        // Act
+        var result = await InvokeAsync(sut, "ValidateLicenseAsync", request, CancellationToken.None);
+
+        // Assert
+        GetIsFailure(result).Should().BeTrue();
+        GetError(result).Code.Should().Be("LemonSqueezy.HttpError");
+    }
+
+    [Fact]
+    public async Task DeleteSubscriptionAsync_OnEmptyBodyError_FallsBackToReasonPhrase()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Delete, BaseUrl + "subscriptions/x")
+            .Respond(req => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                ReasonPhrase = "Server Error",
+                Content = new StringContent(string.Empty)
+            });
+
+        // Act
+        var result = await InvokeAsync(sut, "DeleteSubscriptionAsync", "x", CancellationToken.None);
+
+        // Assert
+        GetIsFailure(result).Should().BeTrue();
+        GetError(result).Code.Should().Be("LemonSqueezy.Error");
+    }
+
+    [Fact]
+    public async Task DeleteSubscriptionAsync_OnSuccess_ReturnsSuccess()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        mock.When(HttpMethod.Delete, BaseUrl + "subscriptions/sub-ok")
+            .Respond(HttpStatusCode.NoContent);
+
+        // Act
+        var result = await InvokeAsync(sut, "DeleteSubscriptionAsync", "sub-ok", CancellationToken.None);
+
+        // Assert
+        GetIsSuccess(result).Should().BeTrue();
+    }
+
+    // ============================================================================
+    // Authorization header & Accept header
+    // ============================================================================
+
+    [Fact]
+    public async Task HttpClient_SendsBearerAuthorizationHeaderWhenApiKeySet()
+    {
+        // Arrange
+        var (sut, mock) = CreateClient();
+        var captured = mock.When(HttpMethod.Get, BaseUrl + "customers/cust-1")
+            .Respond(req =>
+            {
+                req.Headers.Authorization.Should().NotBeNull();
+                req.Headers.Authorization!.Scheme.Should().Be("Bearer");
+                req.Headers.Authorization.Parameter.Should().Be("sk_test_http_client");
+                req.Headers.Accept.ToString().Should().Contain("application/vnd.api+json");
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "{\"data\":{\"id\":\"cust-1\",\"type\":\"customers\",\"attributes\":{\"email\":\"e\"}}}",
+                        System.Text.Encoding.UTF8,
+                        "application/vnd.api+json")
+                };
+            });
+
+        // Act
+        var result = await InvokeAsync(sut, "GetCustomerAsync", "cust-1", CancellationToken.None);
+
+        // Assert
+        GetIsSuccess(result).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HttpClient_WhenApiKeyEmpty_DoesNotSendAuthorizationHeader()
+    {
+        // Arrange — exercises the !IsNullOrEmpty branch in ConfigureHttpClient
+        var options = new LemonSqueezyOptions { ApiKey = string.Empty, StoreId = "s", BaseUrl = BaseUrl };
+        var (sut, mock) = CreateClient(options);
+        mock.When(HttpMethod.Get, BaseUrl + "customers/x")
+            .Respond(req =>
+            {
+                req.Headers.Authorization.Should().BeNull();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "{\"data\":{\"id\":\"x\",\"type\":\"customers\",\"attributes\":{\"email\":\"e\"}}}",
+                        System.Text.Encoding.UTF8,
+                        "application/vnd.api+json")
+                };
+            });
+
+        // Act
+        var result = await InvokeAsync(sut, "GetCustomerAsync", "x", CancellationToken.None);
+
+        // Assert
+        GetIsSuccess(result).Should().BeTrue();
+    }
+}

--- a/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Services/LemonSqueezyBillingServiceTests.cs
+++ b/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Services/LemonSqueezyBillingServiceTests.cs
@@ -1,0 +1,518 @@
+// -----------------------------------------------------------------------
+// <copyright file="LemonSqueezyBillingServiceTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using Compendium.Abstractions.Billing;
+using Compendium.Abstractions.Billing.Models;
+using Compendium.Adapters.LemonSqueezy.Configuration;
+using Compendium.Adapters.LemonSqueezy.Tests.Helpers;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+
+namespace Compendium.Adapters.LemonSqueezy.Tests.Services;
+
+/// <summary>
+/// Unit tests for the internal <c>LemonSqueezyBillingService</c> exercised via the public
+/// <see cref="IBillingService"/> contract. HTTP traffic is mocked with
+/// <see cref="MockHttpMessageHandler"/>.
+/// </summary>
+public class LemonSqueezyBillingServiceTests
+{
+    private const string BaseUrl = "https://api.lemonsqueezy.com/v1/";
+
+    private static LemonSqueezyOptions CreateOptions(string storeId = "store-1") => new()
+    {
+        ApiKey = "sk_test_api_key",
+        StoreId = storeId,
+        BaseUrl = BaseUrl
+    };
+
+    // ============================================================================
+    // CreateCheckoutSessionAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task CreateCheckoutSessionAsync_WhenSucceeds_ReturnsMappedSession()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var responseJson = """
+        {
+          "data": {
+            "type": "checkouts",
+            "id": "ck_123",
+            "attributes": {
+              "store_id": 42,
+              "variant_id": 100,
+              "url": "https://store.lemonsqueezy.com/checkout/ck_123",
+              "created_at": "2026-01-01T10:00:00Z",
+              "expires_at": "2026-01-02T10:00:00Z"
+            }
+          }
+        }
+        """;
+        mock.When(HttpMethod.Post, BaseUrl + "checkouts")
+            .Respond("application/vnd.api+json", responseJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+        var request = new CreateCheckoutRequest { VariantId = "100", Email = "test@example.com" };
+
+        // Act
+        var result = await sut.CreateCheckoutSessionAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be("ck_123");
+        result.Value.CheckoutUrl.Should().Be("https://store.lemonsqueezy.com/checkout/ck_123");
+        result.Value.StoreId.Should().Be("42");
+        result.Value.VariantId.Should().Be("100");
+    }
+
+    [Fact]
+    public async Task CreateCheckoutSessionAsync_WhenCustomDataProvided_ForwardsItToCheckout()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var responseJson = """
+        {
+          "data": {
+            "type": "checkouts",
+            "id": "ck_with_custom",
+            "attributes": {
+              "url": "https://example.com/checkout",
+              "checkout_data": { "custom": { "tenant_id": "t-1" } }
+            }
+          }
+        }
+        """;
+        mock.When(HttpMethod.Post, BaseUrl + "checkouts")
+            .Respond("application/vnd.api+json", responseJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+        var customData = new Dictionary<string, object> { ["tenant_id"] = "t-1" };
+        var request = new CreateCheckoutRequest
+        {
+            VariantId = "200",
+            Embed = true,
+            DiscountCode = "DISC10",
+            Name = "John",
+            SuccessUrl = "https://example.com/success",
+            CustomData = customData
+        };
+
+        // Act
+        var result = await sut.CreateCheckoutSessionAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CustomData.Should().NotBeNull();
+        result.Value.CustomData!.Should().ContainKey("tenant_id");
+    }
+
+    [Fact]
+    public async Task CreateCheckoutSessionAsync_WhenApiReturnsBadRequest_ReturnsValidationError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "checkouts")
+            .Respond(HttpStatusCode.BadRequest, "text/plain", "Invalid variant");
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CreateCheckoutSessionAsync(
+            new CreateCheckoutRequest { VariantId = "bad" }, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.BadRequest");
+    }
+
+    [Fact]
+    public async Task CreateCheckoutSessionAsync_WhenApiReturnsEmptyBody_ReturnsEmptyResponseError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "checkouts")
+            .Respond("application/vnd.api+json", "{\"data\":null}");
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CreateCheckoutSessionAsync(
+            new CreateCheckoutRequest { VariantId = "1" }, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.EmptyResponse");
+    }
+
+    [Fact]
+    public async Task CreateCheckoutSessionAsync_WhenHttpFails_ReturnsHttpError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "checkouts")
+            .Throw(new HttpRequestException("connection refused"));
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CreateCheckoutSessionAsync(
+            new CreateCheckoutRequest { VariantId = "1" }, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.HttpError");
+    }
+
+    [Fact]
+    public async Task CreateCheckoutSessionAsync_WhenRequestNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.CreateCheckoutSessionAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // GetCustomerAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task GetCustomerAsync_WhenFound_ReturnsMappedCustomer()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var responseJson = """
+        {
+          "data": {
+            "type": "customers",
+            "id": "cust-77",
+            "attributes": {
+              "store_id": 42,
+              "name": "Alice",
+              "email": "alice@example.com",
+              "city": "Paris",
+              "region": "IDF",
+              "country": "FR",
+              "total_revenue_currency": 12345,
+              "created_at": "2026-01-01T10:00:00Z",
+              "updated_at": "2026-02-01T10:00:00Z"
+            }
+          }
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "customers/cust-77")
+            .Respond("application/vnd.api+json", responseJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetCustomerAsync("cust-77", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be("cust-77");
+        result.Value.Email.Should().Be("alice@example.com");
+        result.Value.Name.Should().Be("Alice");
+        result.Value.City.Should().Be("Paris");
+        result.Value.Country.Should().Be("FR");
+        result.Value.TotalRevenueCents.Should().Be(12345);
+    }
+
+    [Fact]
+    public async Task GetCustomerAsync_WhenNotFound_ReturnsCustomerNotFound()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "customers/missing")
+            .Respond(HttpStatusCode.NotFound, "text/plain", "no customer");
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetCustomerAsync("missing", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.CustomerNotFound");
+    }
+
+    [Fact]
+    public async Task GetCustomerAsync_WhenApiReturnsServerError_PropagatesError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "customers/x")
+            .Respond(HttpStatusCode.InternalServerError, "text/plain", "boom");
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetCustomerAsync("x", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.Error");
+    }
+
+    [Fact]
+    public async Task GetCustomerAsync_WhenIdNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.GetCustomerAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // GetCustomerByEmailAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task GetCustomerByEmailAsync_WhenFound_ReturnsFirstMatch()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var responseJson = """
+        {
+          "data": [
+            {
+              "type": "customers",
+              "id": "cust-1",
+              "attributes": {
+                "email": "found@example.com",
+                "name": "Found"
+              }
+            }
+          ]
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "customers*")
+            .Respond("application/vnd.api+json", responseJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetCustomerByEmailAsync("found@example.com", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be("cust-1");
+        result.Value.Email.Should().Be("found@example.com");
+    }
+
+    [Fact]
+    public async Task GetCustomerByEmailAsync_WhenNoMatches_ReturnsNotFoundByEmail()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "customers*")
+            .Respond("application/vnd.api+json", "{\"data\":[]}");
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetCustomerByEmailAsync("ghost@example.com", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.CustomerNotFoundByEmail");
+    }
+
+    [Fact]
+    public async Task GetCustomerByEmailAsync_WhenApiFails_ReturnsError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "customers*")
+            .Respond(HttpStatusCode.Unauthorized, "text/plain", "no auth");
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetCustomerByEmailAsync("e@example.com", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.Unauthorized");
+    }
+
+    [Fact]
+    public async Task GetCustomerByEmailAsync_WhenEmailNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.GetCustomerByEmailAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // UpsertCustomerAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task UpsertCustomerAsync_AlwaysReturnsUnsupportedOperation()
+    {
+        // Arrange — LemonSqueezy creates customers on checkout, not directly
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.UpsertCustomerAsync(
+            new UpsertCustomerRequest { Email = "x@example.com" },
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.UnsupportedOperation");
+    }
+
+    [Fact]
+    public async Task UpsertCustomerAsync_WhenRequestNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.UpsertCustomerAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // CreateCustomerPortalUrlAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task CreateCustomerPortalUrlAsync_WhenSubscriptionWithPortalUrlExists_ReturnsUrl()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var responseJson = """
+        {
+          "data": [
+            {
+              "type": "subscriptions",
+              "id": "sub-1",
+              "attributes": {
+                "urls": { "customer_portal": "https://portal.lemonsqueezy.com/sub-1" }
+              }
+            }
+          ]
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions*")
+            .Respond("application/vnd.api+json", responseJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CreateCustomerPortalUrlAsync("cust-1", returnUrl: null, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("https://portal.lemonsqueezy.com/sub-1");
+    }
+
+    [Fact]
+    public async Task CreateCustomerPortalUrlAsync_WhenNoActiveSubscription_ReturnsNoActiveSubscription()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions*")
+            .Respond("application/vnd.api+json", "{\"data\":[]}");
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CreateCustomerPortalUrlAsync("cust-empty", returnUrl: null, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.NoActiveSubscription");
+    }
+
+    [Fact]
+    public async Task CreateCustomerPortalUrlAsync_WhenSubscriptionMissingPortalUrl_ReturnsNoActiveSubscription()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var responseJson = """
+        {
+          "data": [
+            {
+              "type": "subscriptions",
+              "id": "sub-x",
+              "attributes": { "status": "active" }
+            }
+          ]
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions*")
+            .Respond("application/vnd.api+json", responseJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CreateCustomerPortalUrlAsync("cust-1", returnUrl: null, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.NoActiveSubscription");
+    }
+
+    [Fact]
+    public async Task CreateCustomerPortalUrlAsync_WhenApiFails_PropagatesError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions*")
+            .Respond(HttpStatusCode.Forbidden, "text/plain", "no");
+
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CreateCustomerPortalUrlAsync("cust-1", returnUrl: null, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.Forbidden");
+    }
+
+    [Fact]
+    public async Task CreateCustomerPortalUrlAsync_WhenCustomerIdNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateBillingService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.CreateCustomerPortalUrlAsync(null!, null, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Services/LemonSqueezyLicenseServiceTests.cs
+++ b/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Services/LemonSqueezyLicenseServiceTests.cs
@@ -1,0 +1,499 @@
+// -----------------------------------------------------------------------
+// <copyright file="LemonSqueezyLicenseServiceTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using Compendium.Abstractions.Billing;
+using Compendium.Abstractions.Billing.Models;
+using Compendium.Adapters.LemonSqueezy.Configuration;
+using Compendium.Adapters.LemonSqueezy.Tests.Helpers;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+
+namespace Compendium.Adapters.LemonSqueezy.Tests.Services;
+
+/// <summary>
+/// Unit tests for the internal <c>LemonSqueezyLicenseService</c> exercised via the public
+/// <see cref="ILicenseService"/> contract.
+/// </summary>
+public class LemonSqueezyLicenseServiceTests
+{
+    private const string BaseUrl = "https://api.lemonsqueezy.com/v1/";
+
+    private static LemonSqueezyOptions CreateOptions() => new()
+    {
+        ApiKey = "sk_test_license",
+        StoreId = "store-l",
+        BaseUrl = BaseUrl
+    };
+
+    // ============================================================================
+    // ValidateLicenseAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task ValidateLicenseAsync_WhenValid_ReturnsValidResultWithStatusActive()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var responseJson = """
+        {
+          "valid": true,
+          "license_key": {
+            "id": 1,
+            "status": "active",
+            "key": "ABCD-1234-EFGH-5678",
+            "activation_limit": 5,
+            "activation_usage": 1,
+            "created_at": "2026-01-01T00:00:00Z"
+          }
+        }
+        """;
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/validate")
+            .Respond("application/json", responseJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ValidateLicenseAsync("ABCD-1234-EFGH-5678", null, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.IsValid.Should().BeTrue();
+        result.Value.Status.Should().Be(LicenseStatus.Active);
+        result.Value.License.Should().NotBeNull();
+        result.Value.License!.ActivationLimit.Should().Be(5);
+        result.Value.License.ActivationCount.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("active", LicenseStatus.Active)]
+    [InlineData("inactive", LicenseStatus.Inactive)]
+    [InlineData("expired", LicenseStatus.Expired)]
+    [InlineData("disabled", LicenseStatus.Disabled)]
+    [InlineData("unknown", LicenseStatus.Active)]
+    public async Task ValidateLicenseAsync_WhenValidWithStatus_MapsToLicenseStatus(
+        string apiStatus, LicenseStatus expected)
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var responseJson = $$"""
+        {
+          "valid": true,
+          "license_key": { "id": 1, "status": "{{apiStatus}}", "key": "K" }
+        }
+        """;
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/validate")
+            .Respond("application/json", responseJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ValidateLicenseAsync("K", null, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Status.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task ValidateLicenseAsync_WhenInvalidAndNoLicenseData_ReturnsInactiveStatus()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/validate")
+            .Respond("application/json", "{\"valid\":false,\"error\":\"key not found\"}");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ValidateLicenseAsync("BAD-KEY", null, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.IsValid.Should().BeFalse();
+        result.Value.Status.Should().Be(LicenseStatus.Inactive);
+        result.Value.ErrorMessage.Should().Be("key not found");
+    }
+
+    [Fact]
+    public async Task ValidateLicenseAsync_WhenInvalidAndExpired_ReturnsExpiredStatus()
+    {
+        // Arrange — invalid + license data with past expiry
+        var mock = new MockHttpMessageHandler();
+        var responseJson = """
+        {
+          "valid": false,
+          "license_key": { "id": 1, "status": "active", "key": "EXP", "expires_at": "2020-01-01T00:00:00Z" }
+        }
+        """;
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/validate")
+            .Respond("application/json", responseJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ValidateLicenseAsync("EXP", null, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.IsValid.Should().BeFalse();
+        result.Value.Status.Should().Be(LicenseStatus.Expired);
+    }
+
+    [Fact]
+    public async Task ValidateLicenseAsync_WhenInstanceProvided_ReturnsInstanceDetails()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var responseJson = """
+        {
+          "valid": true,
+          "license_key": { "id": 1, "status": "active", "key": "K" },
+          "instance": { "id": "inst-9", "name": "machine-a", "created_at": "2026-01-01T00:00:00Z" }
+        }
+        """;
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/validate")
+            .Respond("application/json", responseJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ValidateLicenseAsync("K", "inst-9", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Instance.Should().NotBeNull();
+        result.Value.Instance!.Id.Should().Be("inst-9");
+        result.Value.Instance.Name.Should().Be("machine-a");
+    }
+
+    [Fact]
+    public async Task ValidateLicenseAsync_WhenApiFails_PropagatesError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/validate")
+            .Respond(HttpStatusCode.InternalServerError, "text/plain", "boom");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ValidateLicenseAsync("ANY", null, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.Error");
+    }
+
+    [Fact]
+    public async Task ValidateLicenseAsync_WhenLicenseKeyNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.ValidateLicenseAsync(null!, null, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task ValidateLicenseAsync_WhenShortKey_LogsMaskedKeyWithoutThrowing()
+    {
+        // Arrange — exercises the GetKeyShort fallback for short keys
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/validate")
+            .Respond("application/json", "{\"valid\":true,\"license_key\":{\"id\":1,\"status\":\"active\"}}");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ValidateLicenseAsync("abc", null, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    // ============================================================================
+    // ActivateLicenseAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task ActivateLicenseAsync_WhenSucceeds_ReturnsActivationWithInstance()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var responseJson = """
+        {
+          "activated": true,
+          "license_key": { "id": 1, "status": "active", "key": "ABCD-1234-EFGH-5678" },
+          "instance": { "id": "inst-1", "name": "host-1", "created_at": "2026-01-01T00:00:00Z" }
+        }
+        """;
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/activate")
+            .Respond("application/json", responseJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ActivateLicenseAsync("ABCD-1234-EFGH-5678", "host-1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Activated.Should().BeTrue();
+        result.Value.Instance.Should().NotBeNull();
+        result.Value.Instance!.Id.Should().Be("inst-1");
+        result.Value.License.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ActivateLicenseAsync_WhenActivationLimitReached_ReturnsLimitError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/activate")
+            .Respond("application/json",
+                "{\"activated\":false,\"error\":\"License has reached its activation limit\"}");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ActivateLicenseAsync("KEY", "host", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.LicenseActivationLimitReached");
+    }
+
+    [Fact]
+    public async Task ActivateLicenseAsync_WhenInvalidKey_ReturnsInvalidLicense()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/activate")
+            .Respond("application/json",
+                "{\"activated\":false,\"error\":\"License key not found\"}");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ActivateLicenseAsync("BAD", "host", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.InvalidLicense");
+    }
+
+    [Fact]
+    public async Task ActivateLicenseAsync_WhenActivatedFalseAndNoErrorMessage_ReturnsInvalidLicense()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/activate")
+            .Respond("application/json", "{\"activated\":false}");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ActivateLicenseAsync("KEY", "host", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.InvalidLicense");
+    }
+
+    [Fact]
+    public async Task ActivateLicenseAsync_WhenApiFails_PropagatesError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/activate")
+            .Respond(HttpStatusCode.BadRequest, "text/plain", "bad");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ActivateLicenseAsync("KEY", "host", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.BadRequest");
+    }
+
+    [Fact]
+    public async Task ActivateLicenseAsync_WhenInstanceNullInResponse_ReturnsActivationWithoutInstance()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/activate")
+            .Respond("application/json", "{\"activated\":true}");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ActivateLicenseAsync("KEY", "host", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Activated.Should().BeTrue();
+        result.Value.Instance.Should().BeNull();
+        result.Value.License.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ActivateLicenseAsync_WhenLicenseKeyNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.ActivateLicenseAsync(null!, "host", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task ActivateLicenseAsync_WhenInstanceNameNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.ActivateLicenseAsync("KEY", null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // DeactivateLicenseAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task DeactivateLicenseAsync_WhenSucceeds_ReturnsSuccess()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/deactivate")
+            .Respond("application/json", "{\"deactivated\":true}");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.DeactivateLicenseAsync("KEY", "inst-1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeactivateLicenseAsync_WhenInstanceNotFound_ReturnsInstanceNotFoundError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/deactivate")
+            .Respond("application/json",
+                "{\"deactivated\":false,\"error\":\"instance not found\"}");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.DeactivateLicenseAsync("KEY", "missing", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.LicenseInstanceNotFound");
+    }
+
+    [Fact]
+    public async Task DeactivateLicenseAsync_WhenDeactivationFailedGenericReason_ReturnsDeactivationFailedError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/deactivate")
+            .Respond("application/json",
+                "{\"deactivated\":false,\"error\":\"some other reason\"}");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.DeactivateLicenseAsync("KEY", "inst-1", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.DeactivationFailed");
+    }
+
+    [Fact]
+    public async Task DeactivateLicenseAsync_WhenDeactivatedFalseAndNoError_ReturnsDeactivationFailed()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/deactivate")
+            .Respond("application/json", "{\"deactivated\":false}");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.DeactivateLicenseAsync("KEY", "inst-1", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.DeactivationFailed");
+    }
+
+    [Fact]
+    public async Task DeactivateLicenseAsync_WhenApiFails_PropagatesError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Post, BaseUrl + "licenses/deactivate")
+            .Respond(HttpStatusCode.Unauthorized, "text/plain", "no auth");
+
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.DeactivateLicenseAsync("KEY", "inst-1", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.Unauthorized");
+    }
+
+    [Fact]
+    public async Task DeactivateLicenseAsync_WhenLicenseKeyNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.DeactivateLicenseAsync(null!, "inst", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task DeactivateLicenseAsync_WhenInstanceIdNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateLicenseService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.DeactivateLicenseAsync("KEY", null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Services/LemonSqueezySubscriptionServiceTests.cs
+++ b/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Services/LemonSqueezySubscriptionServiceTests.cs
@@ -1,0 +1,728 @@
+// -----------------------------------------------------------------------
+// <copyright file="LemonSqueezySubscriptionServiceTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using Compendium.Abstractions.Billing;
+using Compendium.Abstractions.Billing.Models;
+using Compendium.Adapters.LemonSqueezy.Configuration;
+using Compendium.Adapters.LemonSqueezy.Tests.Helpers;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+
+namespace Compendium.Adapters.LemonSqueezy.Tests.Services;
+
+/// <summary>
+/// Unit tests for the internal <c>LemonSqueezySubscriptionService</c> exercised via the
+/// public <see cref="ISubscriptionService"/> contract.
+/// </summary>
+public class LemonSqueezySubscriptionServiceTests
+{
+    private const string BaseUrl = "https://api.lemonsqueezy.com/v1/";
+
+    private static LemonSqueezyOptions CreateOptions() => new()
+    {
+        ApiKey = "sk_test_subscription",
+        StoreId = "store-9",
+        BaseUrl = BaseUrl
+    };
+
+    private static string SubscriptionResponse(
+        string id = "sub-1",
+        string status = "active",
+        bool? cancelled = null,
+        bool paused = false) =>
+        $$"""
+        {
+          "data": {
+            "type": "subscriptions",
+            "id": "{{id}}",
+            "attributes": {
+              "store_id": 1,
+              "customer_id": 99,
+              "product_id": 200,
+              "variant_id": 300,
+              "product_name": "Pro",
+              "variant_name": "Monthly",
+              "status": "{{status}}",
+              "cancelled": {{(cancelled.HasValue ? cancelled.Value.ToString().ToLowerInvariant() : "null")}},
+              {{(paused ? "\"pause\": { \"mode\": \"void\", \"resumes_at\": \"2026-12-31T00:00:00Z\" }," : "")}}
+              "renews_at": "2026-12-01T00:00:00Z",
+              "created_at": "2026-01-01T10:00:00Z",
+              "updated_at": "2026-02-01T10:00:00Z"
+            }
+          }
+        }
+        """;
+
+    // ============================================================================
+    // GetSubscriptionAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task GetSubscriptionAsync_WhenFound_ReturnsMappedSubscription()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/sub-1")
+            .Respond("application/vnd.api+json", SubscriptionResponse(id: "sub-1", status: "active"));
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetSubscriptionAsync("sub-1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be("sub-1");
+        result.Value.CustomerId.Should().Be("99");
+        result.Value.ProductId.Should().Be("200");
+        result.Value.VariantId.Should().Be("300");
+        result.Value.Status.Should().Be(BillingSubscriptionStatus.Active);
+    }
+
+    [Fact]
+    public async Task GetSubscriptionAsync_WhenNotFound_ReturnsSubscriptionNotFound()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/missing")
+            .Respond(HttpStatusCode.NotFound, "text/plain", "no sub");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetSubscriptionAsync("missing", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.SubscriptionNotFound");
+    }
+
+    [Fact]
+    public async Task GetSubscriptionAsync_WhenServerError_PropagatesGenericError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/x")
+            .Respond(HttpStatusCode.InternalServerError, "text/plain", "boom");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetSubscriptionAsync("x", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.Error");
+    }
+
+    [Fact]
+    public async Task GetSubscriptionAsync_WhenIdNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.GetSubscriptionAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // GetActiveSubscriptionAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task GetActiveSubscriptionAsync_WhenActiveExists_ReturnsSubscription()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var listJson = """
+        {
+          "data": [
+            {
+              "type": "subscriptions",
+              "id": "sub-active",
+              "attributes": {
+                "customer_id": 1,
+                "status": "active",
+                "product_id": 2,
+                "variant_id": 3,
+                "created_at": "2026-01-01T00:00:00Z"
+              }
+            }
+          ]
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions*")
+            .Respond("application/vnd.api+json", listJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetActiveSubscriptionAsync("1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Id.Should().Be("sub-active");
+    }
+
+    [Fact]
+    public async Task GetActiveSubscriptionAsync_WhenNoActive_ReturnsSuccessWithNull()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions*")
+            .Respond("application/vnd.api+json", "{\"data\":[]}");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetActiveSubscriptionAsync("nobody", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetActiveSubscriptionAsync_WhenApiFails_PropagatesError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions*")
+            .Respond(HttpStatusCode.TooManyRequests, "text/plain", "rate limited");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetActiveSubscriptionAsync("1", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.RateLimitExceeded");
+    }
+
+    [Fact]
+    public async Task GetActiveSubscriptionAsync_WhenCustomerIdNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.GetActiveSubscriptionAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // ListSubscriptionsAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task ListSubscriptionsAsync_WhenSubscriptionsExist_ReturnsMappedList()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var listJson = """
+        {
+          "data": [
+            {
+              "type": "subscriptions",
+              "id": "sub-1",
+              "attributes": { "customer_id": 1, "status": "active", "product_id": 2, "variant_id": 3 }
+            },
+            {
+              "type": "subscriptions",
+              "id": "sub-2",
+              "attributes": { "customer_id": 1, "status": "cancelled", "cancelled": true, "product_id": 2, "variant_id": 3 }
+            }
+          ]
+        }
+        """;
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions*")
+            .Respond("application/vnd.api+json", listJson);
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ListSubscriptionsAsync("1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+        result.Value[0].Id.Should().Be("sub-1");
+        result.Value[1].Status.Should().Be(BillingSubscriptionStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task ListSubscriptionsAsync_WhenApiFails_ReturnsError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions*")
+            .Respond(HttpStatusCode.ServiceUnavailable, "text/plain", "down");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ListSubscriptionsAsync("1", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.ProviderUnavailable");
+    }
+
+    [Fact]
+    public async Task ListSubscriptionsAsync_WhenCustomerIdNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.ListSubscriptionsAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // CancelSubscriptionAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task CancelSubscriptionAsync_WhenActive_DeletesSuccessfully()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/sub-1")
+            .Respond("application/vnd.api+json", SubscriptionResponse(id: "sub-1", status: "active"));
+        mock.When(HttpMethod.Delete, BaseUrl + "subscriptions/sub-1")
+            .Respond(HttpStatusCode.NoContent);
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CancelSubscriptionAsync("sub-1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CancelSubscriptionAsync_WhenAlreadyCancelled_ReturnsAlreadyCanceledError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/sub-cx")
+            .Respond("application/vnd.api+json", SubscriptionResponse(id: "sub-cx", status: "cancelled", cancelled: true));
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CancelSubscriptionAsync("sub-cx", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.SubscriptionAlreadyCanceled");
+    }
+
+    [Fact]
+    public async Task CancelSubscriptionAsync_WhenNotFound_ReturnsSubscriptionNotFound()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/ghost")
+            .Respond(HttpStatusCode.NotFound, "text/plain", "missing");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CancelSubscriptionAsync("ghost", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.SubscriptionNotFound");
+    }
+
+    [Fact]
+    public async Task CancelSubscriptionAsync_WhenGetFailsNonNotFound_PropagatesError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/forbidden")
+            .Respond(HttpStatusCode.Forbidden, "text/plain", "denied");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CancelSubscriptionAsync("forbidden", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.Forbidden");
+    }
+
+    [Fact]
+    public async Task CancelSubscriptionAsync_WhenDeleteFails_ReturnsErrorFromDelete()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/sub-1")
+            .Respond("application/vnd.api+json", SubscriptionResponse(id: "sub-1", status: "active"));
+        mock.When(HttpMethod.Delete, BaseUrl + "subscriptions/sub-1")
+            .Respond(HttpStatusCode.UnprocessableEntity, "text/plain", "validation");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.CancelSubscriptionAsync("sub-1", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.UnprocessableEntity");
+    }
+
+    [Fact]
+    public async Task CancelSubscriptionAsync_WhenIdNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.CancelSubscriptionAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // PauseSubscriptionAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task PauseSubscriptionAsync_WhenSucceeds_ReturnsSuccess()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Patch, BaseUrl + "subscriptions/sub-pause")
+            .Respond("application/vnd.api+json", SubscriptionResponse(id: "sub-pause", status: "active", paused: true));
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.PauseSubscriptionAsync("sub-pause", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PauseSubscriptionAsync_WhenApiFails_ReturnsError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Patch, BaseUrl + "subscriptions/sub-x")
+            .Respond(HttpStatusCode.Conflict, "text/plain", "conflict");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.PauseSubscriptionAsync("sub-x", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.Conflict");
+    }
+
+    [Fact]
+    public async Task PauseSubscriptionAsync_WhenIdNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.PauseSubscriptionAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // ResumeSubscriptionAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task ResumeSubscriptionAsync_WhenPaused_ResumesSuccessfully()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/sub-paused")
+            .Respond("application/vnd.api+json", SubscriptionResponse(id: "sub-paused", status: "paused", paused: true));
+        mock.When(HttpMethod.Patch, BaseUrl + "subscriptions/sub-paused")
+            .Respond("application/vnd.api+json", SubscriptionResponse(id: "sub-paused", status: "active"));
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ResumeSubscriptionAsync("sub-paused", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ResumeSubscriptionAsync_WhenNotPaused_ReturnsSubscriptionNotPaused()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/sub-active")
+            .Respond("application/vnd.api+json", SubscriptionResponse(id: "sub-active", status: "active"));
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ResumeSubscriptionAsync("sub-active", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.SubscriptionNotPaused");
+    }
+
+    [Fact]
+    public async Task ResumeSubscriptionAsync_WhenNotFound_ReturnsSubscriptionNotFound()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/ghost")
+            .Respond(HttpStatusCode.NotFound, "text/plain", "missing");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ResumeSubscriptionAsync("ghost", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.SubscriptionNotFound");
+    }
+
+    [Fact]
+    public async Task ResumeSubscriptionAsync_WhenGetFailsNonNotFound_PropagatesError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/forbidden")
+            .Respond(HttpStatusCode.Forbidden, "text/plain", "no");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ResumeSubscriptionAsync("forbidden", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.Forbidden");
+    }
+
+    [Fact]
+    public async Task ResumeSubscriptionAsync_WhenPatchFails_ReturnsError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/sub-paused")
+            .Respond("application/vnd.api+json", SubscriptionResponse(id: "sub-paused", status: "paused", paused: true));
+        mock.When(HttpMethod.Patch, BaseUrl + "subscriptions/sub-paused")
+            .Respond(HttpStatusCode.BadRequest, "text/plain", "bad request");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.ResumeSubscriptionAsync("sub-paused", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.BadRequest");
+    }
+
+    [Fact]
+    public async Task ResumeSubscriptionAsync_WhenIdNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.ResumeSubscriptionAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // UpdateSubscriptionAsync
+    // ============================================================================
+
+    [Fact]
+    public async Task UpdateSubscriptionAsync_WhenValidVariant_ReturnsUpdatedSubscription()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Patch, BaseUrl + "subscriptions/sub-1")
+            .Respond("application/vnd.api+json", SubscriptionResponse(id: "sub-1", status: "active"));
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.UpdateSubscriptionAsync("sub-1", "777", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be("sub-1");
+    }
+
+    [Fact]
+    public async Task UpdateSubscriptionAsync_WhenVariantIdNotInteger_ReturnsVariantNotFound()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.UpdateSubscriptionAsync("sub-1", "not-numeric", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.VariantNotFound");
+    }
+
+    [Fact]
+    public async Task UpdateSubscriptionAsync_WhenApiFails_ReturnsError()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Patch, BaseUrl + "subscriptions/sub-1")
+            .Respond(HttpStatusCode.UnprocessableEntity, "text/plain", "bad");
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.UpdateSubscriptionAsync("sub-1", "888", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("LemonSqueezy.UnprocessableEntity");
+    }
+
+    [Fact]
+    public async Task UpdateSubscriptionAsync_WhenSubscriptionIdNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.UpdateSubscriptionAsync(null!, "1", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task UpdateSubscriptionAsync_WhenVariantIdNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var act = async () => await sut.UpdateSubscriptionAsync("sub-1", null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ============================================================================
+    // Status mapping (covers MapSubscriptionStatus switch arms)
+    // ============================================================================
+
+    [Theory]
+    [InlineData("on_trial", BillingSubscriptionStatus.OnTrial)]
+    [InlineData("active", BillingSubscriptionStatus.Active)]
+    [InlineData("paused", BillingSubscriptionStatus.Paused)]
+    [InlineData("past_due", BillingSubscriptionStatus.PastDue)]
+    [InlineData("unpaid", BillingSubscriptionStatus.Unpaid)]
+    [InlineData("cancelled", BillingSubscriptionStatus.Cancelled)]
+    [InlineData("expired", BillingSubscriptionStatus.Expired)]
+    [InlineData("unknown_value", BillingSubscriptionStatus.Active)]
+    public async Task GetSubscriptionAsync_MapsLemonSqueezyStatusToBillingStatus(
+        string apiStatus, BillingSubscriptionStatus expected)
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/sub-status")
+            .Respond("application/vnd.api+json", SubscriptionResponse(id: "sub-status", status: apiStatus));
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetSubscriptionAsync("sub-status", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Status.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task GetSubscriptionAsync_WhenCancelledFlagTrue_PrioritizesCancelledStatus()
+    {
+        // Arrange — cancelled flag should take precedence over active status
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/sub-c")
+            .Respond("application/vnd.api+json",
+                SubscriptionResponse(id: "sub-c", status: "active", cancelled: true));
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetSubscriptionAsync("sub-c", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Status.Should().Be(BillingSubscriptionStatus.Cancelled);
+        result.Value.CanceledAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetSubscriptionAsync_WhenPaused_MapsToPausedAndPopulatesPausedAt()
+    {
+        // Arrange
+        var mock = new MockHttpMessageHandler();
+        mock.When(HttpMethod.Get, BaseUrl + "subscriptions/sub-p")
+            .Respond("application/vnd.api+json",
+                SubscriptionResponse(id: "sub-p", status: "active", paused: true));
+
+        var sut = LemonSqueezyTestHelpers.CreateSubscriptionService(mock, CreateOptions());
+
+        // Act
+        var result = await sut.GetSubscriptionAsync("sub-p", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Status.Should().Be(BillingSubscriptionStatus.Paused);
+        result.Value.PausedAt.Should().NotBeNull();
+        result.Value.ResumesAt.Should().NotBeNull();
+    }
+}

--- a/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Webhooks/LemonSqueezyWebhookHandlerTests.cs
+++ b/tests/Unit/Compendium.Adapters.LemonSqueezy.Tests/Webhooks/LemonSqueezyWebhookHandlerTests.cs
@@ -1,0 +1,331 @@
+// -----------------------------------------------------------------------
+// <copyright file="LemonSqueezyWebhookHandlerTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Billing;
+using Compendium.Adapters.LemonSqueezy.Configuration;
+using Compendium.Adapters.LemonSqueezy.Tests.Helpers;
+using FluentAssertions;
+
+namespace Compendium.Adapters.LemonSqueezy.Tests.Webhooks;
+
+/// <summary>
+/// Unit tests for the internal <c>LemonSqueezyWebhookHandler</c> exercised via the public
+/// <see cref="IPaymentWebhookHandler"/> contract. Webhook signatures use HMAC-SHA256 in
+/// lowercase hex format (with optional <c>sha256=</c> prefix).
+/// </summary>
+public class LemonSqueezyWebhookHandlerTests
+{
+    private const string SigningSecret = "ls_whsec_unit_test_secret";
+
+    private const string SamplePayload = """
+    {"meta":{"event_name":"subscription_created","custom_data":{"tenant_id":"tenant-42"}},"data":{"type":"subscriptions","id":"sub_99","attributes":{"status":"active","customer_id":1,"product_id":2,"variant_id":3,"user_email":"alice@example.com"}}}
+    """;
+
+    private static LemonSqueezyOptions CreateOptions(string secret = SigningSecret) => new()
+    {
+        WebhookSigningSecret = secret
+    };
+
+    // ============================================================================
+    // Signature validation
+    // ============================================================================
+
+    [Fact]
+    public async Task ProcessWebhookAsync_ValidSignature_ReturnsSuccess()
+    {
+        // Arrange
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions());
+        var signature = LemonSqueezyTestHelpers.ComputeWebhookSignature(SigningSecret, SamplePayload);
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(SamplePayload, signature, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Processed.Should().BeTrue();
+        result.Value.EventType.Should().Be("subscription_created");
+        result.Value.ResourceType.Should().Be("subscriptions");
+        result.Value.ResourceId.Should().Be("sub_99");
+        result.Value.TenantId.Should().Be("tenant-42");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_ValidSignatureWithSha256Prefix_ReturnsSuccess()
+    {
+        // Arrange — LemonSqueezy supports both raw hex and "sha256=<hex>" headers
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions());
+        var rawSig = LemonSqueezyTestHelpers.ComputeWebhookSignature(SigningSecret, SamplePayload);
+        var signature = "sha256=" + rawSig;
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(SamplePayload, signature, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_InvalidSignature_ReturnsInvalidSignatureError()
+    {
+        // Arrange
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions());
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(SamplePayload, "deadbeef", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.InvalidWebhookSignature");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_SignatureWithDifferentSecret_ReturnsInvalidSignatureError()
+    {
+        // Arrange
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions());
+        var wrongSig = LemonSqueezyTestHelpers.ComputeWebhookSignature("other_secret", SamplePayload);
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(SamplePayload, wrongSig, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.InvalidWebhookSignature");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_EmptySigningSecret_BypassesValidation()
+    {
+        // Arrange — dev mode: no secret means we accept anything
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions(secret: string.Empty));
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(SamplePayload, "irrelevant", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.EventType.Should().Be("subscription_created");
+    }
+
+    // ============================================================================
+    // Payload parsing & validation
+    // ============================================================================
+
+    [Fact]
+    public async Task ProcessWebhookAsync_PayloadNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions());
+
+        // Act
+        var act = async () => await handler.ProcessWebhookAsync(null!, "sig", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_SignatureNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions());
+
+        // Act
+        var act = async () => await handler.ProcessWebhookAsync(SamplePayload, null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_MalformedJson_ReturnsProcessingFailedError()
+    {
+        // Arrange — dev mode lets the malformed payload reach the deserializer
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions(secret: string.Empty));
+
+        // Act
+        var result = await handler.ProcessWebhookAsync("{not-json", string.Empty, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.WebhookProcessingFailed");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_MissingMeta_ReturnsProcessingFailedError()
+    {
+        // Arrange — JSON parses but lacks the required meta object
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions(secret: string.Empty));
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(
+            "{\"data\":{\"type\":\"subscriptions\",\"id\":\"x\"}}",
+            string.Empty,
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.WebhookProcessingFailed");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_MissingEventName_ReturnsUnknownEventType()
+    {
+        // Arrange — empty meta still produces a successful result with EventName = "unknown"
+        var payload = "{\"meta\":{},\"data\":{\"type\":\"sub\",\"id\":\"1\"}}";
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions(secret: string.Empty));
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(payload, string.Empty, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.EventType.Should().Be("unknown");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_NullData_ReturnsSuccessWithoutResourceFields()
+    {
+        // Arrange
+        var payload = "{\"meta\":{\"event_name\":\"order_created\"}}";
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions(secret: string.Empty));
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(payload, string.Empty, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.EventType.Should().Be("order_created");
+        result.Value.ResourceId.Should().BeNull();
+        result.Value.ResourceType.Should().BeNull();
+        result.Value.ExtractedData.Should().BeNull();
+    }
+
+    // ============================================================================
+    // Event type dispatch (covers every switch arm)
+    // ============================================================================
+
+    [Theory]
+    [InlineData("subscription_created")]
+    [InlineData("subscription_updated")]
+    [InlineData("subscription_cancelled")]
+    [InlineData("subscription_resumed")]
+    [InlineData("subscription_expired")]
+    [InlineData("subscription_paused")]
+    [InlineData("subscription_unpaused")]
+    [InlineData("subscription_payment_success")]
+    [InlineData("subscription_payment_failed")]
+    [InlineData("subscription_payment_recovered")]
+    [InlineData("order_created")]
+    [InlineData("order_refunded")]
+    [InlineData("license_key_created")]
+    [InlineData("license_key_updated")]
+    [InlineData("totally_unknown_event")]
+    public async Task ProcessWebhookAsync_AcknowledgesAllSupportedAndUnknownEvents(string eventName)
+    {
+        // Arrange
+        var payload = "{\"meta\":{\"event_name\":\"" + eventName + "\"},\"data\":{\"type\":\"x\",\"id\":\"1\"}}";
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions(secret: string.Empty));
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(payload, string.Empty, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.EventType.Should().Be(eventName);
+    }
+
+    // ============================================================================
+    // Data extraction
+    // ============================================================================
+
+    [Fact]
+    public async Task ProcessWebhookAsync_FullAttributesPayload_ExtractsKnownFields()
+    {
+        // Arrange
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions(secret: string.Empty));
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(SamplePayload, string.Empty, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExtractedData.Should().NotBeNull();
+        var data = result.Value.ExtractedData!;
+        data.Should().ContainKey("resource_id");
+        data.Should().ContainKey("resource_type");
+        data.Should().ContainKey("status");
+        data.Should().ContainKey("customer_id");
+        data.Should().ContainKey("product_id");
+        data.Should().ContainKey("variant_id");
+        data.Should().ContainKey("user_email");
+        data["status"].Should().Be("active");
+        data["user_email"].Should().Be("alice@example.com");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_PayloadWithCustomData_PrefixesCustomKeys()
+    {
+        // Arrange
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions(secret: string.Empty));
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(SamplePayload, string.Empty, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExtractedData.Should().NotBeNull();
+        result.Value.ExtractedData!.Should().ContainKey("custom_tenant_id");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_NoTenantIdInCustomData_ReturnsNullTenantId()
+    {
+        // Arrange
+        var payload = "{\"meta\":{\"event_name\":\"order_created\"},\"data\":{\"type\":\"orders\",\"id\":\"o-1\"}}";
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions(secret: string.Empty));
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(payload, string.Empty, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TenantId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_DataMissingTypeAndId_ReturnsNullResourceFields()
+    {
+        // Arrange
+        var payload = "{\"meta\":{\"event_name\":\"order_created\"},\"data\":{}}";
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions(secret: string.Empty));
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(payload, string.Empty, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ResourceType.Should().BeNull();
+        result.Value.ResourceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_DataIsNotObject_StillSucceedsWithoutResourceFields()
+    {
+        // Arrange — data is a string instead of an object; must not throw
+        var payload = "{\"meta\":{\"event_name\":\"order_created\"},\"data\":\"not-an-object\"}";
+        var handler = LemonSqueezyTestHelpers.CreateWebhookHandler(CreateOptions(secret: string.Empty));
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(payload, string.Empty, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ResourceId.Should().BeNull();
+        result.Value.ResourceType.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
Tops up `Compendium.Adapters.LemonSqueezy` from 10.9 % → **98.2 %** line coverage. Part of the testing campaign (VK POM-471).

## Coverage report — Compendium.Adapters.LemonSqueezy
- Tests added: **147** (170 total - 23 existing)
- Existing tests preserved: 23 (Configuration + DependencyInjection)
- Test files added:
  - `Helpers/LemonSqueezyTestHelpers.cs` — reflection helpers for instantiating the adapter's `internal sealed` services without modifying `src/`
  - `Http/LemonSqueezyHttpClientTests.cs` — direct tests of the internal HTTP client (GetCheckout, GetLicenseKey, ListLicenseKeyInstances, error mapping, HttpRequestException paths, auth header)
  - `Http/LemonSqueezyApiModelsTests.cs` — drives full JSON:API payloads through the client to populate every DTO record's accessors
  - `Services/LemonSqueezyBillingServiceTests.cs` — checkout / customer / portal flows, all error paths
  - `Services/LemonSqueezySubscriptionServiceTests.cs` — get/list/cancel/pause/resume/update + every status mapping arm
  - `Services/LemonSqueezyLicenseServiceTests.cs` — validate/activate/deactivate, expired-license branch, activation-limit detection
  - `Webhooks/LemonSqueezyWebhookHandlerTests.cs` — HMAC-SHA256 signature validation (with and without `sha256=` prefix), payload parsing, all 14 supported event types + unknown
- **Line coverage: 10.9 % → 98.2 %**
- **Branch coverage: 4.6 % → 85.3 %**
- Per-class coverage:
  - `LemonSqueezyOptions` — 100 %
  - `ServiceCollectionExtensions` — 95.9 %
  - `LemonSqueezyHttpClient` — 94.6 %
  - `LemonSqueezyBillingService` / `SubscriptionService` / `LicenseService` — 100 %
  - `LemonSqueezyWebhookHandler` — 97.3 %
  - All `Ls*` / `JsonApi*` model records — 100 % (except `LsWebhookMeta` 66.6 %, `JsonApiCollectionResponse<T>` 50 % — JSON:API meta fields not used in current adapter flows)
- Bugs surfaced: 0
- Types excluded as integration-only: none (everything HTTP-driven was covered with `RichardSzalay.MockHttp`)

## Approach
- The adapter exposes only interfaces (`IBillingService`, `ISubscriptionService`, `ILicenseService`, `IPaymentWebhookHandler`); concrete classes are `internal sealed`. `LemonSqueezyTestHelpers` uses reflection to instantiate them — no `InternalsVisibleTo` was added, no production code was modified.
- HTTP traffic is mocked with `RichardSzalay.MockHttp` (already centrally pinned at 7.0.0). No real network or DB calls.
- Webhook tests reproduce the LemonSqueezy HMAC-SHA256 lowercase-hex signature scheme.

## Test plan
- [x] `dotnet build Compendium.sln -c Release` green (0 errors)
- [x] `dotnet test tests/Unit/Compendium.Adapters.LemonSqueezy.Tests -c Release` green (170/170 passing, ~90 ms)
- [x] No prod code modified (`src/Adapters/Compendium.Adapters.LemonSqueezy/` untouched)
- [x] No version bumps in `Directory.Packages.props`
- [x] No Moq, no `Assert.*`, no `Thread.Sleep`
- [x] Two consecutive runs identical — no flakes
- [ ] CI green