### PR TITLE
test(core): top up coverage to 90%

### DIFF
--- a/tests/Unit/Compendium.Core.Tests/Domain/Events/DomainEventBaseJsonConstructorTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/Domain/Events/DomainEventBaseJsonConstructorTests.cs
@@ -1,0 +1,89 @@
+// -----------------------------------------------------------------------
+// <copyright file="DomainEventBaseJsonConstructorTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Compendium.Core.Tests.Domain.Events;
+
+/// <summary>
+/// Verifies that <see cref="DomainEventBase"/> can be deserialized via its
+/// <see cref="JsonConstructorAttribute"/>-decorated constructor — exercising the
+/// restoration path for AggregateId / AggregateType / OccurredOn / AggregateVersion / EventVersion.
+/// </summary>
+public class DomainEventBaseJsonConstructorTests
+{
+    /// <summary>
+    /// Concrete derived event whose own constructor delegates to the JSON constructor of
+    /// <see cref="DomainEventBase"/>. We expose both constructors so that
+    /// System.Text.Json picks the JSON one when deserialising.
+    /// </summary>
+    private sealed class JsonRoundTripEvent : DomainEventBase
+    {
+        public JsonRoundTripEvent(string aggregateId, string aggregateType, long aggregateVersion, string payload)
+            : base(aggregateId, aggregateType, aggregateVersion)
+        {
+            Payload = payload;
+        }
+
+        [JsonConstructor]
+        public JsonRoundTripEvent(
+            Guid eventId,
+            string aggregateId,
+            string aggregateType,
+            DateTimeOffset occurredOn,
+            long aggregateVersion,
+            int eventVersion,
+            string payload)
+            : base(eventId, aggregateId, aggregateType, occurredOn, aggregateVersion, eventVersion)
+        {
+            Payload = payload;
+        }
+
+        public string Payload { get; }
+    }
+
+    [Fact]
+    public void DomainEventBase_JsonConstructor_RestoresAllProperties()
+    {
+        // Arrange
+        var original = new JsonRoundTripEvent("agg-1", "Test", 42, "hello");
+        var json = JsonSerializer.Serialize(original);
+
+        // Act
+        var restored = JsonSerializer.Deserialize<JsonRoundTripEvent>(json);
+
+        // Assert
+        restored.Should().NotBeNull();
+        restored!.EventId.Should().Be(original.EventId);
+        restored.AggregateId.Should().Be(original.AggregateId);
+        restored.AggregateType.Should().Be(original.AggregateType);
+        restored.AggregateVersion.Should().Be(original.AggregateVersion);
+        restored.EventVersion.Should().Be(original.EventVersion);
+        restored.OccurredOn.Should().Be(original.OccurredOn);
+        restored.Payload.Should().Be("hello");
+    }
+
+    [Fact]
+    public void DomainEventBase_JsonConstructor_AllowsCustomEventVersion()
+    {
+        // Arrange
+        var original = new JsonRoundTripEvent(
+            eventId: Guid.NewGuid(),
+            aggregateId: "agg-1",
+            aggregateType: "Test",
+            occurredOn: DateTimeOffset.Parse("2026-05-10T00:00:00Z"),
+            aggregateVersion: 7,
+            eventVersion: 3,
+            payload: "x");
+
+        // Act / Assert
+        original.EventVersion.Should().Be(3);
+        original.AggregateVersion.Should().Be(7);
+        original.AggregateId.Should().Be("agg-1");
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/BillingIntegrationEventsTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/BillingIntegrationEventsTests.cs
@@ -1,0 +1,247 @@
+// -----------------------------------------------------------------------
+// <copyright file="BillingIntegrationEventsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.Domain.Events.Integration;
+
+namespace Compendium.Core.Tests.Domain.Events.Integration;
+
+/// <summary>
+/// Unit tests for billing integration event records covering EventType, all positional
+/// parameters, default IntegrationEventBase metadata and structural equality.
+/// </summary>
+public class BillingIntegrationEventsTests
+{
+    [Fact]
+    public void SubscriptionUpdatedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var start = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new SubscriptionUpdatedEvent(
+            SubscriptionId: "sub-1",
+            CustomerId: "cust-2",
+            PlanId: "plan-new",
+            PreviousPlanId: "plan-old",
+            Status: "active",
+            ChangeType: "upgrade");
+
+        // Assert
+        evt.EventType.Should().Be("billing.subscription.updated");
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.CustomerId.Should().Be("cust-2");
+        evt.PlanId.Should().Be("plan-new");
+        evt.PreviousPlanId.Should().Be("plan-old");
+        evt.Status.Should().Be("active");
+        evt.ChangeType.Should().Be("upgrade");
+        evt.EventVersion.Should().Be(1);
+        evt.EventId.Should().NotBe(Guid.Empty);
+        evt.OccurredOn.Should().BeOnOrAfter(start);
+    }
+
+    [Fact]
+    public void SubscriptionPausedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var paused = DateTimeOffset.UtcNow;
+        var resume = paused.AddDays(7);
+
+        // Act
+        var evt = new SubscriptionPausedEvent("sub-1", "cust-1", paused, resume);
+
+        // Assert
+        evt.EventType.Should().Be("billing.subscription.paused");
+        evt.PausedAt.Should().Be(paused);
+        evt.ResumeAt.Should().Be(resume);
+    }
+
+    [Fact]
+    public void SubscriptionPausedEvent_WithNullResumeAt_AllowsNull()
+    {
+        // Act
+        var evt = new SubscriptionPausedEvent("sub-1", "cust-1", DateTimeOffset.UtcNow, ResumeAt: null);
+
+        // Assert
+        evt.ResumeAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void SubscriptionResumedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var resumedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new SubscriptionResumedEvent("sub-1", "cust-1", resumedAt);
+
+        // Assert
+        evt.EventType.Should().Be("billing.subscription.resumed");
+        evt.ResumedAt.Should().Be(resumedAt);
+    }
+
+    [Fact]
+    public void SubscriptionTrialStartedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var start = DateTimeOffset.UtcNow;
+        var end = start.AddDays(14);
+
+        // Act
+        var evt = new SubscriptionTrialStartedEvent("sub-1", "cust-1", "plan-pro", start, end);
+
+        // Assert
+        evt.EventType.Should().Be("billing.subscription.trial_started");
+        evt.PlanId.Should().Be("plan-pro");
+        evt.TrialStart.Should().Be(start);
+        evt.TrialEnd.Should().Be(end);
+    }
+
+    [Fact]
+    public void SubscriptionTrialEndedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var trialEnd = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new SubscriptionTrialEndedEvent("sub-1", "cust-1", trialEnd, ConvertedToPaid: true);
+
+        // Assert
+        evt.EventType.Should().Be("billing.subscription.trial_ended");
+        evt.TrialEnd.Should().Be(trialEnd);
+        evt.ConvertedToPaid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void InvoiceCreatedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var due = DateTimeOffset.UtcNow.AddDays(30);
+
+        // Act
+        var evt = new InvoiceCreatedEvent("inv-1", "cust-1", "sub-1", 12000, "EUR", due);
+
+        // Assert
+        evt.EventType.Should().Be("billing.invoice.created");
+        evt.InvoiceId.Should().Be("inv-1");
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.Amount.Should().Be(12000);
+        evt.Currency.Should().Be("EUR");
+        evt.DueDate.Should().Be(due);
+    }
+
+    [Fact]
+    public void InvoiceCreatedEvent_WithNullSubscriptionId_AllowsNull()
+    {
+        // Act
+        var evt = new InvoiceCreatedEvent("inv-1", "cust-1", SubscriptionId: null, 100, "USD", DateTimeOffset.UtcNow);
+
+        // Assert
+        evt.SubscriptionId.Should().BeNull();
+    }
+
+    [Fact]
+    public void InvoicePaidEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var paid = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new InvoicePaidEvent("inv-1", "cust-1", "pay-1", 12000, "USD", paid);
+
+        // Assert
+        evt.EventType.Should().Be("billing.invoice.paid");
+        evt.InvoiceId.Should().Be("inv-1");
+        evt.PaymentId.Should().Be("pay-1");
+        evt.PaidAt.Should().Be(paid);
+    }
+
+    [Fact]
+    public void BillingCustomerCreatedEvent_Constructor_SetsAllProperties()
+    {
+        // Act
+        var evt = new BillingCustomerCreatedEvent("cust-1", "user@example.com", "John", "ext-42");
+
+        // Assert
+        evt.EventType.Should().Be("billing.customer.created");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.Email.Should().Be("user@example.com");
+        evt.Name.Should().Be("John");
+        evt.ExternalId.Should().Be("ext-42");
+    }
+
+    [Fact]
+    public void BillingCustomerCreatedEvent_WithNullableNullValues_AllowsNull()
+    {
+        // Act
+        var evt = new BillingCustomerCreatedEvent("cust-1", "user@example.com", Name: null, ExternalId: null);
+
+        // Assert
+        evt.Name.Should().BeNull();
+        evt.ExternalId.Should().BeNull();
+    }
+
+    [Fact]
+    public void BillingCustomerUpdatedEvent_Constructor_SetsAllProperties()
+    {
+        // Act
+        var evt = new BillingCustomerUpdatedEvent("cust-1", "u@example.com", "Jane");
+
+        // Assert
+        evt.EventType.Should().Be("billing.customer.updated");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.Email.Should().Be("u@example.com");
+        evt.Name.Should().Be("Jane");
+    }
+
+    [Fact]
+    public void CheckoutCompletedEvent_Constructor_SetsAllProperties()
+    {
+        // Act
+        var evt = new CheckoutCompletedEvent(
+            SessionId: "sess-1",
+            CustomerId: "cust-1",
+            SubscriptionId: "sub-1",
+            Amount: 4999,
+            Currency: "USD",
+            ProductId: "prod-1",
+            VariantId: "var-1");
+
+        // Assert
+        evt.EventType.Should().Be("billing.checkout.completed");
+        evt.SessionId.Should().Be("sess-1");
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.ProductId.Should().Be("prod-1");
+        evt.VariantId.Should().Be("var-1");
+    }
+
+    [Fact]
+    public void CheckoutCompletedEvent_WithoutSubscriptionAndVariant_AllowsNulls()
+    {
+        // Act
+        var evt = new CheckoutCompletedEvent("sess-1", "cust-1", null, 100, "USD", "prod-1", null);
+
+        // Assert
+        evt.SubscriptionId.Should().BeNull();
+        evt.VariantId.Should().BeNull();
+    }
+
+    [Fact]
+    public void BillingEvents_AreRecords_SupportingValueEquality()
+    {
+        // Arrange
+        var paid = DateTimeOffset.Parse("2026-01-15T10:00:00Z");
+        var a = new InvoicePaidEvent("inv-1", "cust-1", "pay-1", 1000, "USD", paid);
+        var b = new InvoicePaidEvent("inv-1", "cust-1", "pay-1", 1000, "USD", paid);
+
+        // Act & Assert
+        // Records compare by value AND inherited init properties. EventId differs so they will
+        // not be equal — but the positional record component portion should be reflected in the
+        // generated PrintMembers. Verify identity is per-instance (different EventIds).
+        a.EventId.Should().NotBe(b.EventId);
+        a.InvoiceId.Should().Be(b.InvoiceId);
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/IdentityIntegrationEventsTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/IdentityIntegrationEventsTests.cs
@@ -1,0 +1,277 @@
+// -----------------------------------------------------------------------
+// <copyright file="IdentityIntegrationEventsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.Domain.Events.Integration;
+
+namespace Compendium.Core.Tests.Domain.Events.Integration;
+
+/// <summary>
+/// Unit tests for identity integration event records.
+/// </summary>
+public class IdentityIntegrationEventsTests
+{
+    [Fact]
+    public void UserUpdatedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var changed = new[] { "Email", "FirstName" };
+
+        // Act
+        var evt = new UserUpdatedEvent("user-1", "u@x.com", "alice", "Alice", "Doe", changed);
+
+        // Assert
+        evt.EventType.Should().Be("identity.user.updated");
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.Username.Should().Be("alice");
+        evt.FirstName.Should().Be("Alice");
+        evt.LastName.Should().Be("Doe");
+        evt.ChangedFields.Should().BeEquivalentTo(changed);
+    }
+
+    [Fact]
+    public void UserUpdatedEvent_WithNullableNulls_AllowsNullValues()
+    {
+        // Act
+        var evt = new UserUpdatedEvent("user-1", "u@x.com", null, null, null, Array.Empty<string>());
+
+        // Assert
+        evt.Username.Should().BeNull();
+        evt.FirstName.Should().BeNull();
+        evt.LastName.Should().BeNull();
+        evt.ChangedFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void UserDeletedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var deletedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new UserDeletedEvent("user-1", "u@x.com", deletedAt, IsSoftDelete: true);
+
+        // Assert
+        evt.EventType.Should().Be("identity.user.deleted");
+        evt.DeletedAt.Should().Be(deletedAt);
+        evt.IsSoftDelete.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UserEmailVerifiedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var verifiedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new UserEmailVerifiedEvent("user-1", "u@x.com", verifiedAt);
+
+        // Assert
+        evt.EventType.Should().Be("identity.user.email_verified");
+        evt.VerifiedAt.Should().Be(verifiedAt);
+    }
+
+    [Fact]
+    public void UserEmailChangedEvent_Constructor_SetsAllProperties()
+    {
+        // Act
+        var evt = new UserEmailChangedEvent("user-1", "old@x.com", "new@x.com", IsNewEmailVerified: false);
+
+        // Assert
+        evt.EventType.Should().Be("identity.user.email_changed");
+        evt.OldEmail.Should().Be("old@x.com");
+        evt.NewEmail.Should().Be("new@x.com");
+        evt.IsNewEmailVerified.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UserLockedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var lockedAt = DateTimeOffset.UtcNow;
+        var until = lockedAt.AddDays(1);
+
+        // Act
+        var evt = new UserLockedEvent("user-1", "u@x.com", "too-many-failures", lockedAt, until);
+
+        // Assert
+        evt.EventType.Should().Be("identity.user.locked");
+        evt.Reason.Should().Be("too-many-failures");
+        evt.LockedAt.Should().Be(lockedAt);
+        evt.LockedUntil.Should().Be(until);
+    }
+
+    [Fact]
+    public void UserLockedEvent_WithoutLockedUntil_AllowsNull()
+    {
+        // Act
+        var evt = new UserLockedEvent("user-1", "u@x.com", "permanent", DateTimeOffset.UtcNow, LockedUntil: null);
+
+        // Assert
+        evt.LockedUntil.Should().BeNull();
+    }
+
+    [Fact]
+    public void UserUnlockedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var unlocked = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new UserUnlockedEvent("user-1", "u@x.com", unlocked);
+
+        // Assert
+        evt.EventType.Should().Be("identity.user.unlocked");
+        evt.UnlockedAt.Should().Be(unlocked);
+    }
+
+    [Fact]
+    public void UserLoggedOutEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var logoutAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new UserLoggedOutEvent("user-1", "u@x.com", logoutAt, "session-123");
+
+        // Assert
+        evt.EventType.Should().Be("identity.user.logged_out");
+        evt.LogoutAt.Should().Be(logoutAt);
+        evt.SessionId.Should().Be("session-123");
+    }
+
+    [Fact]
+    public void UserLoggedOutEvent_WithNullSessionId_AllowsNull()
+    {
+        // Act
+        var evt = new UserLoggedOutEvent("user-1", "u@x.com", DateTimeOffset.UtcNow, SessionId: null);
+
+        // Assert
+        evt.SessionId.Should().BeNull();
+    }
+
+    [Fact]
+    public void UserPasswordChangedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var changedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new UserPasswordChangedEvent("user-1", "u@x.com", changedAt, WasReset: true);
+
+        // Assert
+        evt.EventType.Should().Be("identity.user.password_changed");
+        evt.ChangedAt.Should().Be(changedAt);
+        evt.WasReset.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UserRoleRemovedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var removedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new UserRoleRemovedEvent("user-1", "u@x.com", "role-1", "Admin", removedAt, "actor-1");
+
+        // Assert
+        evt.EventType.Should().Be("identity.user.role_removed");
+        evt.RoleId.Should().Be("role-1");
+        evt.RoleName.Should().Be("Admin");
+        evt.RemovedAt.Should().Be(removedAt);
+        evt.RemovedBy.Should().Be("actor-1");
+    }
+
+    [Fact]
+    public void UserMfaEnabledEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var enabledAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new UserMfaEnabledEvent("user-1", "u@x.com", "TOTP", enabledAt);
+
+        // Assert
+        evt.EventType.Should().Be("identity.user.mfa_enabled");
+        evt.MfaType.Should().Be("TOTP");
+        evt.EnabledAt.Should().Be(enabledAt);
+    }
+
+    [Fact]
+    public void UserMfaDisabledEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var disabledAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new UserMfaDisabledEvent("user-1", "u@x.com", "WebAuthn", disabledAt);
+
+        // Assert
+        evt.EventType.Should().Be("identity.user.mfa_disabled");
+        evt.MfaType.Should().Be("WebAuthn");
+        evt.DisabledAt.Should().Be(disabledAt);
+    }
+
+    [Fact]
+    public void OrganizationUpdatedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var changed = new List<string> { "Name", "Domain" };
+
+        // Act
+        var evt = new OrganizationUpdatedEvent("org-1", "Acme", "acme.com", changed);
+
+        // Assert
+        evt.EventType.Should().Be("identity.organization.updated");
+        evt.OrganizationId.Should().Be("org-1");
+        evt.Name.Should().Be("Acme");
+        evt.Domain.Should().Be("acme.com");
+        evt.ChangedFields.Should().BeEquivalentTo(changed);
+    }
+
+    [Fact]
+    public void OrganizationMemberAddedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var added = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new OrganizationMemberAddedEvent("org-1", "user-1", "u@x.com", "Member", added, "owner-1");
+
+        // Assert
+        evt.EventType.Should().Be("identity.organization.member_added");
+        evt.OrganizationId.Should().Be("org-1");
+        evt.Role.Should().Be("Member");
+        evt.AddedAt.Should().Be(added);
+        evt.AddedBy.Should().Be("owner-1");
+    }
+
+    [Fact]
+    public void OrganizationMemberRemovedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var removed = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new OrganizationMemberRemovedEvent("org-1", "user-1", "u@x.com", removed, "owner-1");
+
+        // Assert
+        evt.EventType.Should().Be("identity.organization.member_removed");
+        evt.RemovedAt.Should().Be(removed);
+        evt.RemovedBy.Should().Be("owner-1");
+    }
+
+    [Fact]
+    public void OrganizationMemberRemovedEvent_WithNullRemovedBy_AllowsNull()
+    {
+        // Act
+        var evt = new OrganizationMemberRemovedEvent("org-1", "user-1", "u@x.com", DateTimeOffset.UtcNow, RemovedBy: null);
+
+        // Assert
+        evt.RemovedBy.Should().BeNull();
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/IntegrationEventPropertyReadTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/IntegrationEventPropertyReadTests.cs
@@ -1,0 +1,961 @@
+// -----------------------------------------------------------------------
+// <copyright file="IntegrationEventPropertyReadTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.Domain.Events.Integration;
+
+namespace Compendium.Core.Tests.Domain.Events.Integration;
+
+/// <summary>
+/// Reads every positional record property on the integration events so the auto-generated
+/// property getters are reached by the coverage collector. Each test asserts the round-trip
+/// of the supplied constructor arguments, which is also a smoke check that the records
+/// expose every field (no typos, no missing setters).
+/// </summary>
+public class IntegrationEventPropertyReadTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-05-10T12:00:00Z");
+
+    [Fact]
+    public void RefundIssuedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new RefundIssuedEvent("ref-1", "pay-1", "cust-1", 1000, "USD", "duplicate", IsPartial: true);
+
+        // Assert — read every positional component to exercise all generated getters.
+        evt.RefundId.Should().Be("ref-1");
+        evt.PaymentId.Should().Be("pay-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.Amount.Should().Be(1000);
+        evt.Currency.Should().Be("USD");
+        evt.Reason.Should().Be("duplicate");
+        evt.IsPartial.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PaymentSucceededEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new PaymentSucceededEvent("pay-1", "cust-1", "sub-1", 9999, "EUR", "card", "inv-1");
+
+        // Assert
+        evt.PaymentId.Should().Be("pay-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.Amount.Should().Be(9999);
+        evt.Currency.Should().Be("EUR");
+        evt.PaymentMethod.Should().Be("card");
+        evt.InvoiceId.Should().Be("inv-1");
+    }
+
+    [Fact]
+    public void PaymentFailedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new PaymentFailedEvent("pay-1", "cust-1", "sub-1", 100, "USD", "decline", "card declined", 3);
+
+        // Assert
+        evt.PaymentId.Should().Be("pay-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.Amount.Should().Be(100);
+        evt.Currency.Should().Be("USD");
+        evt.FailureCode.Should().Be("decline");
+        evt.FailureMessage.Should().Be("card declined");
+        evt.AttemptCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void SubscriptionCancelledEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new SubscriptionCancelledEvent("sub-1", "cust-1", "user-request", Now, ImmediateCancel: false);
+
+        // Assert
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.CancellationReason.Should().Be("user-request");
+        evt.EffectiveDate.Should().Be(Now);
+        evt.ImmediateCancel.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SubscriptionResumedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new SubscriptionResumedEvent("sub-1", "cust-1", Now);
+
+        // Assert
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.ResumedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void LicenseCreatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new LicenseCreatedEvent("lic-1", "K-1", "cust-1", "prod-1", "active", Now, ActivationLimit: 5);
+
+        // Assert
+        evt.LicenseId.Should().Be("lic-1");
+        evt.LicenseKey.Should().Be("K-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.ProductId.Should().Be("prod-1");
+        evt.Status.Should().Be("active");
+        evt.ExpiresAt.Should().Be(Now);
+        evt.ActivationLimit.Should().Be(5);
+    }
+
+    [Fact]
+    public void LicenseActivatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new LicenseActivatedEvent("lic-1", "K-1", "inst-1", "Work PC", 1, 5, Now);
+
+        // Assert
+        evt.LicenseId.Should().Be("lic-1");
+        evt.LicenseKey.Should().Be("K-1");
+        evt.InstanceId.Should().Be("inst-1");
+        evt.InstanceName.Should().Be("Work PC");
+        evt.ActivationCount.Should().Be(1);
+        evt.ActivationLimit.Should().Be(5);
+        evt.ActivatedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void LicenseDeactivatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new LicenseDeactivatedEvent("lic-1", "K-1", "inst-1", 0, Now);
+
+        // Assert
+        evt.LicenseId.Should().Be("lic-1");
+        evt.LicenseKey.Should().Be("K-1");
+        evt.InstanceId.Should().Be("inst-1");
+        evt.ActivationCount.Should().Be(0);
+        evt.DeactivatedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void LicenseRenewedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange
+        var prev = Now;
+        var next = Now.AddYears(1);
+
+        // Act
+        var evt = new LicenseRenewedEvent("lic-1", "K-1", "cust-1", prev, next);
+
+        // Assert
+        evt.LicenseId.Should().Be("lic-1");
+        evt.LicenseKey.Should().Be("K-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.PreviousExpiresAt.Should().Be(prev);
+        evt.NewExpiresAt.Should().Be(next);
+    }
+
+    [Fact]
+    public void LicenseRevokedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new LicenseRevokedEvent("lic-1", "K-1", "cust-1", "fraud", Now);
+
+        // Assert
+        evt.LicenseId.Should().Be("lic-1");
+        evt.LicenseKey.Should().Be("K-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.Reason.Should().Be("fraud");
+        evt.RevokedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void UserCreatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserCreatedEvent("user-1", "u@x.com", "alice", "Alice", "Doe", IsEmailVerified: true);
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.Username.Should().Be("alice");
+        evt.FirstName.Should().Be("Alice");
+        evt.LastName.Should().Be("Doe");
+        evt.IsEmailVerified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UserLoggedInEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserLoggedInEvent("user-1", "u@x.com", Now, "1.2.3.4", "Mozilla/5.0", "password");
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.LoginAt.Should().Be(Now);
+        evt.IpAddress.Should().Be("1.2.3.4");
+        evt.UserAgent.Should().Be("Mozilla/5.0");
+        evt.AuthMethod.Should().Be("password");
+    }
+
+    [Fact]
+    public void UserEmailVerifiedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserEmailVerifiedEvent("user-1", "u@x.com", Now);
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.VerifiedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void UserUnlockedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserUnlockedEvent("user-1", "u@x.com", Now);
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.UnlockedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void UserRoleAssignedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserRoleAssignedEvent("user-1", "u@x.com", "role-1", "Admin", Now, "owner-1");
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.RoleId.Should().Be("role-1");
+        evt.RoleName.Should().Be("Admin");
+        evt.AssignedAt.Should().Be(Now);
+        evt.AssignedBy.Should().Be("owner-1");
+    }
+
+    [Fact]
+    public void OrganizationCreatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new OrganizationCreatedEvent("org-1", "Acme", "acme.com", "owner-1");
+
+        // Assert
+        evt.OrganizationId.Should().Be("org-1");
+        evt.Name.Should().Be("Acme");
+        evt.Domain.Should().Be("acme.com");
+        evt.OwnerId.Should().Be("owner-1");
+    }
+
+    [Fact]
+    public void OrganizationMemberAddedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new OrganizationMemberAddedEvent("org-1", "user-1", "u@x.com", "Member", Now, "owner-1");
+
+        // Assert
+        evt.OrganizationId.Should().Be("org-1");
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.Role.Should().Be("Member");
+        evt.AddedAt.Should().Be(Now);
+        evt.AddedBy.Should().Be("owner-1");
+    }
+
+    [Fact]
+    public void OrganizationMemberRemovedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new OrganizationMemberRemovedEvent("org-1", "user-1", "u@x.com", Now, "owner-1");
+
+        // Assert
+        evt.OrganizationId.Should().Be("org-1");
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.RemovedAt.Should().Be(Now);
+        evt.RemovedBy.Should().Be("owner-1");
+    }
+
+    [Fact]
+    public void SubscriberSubscribedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new SubscriberSubscribedEvent("sub-1", "u@x.com", "list-1", "Newsletter", Now, "web", IsDoubleOptIn: true);
+
+        // Assert
+        evt.SubscriberId.Should().Be("sub-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.ListId.Should().Be("list-1");
+        evt.ListName.Should().Be("Newsletter");
+        evt.SubscribedAt.Should().Be(Now);
+        evt.SubscriptionMethod.Should().Be("web");
+        evt.IsDoubleOptIn.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SubscriberUnsubscribedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new SubscriberUnsubscribedEvent("sub-1", "u@x.com", "list-1", "Newsletter", Now, "no longer", "link");
+
+        // Assert
+        evt.SubscriberId.Should().Be("sub-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.ListId.Should().Be("list-1");
+        evt.ListName.Should().Be("Newsletter");
+        evt.UnsubscribedAt.Should().Be(Now);
+        evt.UnsubscribeReason.Should().Be("no longer");
+        evt.UnsubscribeMethod.Should().Be("link");
+    }
+
+    [Fact]
+    public void SubscriberConfirmedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new SubscriberConfirmedEvent("sub-1", "u@x.com", "list-1", "Newsletter", Now);
+
+        // Assert
+        evt.SubscriberId.Should().Be("sub-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.ListId.Should().Be("list-1");
+        evt.ListName.Should().Be("Newsletter");
+        evt.ConfirmedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void SubscriberBouncedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new SubscriberBouncedEvent("sub-1", "u@x.com", "hard", "no-mailbox", Now, "camp-1");
+
+        // Assert
+        evt.SubscriberId.Should().Be("sub-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.BounceType.Should().Be("hard");
+        evt.BounceReason.Should().Be("no-mailbox");
+        evt.BouncedAt.Should().Be(Now);
+        evt.CampaignId.Should().Be("camp-1");
+    }
+
+    [Fact]
+    public void SubscriberComplainedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new SubscriberComplainedEvent("sub-1", "u@x.com", Now, "camp-1");
+
+        // Assert
+        evt.SubscriberId.Should().Be("sub-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.ComplainedAt.Should().Be(Now);
+        evt.CampaignId.Should().Be("camp-1");
+    }
+
+    [Fact]
+    public void SubscriberBlocklistedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new SubscriberBlocklistedEvent("sub-1", "u@x.com", "spam", Now);
+
+        // Assert
+        evt.SubscriberId.Should().Be("sub-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.BlocklistReason.Should().Be("spam");
+        evt.BlocklistedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void SubscriberAttributesUpdatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange
+        var attrs = new Dictionary<string, string?> { ["k"] = "v" };
+
+        // Act
+        var evt = new SubscriberAttributesUpdatedEvent("sub-1", "u@x.com", attrs, Now);
+
+        // Assert
+        evt.SubscriberId.Should().Be("sub-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.UpdatedAttributes.Should().BeSameAs(attrs);
+        evt.UpdatedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void CampaignSentEvent_AllPropertiesAreReadable()
+    {
+        // Arrange
+        var lists = new[] { "l1", "l2" };
+
+        // Act
+        var evt = new CampaignSentEvent("camp-1", "Summer", "Sale", lists, 100, Now);
+
+        // Assert
+        evt.CampaignId.Should().Be("camp-1");
+        evt.CampaignName.Should().Be("Summer");
+        evt.Subject.Should().Be("Sale");
+        evt.ListIds.Should().BeSameAs(lists);
+        evt.RecipientCount.Should().Be(100);
+        evt.SentAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void CampaignOpenedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new CampaignOpenedEvent("camp-1", "sub-1", "u@x.com", Now, "1.2.3.4", "ua");
+
+        // Assert
+        evt.CampaignId.Should().Be("camp-1");
+        evt.SubscriberId.Should().Be("sub-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.OpenedAt.Should().Be(Now);
+        evt.IpAddress.Should().Be("1.2.3.4");
+        evt.UserAgent.Should().Be("ua");
+    }
+
+    [Fact]
+    public void CampaignLinkClickedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new CampaignLinkClickedEvent("camp-1", "sub-1", "u@x.com", "https://x", Now, "1.2.3.4");
+
+        // Assert
+        evt.CampaignId.Should().Be("camp-1");
+        evt.SubscriberId.Should().Be("sub-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.LinkUrl.Should().Be("https://x");
+        evt.ClickedAt.Should().Be(Now);
+        evt.IpAddress.Should().Be("1.2.3.4");
+    }
+
+    [Fact]
+    public void ListDeletedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new ListDeletedEvent("list-1", "Old", 42, Now);
+
+        // Assert
+        evt.ListId.Should().Be("list-1");
+        evt.Name.Should().Be("Old");
+        evt.SubscriberCount.Should().Be(42);
+        evt.DeletedAt.Should().Be(Now);
+    }
+
+    // Note: tenancy integration events declare a positional TenantId parameter that shadows
+    // the inherited IntegrationEventBase.TenantId init-property. Due to a known C# record-
+    // inheritance quirk (compiler warns CS8907 "Parameter 'TenantId' is unread"), the positional
+    // value is NOT stored — TenantId remains null unless set via the inherited init syntax.
+    // The tests below exercise the OTHER positional members and verify the documented init-path
+    // behaviour for TenantId.
+    [Fact]
+    public void TenantCreatedEvent_AllPositionalPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new TenantCreatedEvent("tenant-1", "Acme", "acme", "user-1", "pro", IsActive: true)
+        {
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        evt.TenantId.Should().Be("tenant-1");
+        evt.Name.Should().Be("Acme");
+        evt.Identifier.Should().Be("acme");
+        evt.OwnerId.Should().Be("user-1");
+        evt.Plan.Should().Be("pro");
+        evt.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TenantPlanChangedEvent_AllPositionalPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new TenantPlanChangedEvent("tenant-1", "Acme", "starter", "pro", "upgrade", Now)
+        {
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        evt.TenantId.Should().Be("tenant-1");
+        evt.Name.Should().Be("Acme");
+        evt.OldPlan.Should().Be("starter");
+        evt.NewPlan.Should().Be("pro");
+        evt.ChangeType.Should().Be("upgrade");
+        evt.ChangedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void TenantQuotaExceededEvent_AllPositionalPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new TenantQuotaExceededEvent("tenant-1", "Acme", "storage", 110, 100, Now)
+        {
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        evt.TenantId.Should().Be("tenant-1");
+        evt.Name.Should().Be("Acme");
+        evt.QuotaType.Should().Be("storage");
+        evt.CurrentUsage.Should().Be(110);
+        evt.Limit.Should().Be(100);
+        evt.ExceededAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void TransactionalEmailSentEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new TransactionalEmailSentEvent("tx-1", "tpl-1", "u@x.com", "Hi", Now, "sent");
+
+        // Assert
+        evt.TransactionalId.Should().Be("tx-1");
+        evt.TemplateId.Should().Be("tpl-1");
+        evt.RecipientEmail.Should().Be("u@x.com");
+        evt.Subject.Should().Be("Hi");
+        evt.SentAt.Should().Be(Now);
+        evt.Status.Should().Be("sent");
+    }
+
+    [Fact]
+    public void TenantUserAddedEvent_AllPositionalPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new TenantUserAddedEvent("tenant-1", "user-1", "u@x.com", "Owner", Now, "actor")
+        {
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        evt.TenantId.Should().Be("tenant-1");
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.Role.Should().Be("Owner");
+        evt.AddedAt.Should().Be(Now);
+        evt.AddedBy.Should().Be("actor");
+    }
+
+    [Fact]
+    public void TenantUserRoleChangedEvent_AllPositionalPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new TenantUserRoleChangedEvent("tenant-1", "user-1", "u@x.com", "Member", "Owner", Now, "actor")
+        {
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        evt.TenantId.Should().Be("tenant-1");
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.OldRole.Should().Be("Member");
+        evt.NewRole.Should().Be("Owner");
+        evt.ChangedAt.Should().Be(Now);
+        evt.ChangedBy.Should().Be("actor");
+    }
+
+    [Fact]
+    public void TenantSettingsUpdatedEvent_AllPositionalPropertiesAreReadable()
+    {
+        // Arrange
+        var s = new Dictionary<string, string?> { ["k"] = "v" };
+
+        // Act
+        var evt = new TenantSettingsUpdatedEvent("tenant-1", "Acme", "general", s, Now, "actor")
+        {
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        evt.TenantId.Should().Be("tenant-1");
+        evt.Name.Should().Be("Acme");
+        evt.SettingsCategory.Should().Be("general");
+        evt.ChangedSettings.Should().BeSameAs(s);
+        evt.UpdatedAt.Should().Be(Now);
+        evt.UpdatedBy.Should().Be("actor");
+    }
+
+    [Fact]
+    public void TenantSuspendedEvent_AllPositionalPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new TenantSuspendedEvent("tenant-1", "Acme", "non-payment", Now, Now.AddDays(7))
+        {
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        evt.TenantId.Should().Be("tenant-1");
+        evt.Name.Should().Be("Acme");
+        evt.Reason.Should().Be("non-payment");
+        evt.SuspendedAt.Should().Be(Now);
+        evt.SuspendedUntil.Should().Be(Now.AddDays(7));
+    }
+
+    [Fact]
+    public void TenantReactivatedEvent_AllPositionalPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new TenantReactivatedEvent("tenant-1", "Acme", Now)
+        {
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        evt.TenantId.Should().Be("tenant-1");
+        evt.Name.Should().Be("Acme");
+        evt.ReactivatedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void TenantDeletedEvent_AllPositionalPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new TenantDeletedEvent("tenant-1", "Acme", Now, IsSoftDelete: true)
+        {
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        evt.TenantId.Should().Be("tenant-1");
+        evt.Name.Should().Be("Acme");
+        evt.DeletedAt.Should().Be(Now);
+        evt.IsSoftDelete.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TenantUserRemovedEvent_AllPositionalPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new TenantUserRemovedEvent("tenant-1", "user-1", "u@x.com", Now, "actor")
+        {
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        evt.TenantId.Should().Be("tenant-1");
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.RemovedAt.Should().Be(Now);
+        evt.RemovedBy.Should().Be("actor");
+    }
+
+    [Fact]
+    public void TenantUpdatedEvent_AllPositionalPropertiesAreReadable()
+    {
+        // Arrange
+        var changed = new[] { "Name" };
+
+        // Act
+        var evt = new TenantUpdatedEvent("tenant-1", "Acme", "acme", changed)
+        {
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        evt.TenantId.Should().Be("tenant-1");
+        evt.Name.Should().Be("Acme");
+        evt.Identifier.Should().Be("acme");
+        evt.ChangedFields.Should().BeSameAs(changed);
+    }
+
+    [Fact]
+    public void UserDeletedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserDeletedEvent("user-1", "u@x.com", Now, IsSoftDelete: false);
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.DeletedAt.Should().Be(Now);
+        evt.IsSoftDelete.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UserEmailChangedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserEmailChangedEvent("user-1", "old@x.com", "new@x.com", IsNewEmailVerified: true);
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.OldEmail.Should().Be("old@x.com");
+        evt.NewEmail.Should().Be("new@x.com");
+        evt.IsNewEmailVerified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UserLockedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserLockedEvent("user-1", "u@x.com", "many-failures", Now, Now.AddHours(1));
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.Reason.Should().Be("many-failures");
+        evt.LockedAt.Should().Be(Now);
+        evt.LockedUntil.Should().Be(Now.AddHours(1));
+    }
+
+    [Fact]
+    public void UserLoggedOutEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserLoggedOutEvent("user-1", "u@x.com", Now, "session-1");
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.LogoutAt.Should().Be(Now);
+        evt.SessionId.Should().Be("session-1");
+    }
+
+    [Fact]
+    public void UserPasswordChangedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserPasswordChangedEvent("user-1", "u@x.com", Now, WasReset: false);
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.ChangedAt.Should().Be(Now);
+        evt.WasReset.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UserRoleRemovedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserRoleRemovedEvent("user-1", "u@x.com", "role-1", "Admin", Now, "actor");
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.RoleId.Should().Be("role-1");
+        evt.RoleName.Should().Be("Admin");
+        evt.RemovedAt.Should().Be(Now);
+        evt.RemovedBy.Should().Be("actor");
+    }
+
+    [Fact]
+    public void UserMfaEnabledEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserMfaEnabledEvent("user-1", "u@x.com", "TOTP", Now);
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.MfaType.Should().Be("TOTP");
+        evt.EnabledAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void UserMfaDisabledEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new UserMfaDisabledEvent("user-1", "u@x.com", "TOTP", Now);
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.MfaType.Should().Be("TOTP");
+        evt.DisabledAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void OrganizationUpdatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange
+        var changed = new[] { "Name" };
+
+        // Act
+        var evt = new OrganizationUpdatedEvent("org-1", "Acme", "acme.com", changed);
+
+        // Assert
+        evt.OrganizationId.Should().Be("org-1");
+        evt.Name.Should().Be("Acme");
+        evt.Domain.Should().Be("acme.com");
+        evt.ChangedFields.Should().BeSameAs(changed);
+    }
+
+    [Fact]
+    public void UserUpdatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange
+        var changed = new[] { "Email" };
+
+        // Act
+        var evt = new UserUpdatedEvent("user-1", "u@x.com", "alice", "Alice", "Doe", changed);
+
+        // Assert
+        evt.UserId.Should().Be("user-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.Username.Should().Be("alice");
+        evt.FirstName.Should().Be("Alice");
+        evt.LastName.Should().Be("Doe");
+        evt.ChangedFields.Should().BeSameAs(changed);
+    }
+
+    [Fact]
+    public void LicenseExpiredEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new LicenseExpiredEvent("lic-1", "K", "cust-1", "prod-1", Now);
+
+        // Assert
+        evt.LicenseId.Should().Be("lic-1");
+        evt.LicenseKey.Should().Be("K");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.ProductId.Should().Be("prod-1");
+        evt.ExpiredAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void LicenseValidatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new LicenseValidatedEvent("lic-1", "K", "inst-1", IsValid: true, "ok", Now);
+
+        // Assert
+        evt.LicenseId.Should().Be("lic-1");
+        evt.LicenseKey.Should().Be("K");
+        evt.InstanceId.Should().Be("inst-1");
+        evt.IsValid.Should().BeTrue();
+        evt.ValidationMessage.Should().Be("ok");
+        evt.ValidatedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void SubscriptionPausedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new SubscriptionPausedEvent("sub-1", "cust-1", Now, Now.AddDays(7));
+
+        // Assert
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.PausedAt.Should().Be(Now);
+        evt.ResumeAt.Should().Be(Now.AddDays(7));
+    }
+
+    [Fact]
+    public void SubscriptionTrialStartedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new SubscriptionTrialStartedEvent("sub-1", "cust-1", "plan-1", Now, Now.AddDays(14));
+
+        // Assert
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.PlanId.Should().Be("plan-1");
+        evt.TrialStart.Should().Be(Now);
+        evt.TrialEnd.Should().Be(Now.AddDays(14));
+    }
+
+    [Fact]
+    public void SubscriptionTrialEndedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new SubscriptionTrialEndedEvent("sub-1", "cust-1", Now, ConvertedToPaid: true);
+
+        // Assert
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.TrialEnd.Should().Be(Now);
+        evt.ConvertedToPaid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void InvoicePaidEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new InvoicePaidEvent("inv-1", "cust-1", "pay-1", 1000, "USD", Now);
+
+        // Assert
+        evt.InvoiceId.Should().Be("inv-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.PaymentId.Should().Be("pay-1");
+        evt.Amount.Should().Be(1000);
+        evt.Currency.Should().Be("USD");
+        evt.PaidAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void InvoiceCreatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new InvoiceCreatedEvent("inv-1", "cust-1", "sub-1", 1000, "USD", Now);
+
+        // Assert
+        evt.InvoiceId.Should().Be("inv-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.Amount.Should().Be(1000);
+        evt.Currency.Should().Be("USD");
+        evt.DueDate.Should().Be(Now);
+    }
+
+    [Fact]
+    public void CheckoutCompletedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new CheckoutCompletedEvent("sess-1", "cust-1", "sub-1", 999, "USD", "prod-1", "var-1");
+
+        // Assert
+        evt.SessionId.Should().Be("sess-1");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.SubscriptionId.Should().Be("sub-1");
+        evt.Amount.Should().Be(999);
+        evt.Currency.Should().Be("USD");
+        evt.ProductId.Should().Be("prod-1");
+        evt.VariantId.Should().Be("var-1");
+    }
+
+    [Fact]
+    public void BillingCustomerCreatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new BillingCustomerCreatedEvent("cust-1", "u@x.com", "Jane", "ext-1");
+
+        // Assert
+        evt.CustomerId.Should().Be("cust-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.Name.Should().Be("Jane");
+        evt.ExternalId.Should().Be("ext-1");
+    }
+
+    [Fact]
+    public void BillingCustomerUpdatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new BillingCustomerUpdatedEvent("cust-1", "u@x.com", "Jane");
+
+        // Assert
+        evt.CustomerId.Should().Be("cust-1");
+        evt.Email.Should().Be("u@x.com");
+        evt.Name.Should().Be("Jane");
+    }
+
+    [Fact]
+    public void ListCreatedEvent_AllPropertiesAreReadable()
+    {
+        // Arrange / Act
+        var evt = new ListCreatedEvent("list-1", "Friends", "desc", "private", Now);
+
+        // Assert
+        evt.ListId.Should().Be("list-1");
+        evt.Name.Should().Be("Friends");
+        evt.Description.Should().Be("desc");
+        evt.ListType.Should().Be("private");
+        evt.CreatedAt.Should().Be(Now);
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/LicenseIntegrationEventsTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/LicenseIntegrationEventsTests.cs
@@ -1,0 +1,146 @@
+// -----------------------------------------------------------------------
+// <copyright file="LicenseIntegrationEventsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.Domain.Events.Integration;
+
+namespace Compendium.Core.Tests.Domain.Events.Integration;
+
+/// <summary>
+/// Unit tests for license integration event records.
+/// </summary>
+public class LicenseIntegrationEventsTests
+{
+    [Fact]
+    public void LicenseValidatedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var validatedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new LicenseValidatedEvent(
+            LicenseId: "lic-1",
+            LicenseKey: "AAAA-BBBB",
+            InstanceId: "inst-1",
+            IsValid: true,
+            ValidationMessage: "ok",
+            ValidatedAt: validatedAt);
+
+        // Assert
+        evt.EventType.Should().Be("license.validated");
+        evt.LicenseId.Should().Be("lic-1");
+        evt.LicenseKey.Should().Be("AAAA-BBBB");
+        evt.InstanceId.Should().Be("inst-1");
+        evt.IsValid.Should().BeTrue();
+        evt.ValidationMessage.Should().Be("ok");
+        evt.ValidatedAt.Should().Be(validatedAt);
+    }
+
+    [Fact]
+    public void LicenseValidatedEvent_WithNullableNulls_AllowsNullValues()
+    {
+        // Act
+        var evt = new LicenseValidatedEvent("lic-1", "K", InstanceId: null, IsValid: false, ValidationMessage: null, ValidatedAt: DateTimeOffset.UtcNow);
+
+        // Assert
+        evt.InstanceId.Should().BeNull();
+        evt.ValidationMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void LicenseExpiredEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var expiredAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new LicenseExpiredEvent("lic-1", "K", "cust-1", "prod-1", expiredAt);
+
+        // Assert
+        evt.EventType.Should().Be("license.expired");
+        evt.CustomerId.Should().Be("cust-1");
+        evt.ProductId.Should().Be("prod-1");
+        evt.ExpiredAt.Should().Be(expiredAt);
+    }
+
+    [Fact]
+    public void LicenseRenewedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var prev = DateTimeOffset.UtcNow;
+        var next = prev.AddYears(1);
+
+        // Act
+        var evt = new LicenseRenewedEvent("lic-1", "K", "cust-1", prev, next);
+
+        // Assert
+        evt.EventType.Should().Be("license.renewed");
+        evt.PreviousExpiresAt.Should().Be(prev);
+        evt.NewExpiresAt.Should().Be(next);
+    }
+
+    [Fact]
+    public void LicenseRevokedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var revokedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new LicenseRevokedEvent("lic-1", "K", "cust-1", "Fraud", revokedAt);
+
+        // Assert
+        evt.EventType.Should().Be("license.revoked");
+        evt.Reason.Should().Be("Fraud");
+        evt.RevokedAt.Should().Be(revokedAt);
+    }
+
+    [Fact]
+    public void LicenseRevokedEvent_WithNullReason_AllowsNull()
+    {
+        // Act
+        var evt = new LicenseRevokedEvent("lic-1", "K", "cust-1", Reason: null, DateTimeOffset.UtcNow);
+
+        // Assert
+        evt.Reason.Should().BeNull();
+    }
+
+    [Fact]
+    public void LicenseCreatedEvent_WithNullableNulls_AllowsNulls()
+    {
+        // Act
+        var evt = new LicenseCreatedEvent(
+            LicenseId: "lic-1",
+            LicenseKey: "K",
+            CustomerId: "cust-1",
+            ProductId: "prod-1",
+            Status: "issued",
+            ExpiresAt: null,
+            ActivationLimit: null);
+
+        // Assert
+        evt.EventType.Should().Be("license.created");
+        evt.ExpiresAt.Should().BeNull();
+        evt.ActivationLimit.Should().BeNull();
+    }
+
+    [Fact]
+    public void LicenseActivatedEvent_WithNullableNulls_AllowsNulls()
+    {
+        // Act
+        var evt = new LicenseActivatedEvent(
+            LicenseId: "lic-1",
+            LicenseKey: "K",
+            InstanceId: "inst-1",
+            InstanceName: null,
+            ActivationCount: 1,
+            ActivationLimit: null,
+            ActivatedAt: DateTimeOffset.UtcNow);
+
+        // Assert
+        evt.InstanceName.Should().BeNull();
+        evt.ActivationLimit.Should().BeNull();
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/MarketingIntegrationEventsTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/MarketingIntegrationEventsTests.cs
@@ -1,0 +1,225 @@
+// -----------------------------------------------------------------------
+// <copyright file="MarketingIntegrationEventsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.Domain.Events.Integration;
+
+namespace Compendium.Core.Tests.Domain.Events.Integration;
+
+/// <summary>
+/// Unit tests for marketing integration event records.
+/// </summary>
+public class MarketingIntegrationEventsTests
+{
+    [Fact]
+    public void SubscriberConfirmedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var confirmedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new SubscriberConfirmedEvent("sub-1", "u@x.com", "list-1", "Newsletter", confirmedAt);
+
+        // Assert
+        evt.EventType.Should().Be("marketing.subscriber.confirmed");
+        evt.SubscriberId.Should().Be("sub-1");
+        evt.ListId.Should().Be("list-1");
+        evt.ListName.Should().Be("Newsletter");
+        evt.ConfirmedAt.Should().Be(confirmedAt);
+    }
+
+    [Fact]
+    public void SubscriberBouncedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var bouncedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new SubscriberBouncedEvent("sub-1", "u@x.com", "hard", "mailbox-full", bouncedAt, "camp-1");
+
+        // Assert
+        evt.EventType.Should().Be("marketing.subscriber.bounced");
+        evt.BounceType.Should().Be("hard");
+        evt.BounceReason.Should().Be("mailbox-full");
+        evt.BouncedAt.Should().Be(bouncedAt);
+        evt.CampaignId.Should().Be("camp-1");
+    }
+
+    [Fact]
+    public void SubscriberBouncedEvent_WithNullableNulls_AllowsNulls()
+    {
+        // Act
+        var evt = new SubscriberBouncedEvent("sub-1", "u@x.com", "soft", BounceReason: null, DateTimeOffset.UtcNow, CampaignId: null);
+
+        // Assert
+        evt.BounceReason.Should().BeNull();
+        evt.CampaignId.Should().BeNull();
+    }
+
+    [Fact]
+    public void SubscriberComplainedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var complainedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new SubscriberComplainedEvent("sub-1", "u@x.com", complainedAt, "camp-1");
+
+        // Assert
+        evt.EventType.Should().Be("marketing.subscriber.complained");
+        evt.ComplainedAt.Should().Be(complainedAt);
+        evt.CampaignId.Should().Be("camp-1");
+    }
+
+    [Fact]
+    public void SubscriberComplainedEvent_WithoutCampaign_AllowsNull()
+    {
+        // Act
+        var evt = new SubscriberComplainedEvent("sub-1", "u@x.com", DateTimeOffset.UtcNow, CampaignId: null);
+
+        // Assert
+        evt.CampaignId.Should().BeNull();
+    }
+
+    [Fact]
+    public void SubscriberBlocklistedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var blocklistedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new SubscriberBlocklistedEvent("sub-1", "u@x.com", "spam", blocklistedAt);
+
+        // Assert
+        evt.EventType.Should().Be("marketing.subscriber.blocklisted");
+        evt.BlocklistReason.Should().Be("spam");
+        evt.BlocklistedAt.Should().Be(blocklistedAt);
+    }
+
+    [Fact]
+    public void SubscriberAttributesUpdatedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var attrs = new Dictionary<string, string?>
+        {
+            ["FirstName"] = "Alice",
+            ["LastName"] = null
+        };
+        var updatedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new SubscriberAttributesUpdatedEvent("sub-1", "u@x.com", attrs, updatedAt);
+
+        // Assert
+        evt.EventType.Should().Be("marketing.subscriber.attributes_updated");
+        evt.UpdatedAttributes.Should().BeEquivalentTo(attrs);
+        evt.UpdatedAt.Should().Be(updatedAt);
+    }
+
+    [Fact]
+    public void CampaignOpenedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var openedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new CampaignOpenedEvent("camp-1", "sub-1", "u@x.com", openedAt, "1.2.3.4", "Mozilla/5.0");
+
+        // Assert
+        evt.EventType.Should().Be("marketing.campaign.opened");
+        evt.OpenedAt.Should().Be(openedAt);
+        evt.IpAddress.Should().Be("1.2.3.4");
+        evt.UserAgent.Should().Be("Mozilla/5.0");
+    }
+
+    [Fact]
+    public void CampaignOpenedEvent_WithNullableNulls_AllowsNulls()
+    {
+        // Act
+        var evt = new CampaignOpenedEvent("camp-1", "sub-1", "u@x.com", DateTimeOffset.UtcNow, IpAddress: null, UserAgent: null);
+
+        // Assert
+        evt.IpAddress.Should().BeNull();
+        evt.UserAgent.Should().BeNull();
+    }
+
+    [Fact]
+    public void CampaignLinkClickedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var clickedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new CampaignLinkClickedEvent("camp-1", "sub-1", "u@x.com", "https://example.com", clickedAt, "1.2.3.4");
+
+        // Assert
+        evt.EventType.Should().Be("marketing.campaign.link_clicked");
+        evt.LinkUrl.Should().Be("https://example.com");
+        evt.ClickedAt.Should().Be(clickedAt);
+        evt.IpAddress.Should().Be("1.2.3.4");
+    }
+
+    [Fact]
+    public void TransactionalEmailSentEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var sentAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new TransactionalEmailSentEvent("tx-1", "tpl-1", "u@x.com", "Welcome", sentAt, "delivered");
+
+        // Assert
+        evt.EventType.Should().Be("marketing.transactional.sent");
+        evt.TransactionalId.Should().Be("tx-1");
+        evt.TemplateId.Should().Be("tpl-1");
+        evt.RecipientEmail.Should().Be("u@x.com");
+        evt.Subject.Should().Be("Welcome");
+        evt.SentAt.Should().Be(sentAt);
+        evt.Status.Should().Be("delivered");
+    }
+
+    [Fact]
+    public void ListCreatedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var createdAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new ListCreatedEvent("list-1", "Friends", "Friends list", "private", createdAt);
+
+        // Assert
+        evt.EventType.Should().Be("marketing.list.created");
+        evt.ListId.Should().Be("list-1");
+        evt.Description.Should().Be("Friends list");
+        evt.ListType.Should().Be("private");
+        evt.CreatedAt.Should().Be(createdAt);
+    }
+
+    [Fact]
+    public void ListCreatedEvent_WithNullDescription_AllowsNull()
+    {
+        // Act
+        var evt = new ListCreatedEvent("list-1", "Public", Description: null, "public", DateTimeOffset.UtcNow);
+
+        // Assert
+        evt.Description.Should().BeNull();
+    }
+
+    [Fact]
+    public void ListDeletedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var deletedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new ListDeletedEvent("list-1", "Old List", 1234, deletedAt);
+
+        // Assert
+        evt.EventType.Should().Be("marketing.list.deleted");
+        evt.SubscriberCount.Should().Be(1234);
+        evt.DeletedAt.Should().Be(deletedAt);
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/TenancyIntegrationEventsTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/Domain/Events/Integration/TenancyIntegrationEventsTests.cs
@@ -1,0 +1,187 @@
+// -----------------------------------------------------------------------
+// <copyright file="TenancyIntegrationEventsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.Domain.Events.Integration;
+
+namespace Compendium.Core.Tests.Domain.Events.Integration;
+
+/// <summary>
+/// Unit tests for tenancy integration event records.
+/// </summary>
+public class TenancyIntegrationEventsTests
+{
+    [Fact]
+    public void TenantUpdatedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var changed = new[] { "Name", "Identifier" };
+
+        // Act
+        var evt = new TenantUpdatedEvent("tenant-1", "Acme", "acme", changed);
+
+        // Assert
+        evt.EventType.Should().Be("tenancy.tenant.updated");
+        evt.Identifier.Should().Be("acme");
+        evt.ChangedFields.Should().BeEquivalentTo(changed);
+    }
+
+    [Fact]
+    public void TenantSuspendedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var suspended = DateTimeOffset.UtcNow;
+        var until = suspended.AddDays(30);
+
+        // Act
+        var evt = new TenantSuspendedEvent("tenant-1", "Acme", "non-payment", suspended, until);
+
+        // Assert
+        evt.EventType.Should().Be("tenancy.tenant.suspended");
+        evt.Reason.Should().Be("non-payment");
+        evt.SuspendedAt.Should().Be(suspended);
+        evt.SuspendedUntil.Should().Be(until);
+    }
+
+    [Fact]
+    public void TenantSuspendedEvent_WithNullSuspendedUntil_AllowsNull()
+    {
+        // Act
+        var evt = new TenantSuspendedEvent("tenant-1", "Acme", "fraud", DateTimeOffset.UtcNow, SuspendedUntil: null);
+
+        // Assert
+        evt.SuspendedUntil.Should().BeNull();
+    }
+
+    [Fact]
+    public void TenantReactivatedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var reactivatedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new TenantReactivatedEvent("tenant-1", "Acme", reactivatedAt);
+
+        // Assert
+        evt.EventType.Should().Be("tenancy.tenant.reactivated");
+        evt.ReactivatedAt.Should().Be(reactivatedAt);
+    }
+
+    [Fact]
+    public void TenantDeletedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var deletedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new TenantDeletedEvent("tenant-1", "Acme", deletedAt, IsSoftDelete: true);
+
+        // Assert
+        evt.EventType.Should().Be("tenancy.tenant.deleted");
+        evt.DeletedAt.Should().Be(deletedAt);
+        evt.IsSoftDelete.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TenantUserAddedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var addedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new TenantUserAddedEvent("tenant-1", "user-1", "u@x.com", "Owner", addedAt, "actor-1");
+
+        // Assert
+        evt.EventType.Should().Be("tenancy.tenant.user_added");
+        evt.UserId.Should().Be("user-1");
+        evt.Role.Should().Be("Owner");
+        evt.AddedAt.Should().Be(addedAt);
+        evt.AddedBy.Should().Be("actor-1");
+    }
+
+    [Fact]
+    public void TenantUserRemovedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var removedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new TenantUserRemovedEvent("tenant-1", "user-1", "u@x.com", removedAt, "actor-1");
+
+        // Assert
+        evt.EventType.Should().Be("tenancy.tenant.user_removed");
+        evt.RemovedAt.Should().Be(removedAt);
+        evt.RemovedBy.Should().Be("actor-1");
+    }
+
+    [Fact]
+    public void TenantUserRemovedEvent_WithNullRemovedBy_AllowsNull()
+    {
+        // Act
+        var evt = new TenantUserRemovedEvent("tenant-1", "user-1", "u@x.com", DateTimeOffset.UtcNow, RemovedBy: null);
+
+        // Assert
+        evt.RemovedBy.Should().BeNull();
+    }
+
+    [Fact]
+    public void TenantUserRoleChangedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var changedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new TenantUserRoleChangedEvent("tenant-1", "user-1", "u@x.com", "Member", "Owner", changedAt, "actor-1");
+
+        // Assert
+        evt.EventType.Should().Be("tenancy.tenant.user_role_changed");
+        evt.OldRole.Should().Be("Member");
+        evt.NewRole.Should().Be("Owner");
+        evt.ChangedAt.Should().Be(changedAt);
+        evt.ChangedBy.Should().Be("actor-1");
+    }
+
+    [Fact]
+    public void TenantSettingsUpdatedEvent_Constructor_SetsAllProperties()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?>
+        {
+            ["theme"] = "dark",
+            ["timezone"] = null
+        };
+        var updatedAt = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new TenantSettingsUpdatedEvent("tenant-1", "Acme", "general", settings, updatedAt, "actor-1");
+
+        // Assert
+        evt.EventType.Should().Be("tenancy.tenant.settings_updated");
+        evt.SettingsCategory.Should().Be("general");
+        evt.ChangedSettings.Should().BeEquivalentTo(settings);
+        evt.UpdatedAt.Should().Be(updatedAt);
+        evt.UpdatedBy.Should().Be("actor-1");
+    }
+
+    [Fact]
+    public void TenantSettingsUpdatedEvent_WithNullUpdatedBy_AllowsNull()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?> { ["k"] = "v" };
+
+        // Act
+        var evt = new TenantSettingsUpdatedEvent(
+            "tenant-1",
+            "Acme",
+            "general",
+            settings,
+            DateTimeOffset.UtcNow,
+            UpdatedBy: null);
+
+        // Assert
+        evt.UpdatedBy.Should().BeNull();
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/Domain/Primitives/LockingStrategyEdgeCasesTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/Domain/Primitives/LockingStrategyEdgeCasesTests.cs
@@ -1,0 +1,366 @@
+// -----------------------------------------------------------------------
+// <copyright file="LockingStrategyEdgeCasesTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Core.Tests.Domain.Primitives;
+
+/// <summary>
+/// Coverage for guard-clauses, async overloads, and disposed-state behaviour of every
+/// <see cref="ILockingStrategy"/> implementation. Complements the broader
+/// <see cref="LockingStrategyTests"/> by exercising the lesser-used paths.
+/// </summary>
+public class LockingStrategyEdgeCasesTests
+{
+    #region NoLockStrategy
+
+    [Fact]
+    public void NoLockStrategy_ExecuteRead_WithNullOperation_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var strategy = new NoLockStrategy();
+
+        // Act
+        var act = () => strategy.ExecuteRead<int>(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void NoLockStrategy_ExecuteWrite_WithNullOperation_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var strategy = new NoLockStrategy();
+
+        // Act
+        var act = () => strategy.ExecuteWrite(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task NoLockStrategy_ExecuteReadAsync_RunsOperationAndReturnsValue()
+    {
+        // Arrange
+        using var strategy = new NoLockStrategy();
+
+        // Act
+        var result = await strategy.ExecuteReadAsync(() => Task.FromResult(42));
+
+        // Assert
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task NoLockStrategy_ExecuteReadAsync_WithNullOperation_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var strategy = new NoLockStrategy();
+
+        // Act
+        var act = async () => await strategy.ExecuteReadAsync<int>(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task NoLockStrategy_ExecuteWriteAsync_RunsOperation()
+    {
+        // Arrange
+        using var strategy = new NoLockStrategy();
+        var sentinel = false;
+
+        // Act
+        await strategy.ExecuteWriteAsync(() =>
+        {
+            sentinel = true;
+            return Task.CompletedTask;
+        });
+
+        // Assert
+        sentinel.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task NoLockStrategy_ExecuteWriteAsync_WithNullOperation_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var strategy = new NoLockStrategy();
+
+        // Act
+        var act = async () => await strategy.ExecuteWriteAsync(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void NoLockStrategy_AfterDispose_ExecuteRead_Throws()
+    {
+        // Arrange
+        var strategy = new NoLockStrategy();
+        strategy.Dispose();
+
+        // Act
+        var act = () => strategy.ExecuteRead(() => 1);
+
+        // Assert
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void NoLockStrategy_AfterDispose_ExecuteWrite_Throws()
+    {
+        // Arrange
+        var strategy = new NoLockStrategy();
+        strategy.Dispose();
+
+        // Act
+        var act = () => strategy.ExecuteWrite(() => { });
+
+        // Assert
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task NoLockStrategy_AfterDispose_ExecuteReadAsync_Throws()
+    {
+        // Arrange
+        var strategy = new NoLockStrategy();
+        strategy.Dispose();
+
+        // Act
+        var act = async () => await strategy.ExecuteReadAsync(() => Task.FromResult(1));
+
+        // Assert
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task NoLockStrategy_AfterDispose_ExecuteWriteAsync_Throws()
+    {
+        // Arrange
+        var strategy = new NoLockStrategy();
+        strategy.Dispose();
+
+        // Act
+        var act = async () => await strategy.ExecuteWriteAsync(() => Task.CompletedTask);
+
+        // Assert
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void NoLockStrategy_DoubleDispose_DoesNotThrow()
+    {
+        // Arrange
+        var strategy = new NoLockStrategy();
+
+        // Act
+        strategy.Dispose();
+        var act = () => strategy.Dispose();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    #endregion
+
+    #region ReaderWriterLockStrategy
+
+    [Fact]
+    public void ReaderWriterLockStrategy_ExecuteRead_WithNullOperation_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var strategy = new ReaderWriterLockStrategy();
+
+        // Act
+        var act = () => strategy.ExecuteRead<int>(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ReaderWriterLockStrategy_ExecuteWrite_WithNullOperation_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var strategy = new ReaderWriterLockStrategy();
+
+        // Act
+        var act = () => strategy.ExecuteWrite(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task ReaderWriterLockStrategy_ExecuteReadAsync_RunsOperationAndReleasesLock()
+    {
+        // Arrange
+        using var strategy = new ReaderWriterLockStrategy();
+
+        // Act
+        var result1 = await strategy.ExecuteReadAsync(() => Task.FromResult("a"));
+        var result2 = await strategy.ExecuteReadAsync(() => Task.FromResult("b"));
+
+        // Assert
+        result1.Should().Be("a");
+        result2.Should().Be("b");
+    }
+
+    [Fact]
+    public async Task ReaderWriterLockStrategy_ExecuteReadAsync_WithNullOperation_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var strategy = new ReaderWriterLockStrategy();
+
+        // Act
+        var act = async () => await strategy.ExecuteReadAsync<int>(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task ReaderWriterLockStrategy_ExecuteWriteAsync_RunsOperation()
+    {
+        // Arrange
+        using var strategy = new ReaderWriterLockStrategy();
+        var sentinel = 0;
+
+        // Act
+        await strategy.ExecuteWriteAsync(() =>
+        {
+            Interlocked.Increment(ref sentinel);
+            return Task.CompletedTask;
+        });
+
+        // Assert
+        sentinel.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ReaderWriterLockStrategy_ExecuteWriteAsync_WithNullOperation_ThrowsArgumentNullException()
+    {
+        // Arrange
+        using var strategy = new ReaderWriterLockStrategy();
+
+        // Act
+        var act = async () => await strategy.ExecuteWriteAsync(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ReaderWriterLockStrategy_ExecuteRead_WhenOperationThrows_ReleasesReadLock()
+    {
+        // Arrange
+        using var strategy = new ReaderWriterLockStrategy();
+
+        // Act
+        var firstAttempt = () => strategy.ExecuteRead<int>(() => throw new InvalidOperationException("boom"));
+
+        // Assert
+        firstAttempt.Should().Throw<InvalidOperationException>().WithMessage("boom");
+
+        // After the throw, the lock must have been released — a follow-up read succeeds.
+        var followUp = strategy.ExecuteRead(() => 1);
+        followUp.Should().Be(1);
+    }
+
+    [Fact]
+    public void ReaderWriterLockStrategy_ExecuteWrite_WhenOperationThrows_ReleasesWriteLock()
+    {
+        // Arrange
+        using var strategy = new ReaderWriterLockStrategy();
+
+        // Act
+        var firstAttempt = () => strategy.ExecuteWrite(() => throw new InvalidOperationException("boom"));
+
+        // Assert
+        firstAttempt.Should().Throw<InvalidOperationException>().WithMessage("boom");
+
+        // Subsequent write succeeds, proving the previous lock was released.
+        var followUp = () => strategy.ExecuteWrite(() => { });
+        followUp.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ReaderWriterLockStrategy_AfterDispose_ExecuteRead_Throws()
+    {
+        // Arrange
+        var strategy = new ReaderWriterLockStrategy();
+        strategy.Dispose();
+
+        // Act
+        var act = () => strategy.ExecuteRead(() => 1);
+
+        // Assert
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void ReaderWriterLockStrategy_AfterDispose_ExecuteWrite_Throws()
+    {
+        // Arrange
+        var strategy = new ReaderWriterLockStrategy();
+        strategy.Dispose();
+
+        // Act
+        var act = () => strategy.ExecuteWrite(() => { });
+
+        // Assert
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task ReaderWriterLockStrategy_AfterDispose_ExecuteReadAsync_Throws()
+    {
+        // Arrange
+        var strategy = new ReaderWriterLockStrategy();
+        strategy.Dispose();
+
+        // Act
+        var act = async () => await strategy.ExecuteReadAsync(() => Task.FromResult(1));
+
+        // Assert
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task ReaderWriterLockStrategy_AfterDispose_ExecuteWriteAsync_Throws()
+    {
+        // Arrange
+        var strategy = new ReaderWriterLockStrategy();
+        strategy.Dispose();
+
+        // Act
+        var act = async () => await strategy.ExecuteWriteAsync(() => Task.CompletedTask);
+
+        // Assert
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void ReaderWriterLockStrategy_DoubleDispose_DoesNotThrow()
+    {
+        // Arrange
+        var strategy = new ReaderWriterLockStrategy();
+
+        // Act
+        strategy.Dispose();
+        var act = () => strategy.Dispose();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    #endregion
+}

--- a/tests/Unit/Compendium.Core.Tests/EventSourcing/EventRegistryAssemblyAttributeTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/EventSourcing/EventRegistryAssemblyAttributeTests.cs
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventRegistryAssemblyAttributeTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.EventSourcing.Attributes;
+
+namespace Compendium.Core.Tests.EventSourcing;
+
+/// <summary>
+/// Unit tests for <see cref="EventRegistryAssemblyAttribute"/> defaults and configurability.
+/// </summary>
+public class EventRegistryAssemblyAttributeTests
+{
+    [Fact]
+    public void Constructor_WithDefaults_HasExpectedFlagDefaults()
+    {
+        // Act
+        var attr = new EventRegistryAssemblyAttribute();
+
+        // Assert
+        attr.IncludeAbstract.Should().BeFalse();
+        attr.IncludeInternal.Should().BeTrue();
+        attr.NamespacePrefix.Should().BeNull();
+    }
+
+    [Fact]
+    public void IncludeAbstract_CanBeSet()
+    {
+        // Act
+        var attr = new EventRegistryAssemblyAttribute { IncludeAbstract = true };
+
+        // Assert
+        attr.IncludeAbstract.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IncludeInternal_CanBeOverridden()
+    {
+        // Act
+        var attr = new EventRegistryAssemblyAttribute { IncludeInternal = false };
+
+        // Assert
+        attr.IncludeInternal.Should().BeFalse();
+    }
+
+    [Fact]
+    public void NamespacePrefix_CanBeSet()
+    {
+        // Act
+        var attr = new EventRegistryAssemblyAttribute { NamespacePrefix = "Compendium.Core.Domain" };
+
+        // Assert
+        attr.NamespacePrefix.Should().Be("Compendium.Core.Domain");
+    }
+
+    [Fact]
+    public void Attribute_HasAssemblyTargetUsage()
+    {
+        // Act
+        var usage = (AttributeUsageAttribute?)Attribute.GetCustomAttribute(
+            typeof(EventRegistryAssemblyAttribute),
+            typeof(AttributeUsageAttribute));
+
+        // Assert
+        usage.Should().NotBeNull();
+        usage!.ValidOn.Should().Be(AttributeTargets.Assembly);
+        usage.AllowMultiple.Should().BeFalse();
+        usage.Inherited.Should().BeFalse();
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/EventSourcing/EventTypeMetadataTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/EventSourcing/EventTypeMetadataTests.cs
@@ -1,0 +1,81 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventTypeMetadataTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.EventSourcing;
+using Compendium.Core.Tests.TestHelpers;
+
+namespace Compendium.Core.Tests.EventSourcing;
+
+/// <summary>
+/// Unit tests for the <see cref="EventTypeMetadata"/> DTO used by source-generated event registries.
+/// </summary>
+public class EventTypeMetadataTests
+{
+    [Fact]
+    public void Constructor_WithValidValues_SetsAllProperties()
+    {
+        // Arrange
+        var type = typeof(TestDomainEvent);
+        var typeName = type.AssemblyQualifiedName!;
+        const int priority = 50;
+        const string assembly = "Compendium.Core.Tests";
+
+        // Act
+        var metadata = new EventTypeMetadata(type, typeName, priority, assembly);
+
+        // Assert
+        metadata.Type.Should().Be(type);
+        metadata.TypeName.Should().Be(typeName);
+        metadata.Priority.Should().Be(priority);
+        metadata.SourceAssembly.Should().Be(assembly);
+    }
+
+    [Fact]
+    public void Constructor_WithNullType_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => new EventTypeMetadata(null!, "TypeName", 0, "Asm");
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("type");
+    }
+
+    [Fact]
+    public void Constructor_WithNullTypeName_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => new EventTypeMetadata(typeof(TestDomainEvent), null!, 0, "Asm");
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("typeName");
+    }
+
+    [Fact]
+    public void Constructor_WithNullSourceAssembly_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => new EventTypeMetadata(typeof(TestDomainEvent), "TypeName", 0, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("sourceAssembly");
+    }
+
+    [Theory]
+    [InlineData(int.MinValue)]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(int.MaxValue)]
+    public void Constructor_AcceptsAnyPriorityIntegerValue(int priority)
+    {
+        // Act
+        var metadata = new EventTypeMetadata(typeof(TestDomainEvent), "TypeName", priority, "Asm");
+
+        // Assert
+        metadata.Priority.Should().Be(priority);
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/EventSourcing/EventUpcasterBaseTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/EventSourcing/EventUpcasterBaseTests.cs
@@ -1,0 +1,205 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventUpcasterBaseTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.EventSourcing;
+
+namespace Compendium.Core.Tests.EventSourcing;
+
+/// <summary>
+/// Tests for the non-generic <see cref="IEventUpcaster"/> contract surface implemented by
+/// <see cref="EventUpcasterBase{TSource, TTarget}"/> (CanUpcast, runtime Upcast dispatch,
+/// SourceEventType / TargetEventType reflection).
+/// </summary>
+public class EventUpcasterBaseTests
+{
+    private sealed class FooV1 : DomainEventBase
+    {
+        public FooV1(string id) : base(id, "FooAggregate", 0, eventVersion: 1)
+        {
+        }
+    }
+
+    private sealed class FooV2 : DomainEventBase
+    {
+        public FooV2(string id) : base(id, "FooAggregate", 0, eventVersion: 2)
+        {
+        }
+    }
+
+    private sealed class FooV1ToV2Upcaster : EventUpcasterBase<FooV1, FooV2>
+    {
+        public override int SourceVersion => 1;
+
+        public override int TargetVersion => 2;
+
+        public override FooV2 Upcast(FooV1 sourceEvent)
+        {
+            return new FooV2(sourceEvent.AggregateId);
+        }
+    }
+
+    [Fact]
+    public void SourceEventType_ReturnsTSourceType()
+    {
+        // Arrange
+        var upcaster = new FooV1ToV2Upcaster();
+
+        // Act / Assert
+        upcaster.SourceEventType.Should().Be(typeof(FooV1));
+    }
+
+    [Fact]
+    public void TargetEventType_ReturnsTTargetType()
+    {
+        // Arrange
+        var upcaster = new FooV1ToV2Upcaster();
+
+        // Act / Assert
+        upcaster.TargetEventType.Should().Be(typeof(FooV2));
+    }
+
+    [Fact]
+    public void CanUpcast_WithMatchingTypeAndVersion_ReturnsTrue()
+    {
+        // Arrange
+        var upcaster = new FooV1ToV2Upcaster();
+
+        // Act
+        var result = upcaster.CanUpcast(typeof(FooV1), 1);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanUpcast_WithMismatchedType_ReturnsFalse()
+    {
+        // Arrange
+        var upcaster = new FooV1ToV2Upcaster();
+
+        // Act
+        var result = upcaster.CanUpcast(typeof(FooV2), 1);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanUpcast_WithMismatchedVersion_ReturnsFalse()
+    {
+        // Arrange
+        var upcaster = new FooV1ToV2Upcaster();
+
+        // Act
+        var result = upcaster.CanUpcast(typeof(FooV1), 2);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanUpcast_WithNullEventType_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var upcaster = new FooV1ToV2Upcaster();
+
+        // Act
+        var act = () => upcaster.CanUpcast(null!, 1);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Upcast_WithNullSourceEvent_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var upcaster = new FooV1ToV2Upcaster();
+        IEventUpcaster nonGeneric = upcaster;
+
+        // Act
+        var act = () => nonGeneric.Upcast(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Upcast_NonGeneric_WithMatchingType_ReturnsUpcastedEvent()
+    {
+        // Arrange
+        var upcaster = new FooV1ToV2Upcaster();
+        IEventUpcaster nonGeneric = upcaster;
+        var src = new FooV1("agg-1");
+
+        // Act
+        var result = nonGeneric.Upcast(src);
+
+        // Assert
+        result.Should().BeOfType<FooV2>();
+        result.AggregateId.Should().Be("agg-1");
+        result.EventVersion.Should().Be(2);
+    }
+
+    [Fact]
+    public void Upcast_NonGeneric_WithWrongType_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var upcaster = new FooV1ToV2Upcaster();
+        IEventUpcaster nonGeneric = upcaster;
+        IDomainEvent wrongTypeEvent = new FooV2("agg-1");
+
+        // Act
+        var act = () => nonGeneric.Upcast(wrongTypeEvent);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cannot upcast event of type*");
+    }
+
+    /// <summary>
+    /// FooV1 variant whose constructor declares an EventVersion of 7 — the upcaster expects 1,
+    /// so the version-mismatch branch of <see cref="EventUpcasterBase{TSource, TTarget}.Upcast(IDomainEvent)"/>
+    /// is exercised even though the concrete type matches.
+    /// </summary>
+    private sealed class FooV1WithMismatchedVersion : DomainEventBase
+    {
+        public FooV1WithMismatchedVersion(string id) : base(id, "FooAggregate", 0, eventVersion: 7)
+        {
+        }
+    }
+
+    private sealed class FooV1WithMismatchedVersionUpcaster
+        : EventUpcasterBase<FooV1WithMismatchedVersion, FooV2>
+    {
+        // Source version intentionally mismatches the declared EventVersion of 7 above.
+        public override int SourceVersion => 1;
+
+        public override int TargetVersion => 2;
+
+        public override FooV2 Upcast(FooV1WithMismatchedVersion sourceEvent)
+        {
+            return new FooV2(sourceEvent.AggregateId);
+        }
+    }
+
+    [Fact]
+    public void Upcast_NonGeneric_WithWrongVersion_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var upcaster = new FooV1WithMismatchedVersionUpcaster();
+        IEventUpcaster nonGeneric = upcaster;
+        var src = new FooV1WithMismatchedVersion("agg-1");
+
+        // Act
+        var act = () => nonGeneric.Upcast(src);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cannot upcast event version*");
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/EventSourcing/EventVersionMigratorEdgeCasesTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/EventSourcing/EventVersionMigratorEdgeCasesTests.cs
@@ -1,0 +1,206 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventVersionMigratorEdgeCasesTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.EventSourcing;
+
+namespace Compendium.Core.Tests.EventSourcing;
+
+/// <summary>
+/// Edge-case coverage for <see cref="EventVersionMigrator"/>: re-registering an upcaster,
+/// upcaster throwing, and circular-migration detection (max migrations exceeded).
+/// </summary>
+public sealed class EventVersionMigratorEdgeCasesTests
+{
+    private sealed class EdgeEventV1 : DomainEventBase
+    {
+        public EdgeEventV1(string aggregateId)
+            : base(aggregateId, "EdgeEvent", 0, eventVersion: 1)
+        {
+        }
+    }
+
+    private sealed class EdgeEventV2 : DomainEventBase
+    {
+        public EdgeEventV2(string aggregateId)
+            : base(aggregateId, "EdgeEvent", 0, eventVersion: 2)
+        {
+        }
+    }
+
+    private sealed class FirstUpcaster : EventUpcasterBase<EdgeEventV1, EdgeEventV2>
+    {
+        public override int SourceVersion => 1;
+
+        public override int TargetVersion => 2;
+
+        public override EdgeEventV2 Upcast(EdgeEventV1 sourceEvent) =>
+            new(sourceEvent.AggregateId);
+    }
+
+    private sealed class ReplacementUpcaster : EventUpcasterBase<EdgeEventV1, EdgeEventV2>
+    {
+        public override int SourceVersion => 1;
+
+        public override int TargetVersion => 2;
+
+        public override EdgeEventV2 Upcast(EdgeEventV1 sourceEvent) =>
+            new(sourceEvent.AggregateId);
+    }
+
+    private sealed class ThrowingUpcaster : EventUpcasterBase<EdgeEventV1, EdgeEventV2>
+    {
+        public override int SourceVersion => 1;
+
+        public override int TargetVersion => 2;
+
+        public override EdgeEventV2 Upcast(EdgeEventV1 sourceEvent) =>
+            throw new InvalidOperationException("upcaster boom");
+    }
+
+    /// <summary>
+    /// A perversely-circular upcaster: source and target are the same type/version, and Upcast
+    /// returns an instance with EventVersion=1, so the migrator keeps applying it until it hits
+    /// the maxMigrations safety net (100).
+    /// </summary>
+    private sealed class CircularUpcaster : EventUpcasterBase<EdgeEventV1, EdgeEventV1>
+    {
+        public override int SourceVersion => 1;
+
+        public override int TargetVersion => 1;
+
+        public override EdgeEventV1 Upcast(EdgeEventV1 sourceEvent) =>
+            new(sourceEvent.AggregateId);
+    }
+
+    [Fact]
+    public void RegisterUpcaster_TwiceForSameKey_LogsWarningAndReplaces()
+    {
+        // Arrange
+        string? warning = null;
+        var migrator = new EventVersionMigrator(logWarning: msg => warning = msg);
+        migrator.RegisterUpcaster(new FirstUpcaster());
+
+        // Act
+        migrator.RegisterUpcaster(new ReplacementUpcaster());
+
+        // Assert
+        warning.Should().NotBeNull();
+        warning.Should().Contain("already registered");
+        // Only one (the replacement) should be in the registry — same key.
+        migrator.GetRegisteredUpcasters().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void MigrateToLatest_WithThrowingUpcaster_ReturnsFailureWithUpcastFailedCode()
+    {
+        // Arrange
+        var migrator = new EventVersionMigrator();
+        migrator.RegisterUpcaster(new ThrowingUpcaster());
+
+        // Act
+        var result = migrator.MigrateToLatest(new EdgeEventV1("agg-1"));
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("EventVersionMigrator.UpcastFailed");
+        result.Error.Message.Should().Contain("upcaster boom");
+    }
+
+    [Fact]
+    public void MigrateToLatest_WithCircularUpcaster_ReturnsTooManyMigrationsFailure()
+    {
+        // Arrange
+        var migrator = new EventVersionMigrator();
+        migrator.RegisterUpcaster(new CircularUpcaster());
+
+        // Act
+        var result = migrator.MigrateToLatest(new EdgeEventV1("agg-1"));
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("EventVersionMigrator.TooManyMigrations");
+        result.Error.Message.Should().Contain("circular");
+    }
+
+    [Fact]
+    public void RegisterUpcaster_WithNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var migrator = new EventVersionMigrator();
+
+        // Act
+        var act = () => migrator.RegisterUpcaster(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void MigrateToLatest_WithNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var migrator = new EventVersionMigrator();
+
+        // Act
+        var act = () => migrator.MigrateToLatest(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GetLatestVersion_WithNullType_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var migrator = new EventVersionMigrator();
+
+        // Act
+        var act = () => migrator.GetLatestVersion(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GetLatestVersion_WithUnregisteredType_ReturnsNull()
+    {
+        // Arrange
+        var migrator = new EventVersionMigrator();
+
+        // Act
+        var version = migrator.GetLatestVersion(typeof(EdgeEventV2));
+
+        // Assert
+        version.Should().BeNull();
+    }
+
+    [Fact]
+    public void HasUpcasterForVersion_WithNullType_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var migrator = new EventVersionMigrator();
+
+        // Act
+        var act = () => migrator.HasUpcasterForVersion(null!, 1);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void HasUpcasterForVersion_WithUnregistered_ReturnsFalse()
+    {
+        // Arrange
+        var migrator = new EventVersionMigrator();
+
+        // Act
+        var hasUpcaster = migrator.HasUpcasterForVersion(typeof(EdgeEventV1), 1);
+
+        // Assert
+        hasUpcaster.Should().BeFalse();
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/EventSourcing/SecureEventDeserializerMigrationTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/EventSourcing/SecureEventDeserializerMigrationTests.cs
@@ -1,0 +1,220 @@
+// -----------------------------------------------------------------------
+// <copyright file="SecureEventDeserializerMigrationTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Text.Json;
+using Compendium.Core.EventSourcing;
+using NSubstitute;
+
+namespace Compendium.Core.Tests.EventSourcing;
+
+/// <summary>
+/// Covers the integration between <see cref="SecureEventDeserializer"/> and
+/// <see cref="IEventVersionMigrator"/> — including success migration, failed migration,
+/// and the optional migrator-not-supplied branch.
+/// </summary>
+public class SecureEventDeserializerMigrationTests
+{
+    private sealed class SimpleEvent : DomainEventBase
+    {
+        public SimpleEvent(string aggregateId, string data)
+            : base(aggregateId, "Simple", 0)
+        {
+            Data = data;
+        }
+
+        public string Data { get; init; } = string.Empty;
+    }
+
+    [Fact]
+    public void TryDeserializeEvent_WithMigrator_AppliesMigrationAndReturnsMigratedEvent()
+    {
+        // Arrange
+        var registry = new EventTypeRegistry();
+        registry.RegisterEventType(typeof(SimpleEvent));
+
+        var migratedEvent = new SimpleEvent("agg-1", "migrated");
+        var migrator = Substitute.For<IEventVersionMigrator>();
+        migrator.MigrateToLatest(Arg.Any<IDomainEvent>())
+            .Returns(_ => Result.Success<IDomainEvent>(migratedEvent));
+
+        var deserializer = new SecureEventDeserializer(registry, migrator);
+
+        var original = new SimpleEvent("agg-1", "original");
+        var json = JsonSerializer.Serialize(original);
+
+        // Act
+        var result = deserializer.TryDeserializeEvent(json, typeof(SimpleEvent).AssemblyQualifiedName!);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeSameAs(migratedEvent);
+        migrator.Received(1).MigrateToLatest(Arg.Any<IDomainEvent>());
+    }
+
+    [Fact]
+    public void TryDeserializeEvent_WhenMigrationFails_PropagatesFailureResult()
+    {
+        // Arrange
+        var registry = new EventTypeRegistry();
+        registry.RegisterEventType(typeof(SimpleEvent));
+
+        var migrationError = Error.Failure("Migration.Boom", "could not migrate");
+        var migrator = Substitute.For<IEventVersionMigrator>();
+        migrator.MigrateToLatest(Arg.Any<IDomainEvent>())
+            .Returns(_ => Result.Failure<IDomainEvent>(migrationError));
+
+        Exception? loggedException = null;
+        string? loggedMessage = null;
+        var deserializer = new SecureEventDeserializer(
+            registry,
+            migrator,
+            logError: (ex, msg) =>
+            {
+                loggedException = ex;
+                loggedMessage = msg;
+            });
+
+        var original = new SimpleEvent("agg-1", "original");
+        var json = JsonSerializer.Serialize(original);
+
+        // Act
+        var result = deserializer.TryDeserializeEvent(json, typeof(SimpleEvent).AssemblyQualifiedName!);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(migrationError);
+        loggedException.Should().NotBeNull();
+        loggedMessage.Should().Contain("could not migrate");
+    }
+
+    [Fact]
+    public void TryDeserializeEvent_WhenInputDeserializesToNull_ReturnsFailureResult()
+    {
+        // Arrange
+        var registry = new EventTypeRegistry();
+        registry.RegisterEventType(typeof(SimpleEvent));
+        Exception? loggedException = null;
+        var deserializer = new SecureEventDeserializer(
+            registry,
+            logError: (ex, _) => loggedException = ex);
+
+        // "null" JSON literal will deserialize to a null reference for the event type.
+        const string nullJson = "null";
+
+        // Act
+        var result = deserializer.TryDeserializeEvent(nullJson, typeof(SimpleEvent).AssemblyQualifiedName!);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("EventDeserializer.DeserializationFailed");
+        loggedException.Should().BeOfType<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void DeserializeEvent_WithGenericOverload_NonWhitelisted_LogsWarningAndReturnsNull()
+    {
+        // Arrange
+        var registry = new EventTypeRegistry();
+        string? warning = null;
+        var deserializer = new SecureEventDeserializer(
+            registry,
+            logWarning: msg => warning = msg);
+
+        var src = new SimpleEvent("agg-1", "data");
+        var json = JsonSerializer.Serialize(src);
+
+        // Act
+        var result = deserializer.DeserializeEvent<SimpleEvent>(json);
+
+        // Assert
+        result.Should().BeNull();
+        warning.Should().NotBeNull();
+        warning.Should().Contain("non-whitelisted");
+    }
+
+    [Fact]
+    public void DeserializeEvent_WithGenericOverload_Whitelisted_ReturnsTypedEvent()
+    {
+        // Arrange
+        var registry = new EventTypeRegistry();
+        registry.RegisterEventType(typeof(SimpleEvent));
+        var deserializer = new SecureEventDeserializer(registry);
+
+        var src = new SimpleEvent("agg-1", "hello");
+        var json = JsonSerializer.Serialize(src);
+
+        // Act
+        var result = deserializer.DeserializeEvent<SimpleEvent>(json);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.AggregateId.Should().Be("agg-1");
+        result.Data.Should().Be("hello");
+    }
+
+    [Fact]
+    public void DeserializeEvent_WithGenericOverload_AndInvalidJson_LogsErrorAndReturnsNull()
+    {
+        // Arrange
+        var registry = new EventTypeRegistry();
+        registry.RegisterEventType(typeof(SimpleEvent));
+        Exception? loggedException = null;
+        var deserializer = new SecureEventDeserializer(
+            registry,
+            logError: (ex, _) => loggedException = ex);
+
+        // Act
+        var result = deserializer.DeserializeEvent<SimpleEvent>("{bad json");
+
+        // Assert
+        result.Should().BeNull();
+        loggedException.Should().BeOfType<JsonException>();
+    }
+
+    [Fact]
+    public void DeserializeEvent_WithGenericOverload_NullOrWhitespace_ThrowsArgumentException()
+    {
+        // Arrange
+        var registry = new EventTypeRegistry();
+        var deserializer = new SecureEventDeserializer(registry);
+
+        // Act
+        var act = () => deserializer.DeserializeEvent<SimpleEvent>("   ");
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullRegistry_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => new SecureEventDeserializer(eventTypeRegistry: null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("eventTypeRegistry");
+    }
+
+    [Fact]
+    public void Constructor_WithCustomJsonOptions_UsesProvidedOptions()
+    {
+        // Arrange
+        var registry = new EventTypeRegistry();
+        registry.RegisterEventType(typeof(SimpleEvent));
+        var customOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var deserializer = new SecureEventDeserializer(registry, jsonOptions: customOptions);
+
+        var src = new SimpleEvent("agg-1", "abc");
+        var json = JsonSerializer.Serialize(src);
+
+        // Act
+        var result = deserializer.TryDeserializeEvent(json, typeof(SimpleEvent).AssemblyQualifiedName!);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/Results/ResultGenericTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/Results/ResultGenericTests.cs
@@ -1,0 +1,87 @@
+// -----------------------------------------------------------------------
+// <copyright file="ResultGenericTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.Tests.TestHelpers;
+
+namespace Compendium.Core.Tests.Results;
+
+/// <summary>
+/// Coverage for the generic <see cref="Result{TValue}"/> branches not exercised by ResultTests:
+/// implicit operators (value → success, error → failure) and the override <c>ToString</c> path.
+/// </summary>
+public class ResultGenericTests
+{
+    [Fact]
+    public void ImplicitOperator_FromValue_ReturnsSuccessResult()
+    {
+        // Arrange
+        const string value = "hello";
+
+        // Act
+        Result<string> result = value;
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public void ImplicitOperator_FromError_ReturnsFailureResult()
+    {
+        // Arrange
+        var error = TestData.Errors.CreateValidation("ERR.X", "boom");
+
+        // Act
+        Result<string> result = error;
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(error);
+    }
+
+    [Fact]
+    public void ToString_OnSuccess_IncludesValue()
+    {
+        // Arrange
+        var result = Result.Success(42);
+
+        // Act
+        var str = result.ToString();
+
+        // Assert
+        str.Should().StartWith("Success:");
+        str.Should().Contain("42");
+    }
+
+    [Fact]
+    public void ToString_OnFailure_IncludesErrorMessage()
+    {
+        // Arrange
+        var error = Error.Validation("VAL.42", "bad input");
+        var result = Result.Failure<int>(error);
+
+        // Act
+        var str = result.ToString();
+
+        // Assert
+        str.Should().StartWith("Failure:");
+        str.Should().Contain("bad input");
+    }
+
+    [Fact]
+    public void ToString_OnSuccess_WithNullableNullValue_DoesNotThrow()
+    {
+        // Arrange
+        var result = Result.Success<string?>(null);
+
+        // Act
+        var str = result.ToString();
+
+        // Assert
+        str.Should().StartWith("Success:");
+    }
+}

--- a/tests/Unit/Compendium.Core.Tests/Telemetry/CompendiumTelemetryTests.cs
+++ b/tests/Unit/Compendium.Core.Tests/Telemetry/CompendiumTelemetryTests.cs
@@ -1,0 +1,211 @@
+// -----------------------------------------------------------------------
+// <copyright file="CompendiumTelemetryTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.Telemetry;
+
+namespace Compendium.Core.Tests.Telemetry;
+
+/// <summary>
+/// Unit tests for the static <see cref="CompendiumTelemetry"/> registry of ActivitySource,
+/// Meter, instruments, activity-name constants, and tag keys.
+/// </summary>
+public class CompendiumTelemetryTests
+{
+    [Fact]
+    public void SourceName_IsCompendium()
+    {
+        // Act / Assert
+        CompendiumTelemetry.SourceName.Should().Be("Compendium");
+    }
+
+    [Fact]
+    public void Version_HasSemanticVersionFormat()
+    {
+        // Act / Assert
+        CompendiumTelemetry.Version.Should().Be("1.0.0");
+    }
+
+    [Fact]
+    public void ActivitySource_IsConfigured()
+    {
+        // Act
+        var source = CompendiumTelemetry.ActivitySource;
+
+        // Assert
+        source.Should().NotBeNull();
+        source.Name.Should().Be(CompendiumTelemetry.SourceName);
+        source.Version.Should().Be(CompendiumTelemetry.Version);
+    }
+
+    [Fact]
+    public void Meter_IsConfigured()
+    {
+        // Act
+        var meter = CompendiumTelemetry.Meter;
+
+        // Assert
+        meter.Should().NotBeNull();
+        meter.Name.Should().Be(CompendiumTelemetry.SourceName);
+        meter.Version.Should().Be(CompendiumTelemetry.Version);
+    }
+
+    [Theory]
+    [InlineData("EventsAppended", "compendium.eventstore.events_appended")]
+    [InlineData("EventsRead", "compendium.eventstore.events_read")]
+    [InlineData("CommandsDispatched", "compendium.cqrs.commands_dispatched")]
+    [InlineData("QueriesDispatched", "compendium.cqrs.queries_dispatched")]
+    [InlineData("ProjectionEventsProcessed", "compendium.projection.events_processed")]
+    [InlineData("ProjectionRebuilds", "compendium.projection.rebuilds")]
+    [InlineData("ProjectionRebuildsCompleted", "compendium.projection.rebuilds_completed")]
+    [InlineData("IdempotencyCacheHits", "compendium.idempotency.cache_hits")]
+    [InlineData("IdempotencyCacheMisses", "compendium.idempotency.cache_misses")]
+    [InlineData("IdempotencyKeysGenerated", "compendium.idempotency.keys_generated")]
+    public void Counter_HasExpectedName(string fieldName, string expectedName)
+    {
+        // Arrange
+        var field = typeof(CompendiumTelemetry).GetField(fieldName);
+
+        // Act
+        field.Should().NotBeNull();
+        var counter = field!.GetValue(null) as System.Diagnostics.Metrics.Counter<long>;
+
+        // Assert
+        counter.Should().NotBeNull();
+        counter!.Name.Should().Be(expectedName);
+        counter.Unit.Should().NotBeNullOrEmpty();
+        counter.Description.Should().NotBeNullOrEmpty();
+    }
+
+    [Theory]
+    [InlineData("AppendDuration", "compendium.eventstore.append_duration")]
+    [InlineData("ReadDuration", "compendium.eventstore.read_duration")]
+    [InlineData("CommandDuration", "compendium.cqrs.command_duration")]
+    [InlineData("QueryDuration", "compendium.cqrs.query_duration")]
+    [InlineData("ProjectionProcessDuration", "compendium.projection.process_duration")]
+    [InlineData("ProjectionRebuildDuration", "compendium.projection.rebuild_duration")]
+    [InlineData("ProjectionLag", "compendium.projection.lag_seconds")]
+    [InlineData("IdempotencyCheckDuration", "compendium.idempotency.check_duration")]
+    public void Histogram_HasExpectedName(string fieldName, string expectedName)
+    {
+        // Arrange
+        var field = typeof(CompendiumTelemetry).GetField(fieldName);
+
+        // Act
+        field.Should().NotBeNull();
+        var histogram = field!.GetValue(null) as System.Diagnostics.Metrics.Histogram<double>;
+
+        // Assert
+        histogram.Should().NotBeNull();
+        histogram!.Name.Should().Be(expectedName);
+        histogram.Unit.Should().NotBeNullOrEmpty();
+        histogram.Description.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void EventStoreActivities_DefinesExpectedConstants()
+    {
+        // Assert
+        CompendiumTelemetry.EventStoreActivities.AppendEvents.Should().Be("eventstore.append");
+        CompendiumTelemetry.EventStoreActivities.GetEvents.Should().Be("eventstore.get");
+        CompendiumTelemetry.EventStoreActivities.GetStatistics.Should().Be("eventstore.statistics");
+        CompendiumTelemetry.EventStoreActivities.InitializeSchema.Should().Be("eventstore.init_schema");
+    }
+
+    [Fact]
+    public void CqrsActivities_DefinesExpectedConstants()
+    {
+        // Assert
+        CompendiumTelemetry.CqrsActivities.DispatchCommand.Should().Be("cqrs.command.dispatch");
+        CompendiumTelemetry.CqrsActivities.ExecuteHandler.Should().Be("cqrs.command.handler");
+        CompendiumTelemetry.CqrsActivities.ExecuteBehavior.Should().Be("cqrs.command.behavior");
+        CompendiumTelemetry.CqrsActivities.DispatchQuery.Should().Be("cqrs.query.dispatch");
+        CompendiumTelemetry.CqrsActivities.ExecuteQueryHandler.Should().Be("cqrs.query.handler");
+    }
+
+    [Fact]
+    public void ProjectionActivities_DefinesExpectedConstants()
+    {
+        // Assert
+        CompendiumTelemetry.ProjectionActivities.ProcessEvent.Should().Be("projection.process_event");
+        CompendiumTelemetry.ProjectionActivities.RebuildProjection.Should().Be("projection.rebuild");
+        CompendiumTelemetry.ProjectionActivities.ApplyEvent.Should().Be("projection.apply");
+        CompendiumTelemetry.ProjectionActivities.GetState.Should().Be("projection.get_state");
+    }
+
+    [Fact]
+    public void IdempotencyActivities_DefinesExpectedConstants()
+    {
+        // Assert
+        CompendiumTelemetry.IdempotencyActivities.CheckKey.Should().Be("idempotency.check");
+        CompendiumTelemetry.IdempotencyActivities.StoreKey.Should().Be("idempotency.store");
+        CompendiumTelemetry.IdempotencyActivities.GenerateKey.Should().Be("idempotency.generate");
+    }
+
+    [Fact]
+    public void Tags_DefinesExpectedConstants()
+    {
+        // Assert
+        CompendiumTelemetry.Tags.AggregateType.Should().Be("aggregate_type");
+        CompendiumTelemetry.Tags.AggregateId.Should().Be("aggregate_id");
+        CompendiumTelemetry.Tags.TenantId.Should().Be("tenant_id");
+        CompendiumTelemetry.Tags.EventType.Should().Be("event_type");
+        CompendiumTelemetry.Tags.BatchSize.Should().Be("batch_size");
+        CompendiumTelemetry.Tags.EventCount.Should().Be("event_count");
+        CompendiumTelemetry.Tags.Status.Should().Be("status");
+        CompendiumTelemetry.Tags.CommandType.Should().Be("command_type");
+        CompendiumTelemetry.Tags.HandlerType.Should().Be("handler_type");
+        CompendiumTelemetry.Tags.QueryType.Should().Be("query_type");
+        CompendiumTelemetry.Tags.ProjectionId.Should().Be("projection_id");
+        CompendiumTelemetry.Tags.BehaviorCount.Should().Be("behavior_count");
+        CompendiumTelemetry.Tags.Paginated.Should().Be("paginated");
+        CompendiumTelemetry.Tags.ErrorType.Should().Be("error_type");
+        CompendiumTelemetry.Tags.ErrorMessage.Should().Be("error_message");
+        CompendiumTelemetry.Tags.OperationType.Should().Be("operation_type");
+        CompendiumTelemetry.Tags.Result.Should().Be("result");
+        CompendiumTelemetry.Tags.EventTimestamp.Should().Be("event_timestamp");
+    }
+
+    [Fact]
+    public void StatusValues_DefinesExpectedConstants()
+    {
+        // Assert
+        CompendiumTelemetry.StatusValues.Success.Should().Be("success");
+        CompendiumTelemetry.StatusValues.Failure.Should().Be("failure");
+    }
+
+    [Fact]
+    public void CacheResults_DefinesExpectedConstants()
+    {
+        // Assert
+        CompendiumTelemetry.CacheResults.Hit.Should().Be("hit");
+        CompendiumTelemetry.CacheResults.Miss.Should().Be("miss");
+    }
+
+    [Fact]
+    public void Counter_CanRecordValueWithoutThrowing()
+    {
+        // Arrange / Act
+        var act = () => CompendiumTelemetry.EventsAppended.Add(
+            1,
+            new KeyValuePair<string, object?>(CompendiumTelemetry.Tags.AggregateType, "TestAggregate"));
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Histogram_CanRecordValueWithoutThrowing()
+    {
+        // Arrange / Act
+        var act = () => CompendiumTelemetry.AppendDuration.Record(
+            42.5,
+            new KeyValuePair<string, object?>(CompendiumTelemetry.Tags.AggregateType, "TestAggregate"));
+
+        // Assert
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
## Summary
Tops up `Compendium.Core` from **55.0%** baseline (the orchestrator-tracked baseline was 61.1%; locally measured at 55.0% on this branch's source tree) to **98.0%** line coverage. Part of the testing campaign (VK POM-474, sub-task of the Core/Infrastructure/Multitenancy/AI top-up bundle).

## Coverage report — Compendium.Core
- Tests added: **260** (358 → 618 total)
- Existing tests preserved: **358**
- Test files added: **15**
  - `Domain/Events/DomainEventBaseJsonConstructorTests.cs`
  - `Domain/Events/Integration/BillingIntegrationEventsTests.cs`
  - `Domain/Events/Integration/IdentityIntegrationEventsTests.cs`
  - `Domain/Events/Integration/LicenseIntegrationEventsTests.cs`
  - `Domain/Events/Integration/MarketingIntegrationEventsTests.cs`
  - `Domain/Events/Integration/TenancyIntegrationEventsTests.cs`
  - `Domain/Events/Integration/IntegrationEventPropertyReadTests.cs`
  - `Domain/Primitives/LockingStrategyEdgeCasesTests.cs`
  - `EventSourcing/EventRegistryAssemblyAttributeTests.cs`
  - `EventSourcing/EventTypeMetadataTests.cs`
  - `EventSourcing/EventUpcasterBaseTests.cs`
  - `EventSourcing/EventVersionMigratorEdgeCasesTests.cs`
  - `EventSourcing/SecureEventDeserializerMigrationTests.cs`
  - `Results/ResultGenericTests.cs`
  - `Telemetry/CompendiumTelemetryTests.cs`
- Line coverage: **55.0% → 98.0%**
- Branch coverage: **75.4% → 88.7%**
- Method coverage: **38.5% → 99.3%**
- Bugs surfaced: 0 production bugs (one pre-existing C# record-inheritance quirk noted: tenancy events declare a positional `TenantId` parameter that shadows `IntegrationEventBase.TenantId` — compiler emits CS8907 "Parameter 'TenantId' is unread" on these records and the positional value is silently dropped. Tests use the inherited init-property path, matching documented behaviour.)

## Areas covered
- **Integration events**: every record (~50 events) now has a property-getter coverage test plus dedicated value-equality / nullable-permissibility tests for the per-domain (Billing / Identity / License / Marketing / Tenancy) variants.
- **`CompendiumTelemetry`** static instrument registry: ActivitySource, Meter, every Counter / Histogram name + unit + description, all Activity-name and Tag constants, plus smoke checks that Add / Record do not throw.
- **`EventVersionMigrator`**: re-registration warning path, throwing-upcaster catch block, circular-migration safety net, null-arg guards on every public method.
- **`SecureEventDeserializer`**: migrator integration (success and failure), null-deserialization fallback, generic overload (whitelisted, non-whitelisted, invalid JSON, blank input), null-registry guard, custom JsonSerializerOptions.
- **`EventUpcasterBase<TSource, TTarget>`**: SourceEventType / TargetEventType, CanUpcast (match / mismatch type / mismatch version / null type), non-generic Upcast (success, wrong type → InvalidOperationException, wrong version → InvalidOperationException, null → ArgumentNullException).
- **`NoLockStrategy` / `ReaderWriterLockStrategy`**: null-operation guards on every method, async overloads, post-dispose ObjectDisposedException, lock release on exception, double-dispose tolerance.
- **`DomainEventBase` JSON constructor**: round-trip through `JsonConstructorAttribute` path.
- **`Result<T>`**: implicit value/error operators and ToString override.
- **`EventTypeMetadata`** + **`EventRegistryAssemblyAttribute`**: constructor argument validation, default flag values, `[AttributeUsage]` declaration check.

## Test plan
- [x] `dotnet build Compendium.sln -c Release` green (0 errors)
- [x] `dotnet test tests/Unit/Compendium.Core.Tests -c Release` green (618 / 618 passing, 0 skipped)
- [x] No prod code modified, no version bumps in `Directory.Packages.props`
- [x] No `Moq.`, `Assert.`, or `Thread.Sleep` introduced in new tests
- [x] All new tests use FluentAssertions + NSubstitute and explicit `// Arrange / // Act / // Assert` comments
- [ ] CI green