### PR TITLE
test(infrastructure): top up coverage to 90%

### DIFF
--- a/tests/Unit/Compendium.Infrastructure.Tests/EventSourcing/InMemoryEventStoreSupplementaryTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/EventSourcing/InMemoryEventStoreSupplementaryTests.cs
@@ -1,0 +1,98 @@
+// -----------------------------------------------------------------------
+// <copyright file="InMemoryEventStoreSupplementaryTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.EventSourcing;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Compendium.Infrastructure.Tests.EventSourcing;
+
+/// <summary>
+/// Supplementary tests for <see cref="InMemoryEventStore"/> covering corner cases not exercised
+/// by the existing test suite (last-event lookup, statistics, empty state behaviours).
+/// </summary>
+public sealed class InMemoryEventStoreSupplementaryTests
+{
+    private readonly IEventDeserializer _deserializer;
+    private readonly InMemoryEventStore _sut;
+
+    public InMemoryEventStoreSupplementaryTests()
+    {
+        // Arrange
+        _deserializer = new SecureEventDeserializer(new EventTypeRegistry());
+        _sut = new InMemoryEventStore(_deserializer, NullLogger<InMemoryEventStore>.Instance);
+    }
+
+    [Fact]
+    public void Ctor_NullDeserializer_Throws()
+    {
+        // Arrange / Act
+        var act = () => new InMemoryEventStore(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task GetLastEventAsync_NoEvents_ReturnsNotFound()
+    {
+        // Arrange / Act
+        var result = await _sut.GetLastEventAsync("missing");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("EventStore.NoEvents");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GetLastEventAsync_EmptyAggId_ReturnsValidationFailure(string invalid)
+    {
+        // Arrange / Act
+        var result = await _sut.GetLastEventAsync(invalid);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("EventStore.InvalidAggregateId");
+    }
+
+    [Fact]
+    public async Task GetStatisticsAsync_NoEvents_ReturnsZeroes()
+    {
+        // Arrange / Act
+        var result = await _sut.GetStatisticsAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalAggregates.Should().Be(0);
+        result.Value.TotalEvents.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GetEventsAsync_EmptyAggId_ReturnsValidationFailure(string invalid)
+    {
+        // Arrange / Act
+        var result = await _sut.GetEventsAsync(invalid);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("EventStore.InvalidAggregateId");
+    }
+
+    [Fact]
+    public async Task GetEventsAsync_UnknownAggregate_ReturnsEmpty()
+    {
+        // Arrange / Act
+        var result = await _sut.GetEventsAsync("unknown");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/EventSourcing/InMemorySnapshotStoreSupplementaryTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/EventSourcing/InMemorySnapshotStoreSupplementaryTests.cs
@@ -1,0 +1,177 @@
+// -----------------------------------------------------------------------
+// <copyright file="InMemorySnapshotStoreSupplementaryTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Compendium.Infrastructure.Tests.EventSourcing;
+
+/// <summary>
+/// Supplementary tests for <see cref="InMemorySnapshotStore"/> covering disposal, statistics,
+/// validation, cancellation and tenant isolation.
+/// </summary>
+public sealed class InMemorySnapshotStoreSupplementaryTests
+{
+    private readonly InMemorySnapshotStore _sut = new(NullLogger<InMemorySnapshotStore>.Instance);
+
+    [Fact]
+    public async Task GetLatestSnapshotAsync_AfterDispose_ReturnsFailure()
+    {
+        // Arrange
+        _sut.Dispose();
+
+        // Act
+        var result = await _sut.GetLatestSnapshotAsync<TestState>("a-1");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("SnapshotStore.Disposed");
+    }
+
+    [Fact]
+    public async Task SaveSnapshotAsync_AfterDispose_ReturnsFailure()
+    {
+        // Arrange
+        _sut.Dispose();
+
+        // Act
+        var result = await _sut.SaveSnapshotAsync("a-1", new TestState(), 1);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("SnapshotStore.Disposed");
+    }
+
+    [Fact]
+    public async Task SaveSnapshotAsync_NegativeVersion_ReturnsValidationFailure()
+    {
+        // Arrange / Act
+        var result = await _sut.SaveSnapshotAsync("a-1", new TestState(), -1);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("SnapshotStore.InvalidVersion");
+    }
+
+    [Fact]
+    public async Task SaveSnapshotAsync_OlderVersion_DoesNotOverwrite()
+    {
+        // Arrange
+        var first = new TestState { Value = "v1" };
+        await _sut.SaveSnapshotAsync("a-1", first, 5);
+
+        // Act
+        await _sut.SaveSnapshotAsync("a-1", new TestState { Value = "older" }, 3);
+        var loaded = await _sut.GetLatestSnapshotAsync<TestState>("a-1");
+
+        // Assert
+        loaded.IsSuccess.Should().BeTrue();
+        loaded.Value.State.Value.Should().Be("v1");
+        loaded.Value.Version.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task GetLatestSnapshotAsync_Cancelled_ReturnsCancellationFailure()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var result = await _sut.GetLatestSnapshotAsync<TestState>("a-1", cts.Token);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("SnapshotStore.OperationCancelled");
+    }
+
+    [Fact]
+    public async Task SaveSnapshotAsync_Cancelled_ReturnsCancellationFailure()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var result = await _sut.SaveSnapshotAsync("a-1", new TestState(), 1, cts.Token);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("SnapshotStore.OperationCancelled");
+    }
+
+    [Fact]
+    public async Task GetStatisticsAsync_AfterDispose_ReturnsFailure()
+    {
+        // Arrange
+        _sut.Dispose();
+
+        // Act
+        var result = await _sut.GetStatisticsAsync();
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("SnapshotStore.Disposed");
+    }
+
+    [Fact]
+    public async Task GetStatisticsAsync_EmptyStore_ReturnsZeroes()
+    {
+        // Arrange / Act
+        var result = await _sut.GetStatisticsAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalSnapshots.Should().Be(0);
+        result.Value.OldestSnapshot.Should().BeNull();
+        result.Value.NewestSnapshot.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetStatisticsAsync_AfterSavingSnapshots_ReturnsCounts()
+    {
+        // Arrange
+        await _sut.SaveSnapshotAsync("a-1", new TestState(), 1);
+        await _sut.SaveSnapshotAsync("a-2", new TestState(), 1);
+
+        // Act
+        var result = await _sut.GetStatisticsAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalSnapshots.Should().Be(2);
+        result.Value.OldestSnapshot.Should().NotBeNull();
+        result.Value.NewestSnapshot.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetStatisticsAsync_Cancelled_ReturnsCancellationFailure()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var result = await _sut.GetStatisticsAsync(cts.Token);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("SnapshotStore.OperationCancelled");
+    }
+
+    [Fact]
+    public void Dispose_TwiceIsIdempotent()
+    {
+        // Arrange / Act / Assert
+        _sut.Dispose();
+        _sut.Dispose();
+    }
+
+    private sealed class TestState
+    {
+        public string Value { get; set; } = "default";
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/EventSourcing/ProjectionManagerRebuildTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/EventSourcing/ProjectionManagerRebuildTests.cs
@@ -1,0 +1,292 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProjectionManagerRebuildTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.EventSourcing;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Compendium.Infrastructure.Tests.EventSourcing;
+
+/// <summary>
+/// Additional unit tests for <see cref="ProjectionManager"/> covering rebuild semantics,
+/// state retrieval, statistics, and the checkpoint store integration that the
+/// existing suite does not exercise.
+/// </summary>
+public sealed class ProjectionManagerRebuildTests
+{
+    private readonly IEventStore _eventStore = Substitute.For<IEventStore>();
+    private readonly ProjectionManager _sut;
+
+    public ProjectionManagerRebuildTests()
+    {
+        // Arrange (shared)
+        _sut = new ProjectionManager(_eventStore, NullLogger<ProjectionManager>.Instance);
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_EmptyProjectionId_ReturnsValidationFailure()
+    {
+        // Arrange / Act
+        var result = await _sut.RebuildProjectionAsync("", "agg-1");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("ProjectionManager.InvalidProjectionId");
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_EmptyAggregateId_ReturnsValidationFailure()
+    {
+        // Arrange / Act
+        var result = await _sut.RebuildProjectionAsync("p", "");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("ProjectionManager.InvalidAggregateId");
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_UnknownProjection_ReturnsNotFound()
+    {
+        // Arrange / Act
+        var result = await _sut.RebuildProjectionAsync("missing", "agg-1");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Projection.NotFound");
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_EventStoreFailure_ReturnsFailure()
+    {
+        // Arrange
+        var projection = new TestProjection();
+        _sut.RegisterProjection(projection);
+        _eventStore.GetEventsAsync(Arg.Any<string>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<IReadOnlyList<IDomainEvent>>(Error.Failure("es.fail", "boom")));
+
+        // Act
+        var result = await _sut.RebuildProjectionAsync(projection.ProjectionId, "agg-1");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("es.fail");
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_WithProgress_ReportsProgress()
+    {
+        // Arrange
+        var projection = new TestProjection();
+        _sut.RegisterProjection(projection);
+        IReadOnlyList<IDomainEvent> events = new[] { new TestEvent(), new TestEvent() };
+        _eventStore.GetEventsAsync(Arg.Any<string>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(events));
+
+        var reports = new List<ProjectionRebuildProgress>();
+        var progress = new Progress<ProjectionRebuildProgress>(p => reports.Add(p));
+
+        // Act
+        var result = await _sut.RebuildProjectionAsync(projection.ProjectionId, "agg-1", progress);
+        await Task.Delay(50);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        reports.Should().NotBeEmpty();
+        reports.Last().IsCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_WithCheckpointStore_SavesCheckpoint()
+    {
+        // Arrange
+        var checkpointStore = Substitute.For<IProjectionCheckpointStore>();
+        checkpointStore.GetCheckpointAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(0L));
+        var sut = new ProjectionManager(_eventStore, NullLogger<ProjectionManager>.Instance, checkpointStore, checkpointInterval: 1);
+        var projection = new TestProjection();
+        sut.RegisterProjection(projection);
+
+        IReadOnlyList<IDomainEvent> events = new[] { new TestEvent(), new TestEvent() };
+        _eventStore.GetEventsAsync(Arg.Any<string>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(events));
+
+        // Act
+        var result = await sut.RebuildProjectionAsync(projection.ProjectionId, "agg-1");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await checkpointStore.Received().SaveCheckpointAsync(
+            projection.ProjectionId, "agg-1", Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_CheckpointStoreReturnsNonZero_DoesNotResetState()
+    {
+        // Arrange
+        var checkpointStore = Substitute.For<IProjectionCheckpointStore>();
+        checkpointStore.GetCheckpointAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(50L));
+        var sut = new ProjectionManager(_eventStore, NullLogger<ProjectionManager>.Instance, checkpointStore);
+        var projection = new TestProjection();
+        sut.RegisterProjection(projection);
+
+        IReadOnlyList<IDomainEvent> events = Array.Empty<IDomainEvent>();
+        _eventStore.GetEventsAsync(Arg.Any<string>(), 50L, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(events));
+
+        // Act
+        var result = await sut.RebuildProjectionAsync(projection.ProjectionId, "agg-1");
+
+        // Assert — no projection.Reset because checkpoint > 0
+        result.IsSuccess.Should().BeTrue();
+        projection.ResetCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_WhenProjectionApplyThrows_ReturnsFailure()
+    {
+        // Arrange
+        var projection = new ThrowingProjection();
+        _sut.RegisterProjection(projection);
+        IReadOnlyList<IDomainEvent> events = new[] { new TestEvent() };
+        _eventStore.GetEventsAsync(Arg.Any<string>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(events));
+
+        // Act
+        var result = await _sut.RebuildProjectionAsync(projection.ProjectionId, "agg-1");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Projection.RebuildFailed");
+    }
+
+    [Fact]
+    public async Task GetProjectionStateAsync_EmptyProjectionId_ReturnsValidationFailure()
+    {
+        // Arrange / Act
+        var result = await _sut.GetProjectionStateAsync<object>("");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("ProjectionManager.InvalidProjectionId");
+    }
+
+    [Fact]
+    public async Task GetProjectionStateAsync_UnknownProjection_ReturnsNotFound()
+    {
+        // Arrange / Act
+        var result = await _sut.GetProjectionStateAsync<object>("missing");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Projection.NotFound");
+    }
+
+    [Fact]
+    public async Task GetProjectionStateAsync_WrongType_ReturnsTypeFailure()
+    {
+        // Arrange
+        var projection = new TestProjection();
+        _sut.RegisterProjection(projection);
+
+        // Act
+        var result = await _sut.GetProjectionStateAsync<string>(projection.ProjectionId);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetStatisticsAsync_NoProjections_ReturnsEmpty()
+    {
+        // Arrange / Act
+        var result = await _sut.GetStatisticsAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalProjections.Should().Be(0);
+        result.Value.ProjectionDetails.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetStatisticsAsync_AfterRegistration_ReportsCount()
+    {
+        // Arrange
+        _sut.RegisterProjection(new TestProjection());
+
+        // Act
+        var result = await _sut.GetStatisticsAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalProjections.Should().Be(1);
+        result.Value.ProjectionDetails.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Dispose_TwiceIsIdempotent()
+    {
+        // Arrange / Act / Assert
+        _sut.Dispose();
+        _sut.Dispose();
+    }
+
+    [Fact]
+    public async Task ProcessEventAsync_AfterDispose_Throws()
+    {
+        // Arrange
+        _sut.Dispose();
+
+        // Act
+        Func<Task> act = async () => await _sut.ProcessEventAsync("a", new TestEvent());
+
+        // Assert
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    private sealed class TestProjection : IProjection
+    {
+        public string ProjectionId => "TestProjection";
+        public int Version { get; private set; }
+        public int ResetCount { get; private set; }
+
+        public Task ApplyAsync(IDomainEvent domainEvent, CancellationToken cancellationToken = default)
+        {
+            Version++;
+            return Task.CompletedTask;
+        }
+
+        public Task<object> GetStateAsync(CancellationToken cancellationToken = default) => Task.FromResult<object>(this);
+
+        public Task ResetAsync(CancellationToken cancellationToken = default)
+        {
+            ResetCount++;
+            Version = 0;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingProjection : IProjection
+    {
+        public string ProjectionId => "ThrowingProjection";
+        public int Version => 0;
+        public Task ApplyAsync(IDomainEvent domainEvent, CancellationToken cancellationToken = default)
+            => Task.FromException(new InvalidOperationException("apply-fail"));
+        public Task<object> GetStateAsync(CancellationToken cancellationToken = default) => Task.FromResult<object>(new());
+        public Task ResetAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class TestEvent : IDomainEvent
+    {
+        public Guid EventId { get; init; } = Guid.NewGuid();
+        public string AggregateId { get; init; } = "agg";
+        public string AggregateType { get; init; } = "Test";
+        public DateTimeOffset OccurredOn { get; init; } = DateTimeOffset.UtcNow;
+        public long AggregateVersion { get; init; } = 1;
+        public int EventVersion { get; init; } = 1;
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/EventSourcing/ProjectionManagerTypesTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/EventSourcing/ProjectionManagerTypesTests.cs
@@ -1,0 +1,110 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProjectionManagerTypesTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Infrastructure.Tests.EventSourcing;
+
+/// <summary>
+/// Tests for the simple POCO/record types in the Compendium.Infrastructure.EventSourcing namespace
+/// (ProjectionDetails, ProjectionManagerStatistics, ProjectionRebuildProgress).
+/// </summary>
+public sealed class ProjectionManagerTypesTests
+{
+    [Fact]
+    public void ProjectionDetails_Defaults_AreSensible()
+    {
+        // Arrange / Act
+        var details = new ProjectionDetails();
+
+        // Assert
+        details.ProjectionId.Should().Be(string.Empty);
+        details.LastProcessedVersion.Should().Be(0);
+        details.LastUpdated.Should().Be(default);
+        details.IsRebuilding.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ProjectionDetails_StoresInitializerValues()
+    {
+        // Arrange
+        var ts = DateTimeOffset.UtcNow;
+
+        // Act
+        var details = new ProjectionDetails
+        {
+            ProjectionId = "p1",
+            LastProcessedVersion = 7,
+            LastUpdated = ts,
+            IsRebuilding = true,
+        };
+
+        // Assert
+        details.ProjectionId.Should().Be("p1");
+        details.LastProcessedVersion.Should().Be(7);
+        details.LastUpdated.Should().Be(ts);
+        details.IsRebuilding.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ProjectionManagerStatistics_Defaults_AreSensible()
+    {
+        // Arrange / Act
+        var stats = new ProjectionManagerStatistics();
+
+        // Assert
+        stats.TotalProjections.Should().Be(0);
+        stats.ActiveProjections.Should().Be(0);
+        stats.RebuildingProjections.Should().Be(0);
+        stats.ProjectionDetails.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ProjectionManagerStatistics_StoresInitializerValues()
+    {
+        // Arrange
+        var details = new Dictionary<string, ProjectionDetails> { ["p1"] = new ProjectionDetails() };
+
+        // Act
+        var stats = new ProjectionManagerStatistics
+        {
+            TotalProjections = 3,
+            ActiveProjections = 2,
+            RebuildingProjections = 1,
+            ProjectionDetails = details,
+        };
+
+        // Assert
+        stats.TotalProjections.Should().Be(3);
+        stats.ActiveProjections.Should().Be(2);
+        stats.RebuildingProjections.Should().Be(1);
+        stats.ProjectionDetails.Should().BeSameAs(details);
+    }
+
+    [Fact]
+    public void ProjectionRebuildProgress_StoresAllValues()
+    {
+        // Arrange / Act
+        var progress = new ProjectionRebuildProgress("pid", 50, 100, 50.0, false, 25.5);
+
+        // Assert
+        progress.ProjectionId.Should().Be("pid");
+        progress.ProcessedEvents.Should().Be(50);
+        progress.TotalEvents.Should().Be(100);
+        progress.PercentComplete.Should().Be(50.0);
+        progress.IsCompleted.Should().BeFalse();
+        progress.EventsPerSecond.Should().Be(25.5);
+    }
+
+    [Fact]
+    public void ProjectionRebuildProgress_DefaultEventsPerSecond_IsZero()
+    {
+        // Arrange / Act
+        var progress = new ProjectionRebuildProgress("pid", 0, 0, 0, true);
+
+        // Assert
+        progress.EventsPerSecond.Should().Be(0.0);
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Observability/CorrelationIdTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Observability/CorrelationIdTests.cs
@@ -1,0 +1,191 @@
+// -----------------------------------------------------------------------
+// <copyright file="CorrelationIdTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Infrastructure.Tests.Observability;
+
+/// <summary>
+/// Unit tests for <see cref="CorrelationIdProvider"/> and <see cref="CorrelationIdScope"/>.
+/// Validates correlation ID lifecycle, async-local isolation, and scope semantics.
+/// </summary>
+public sealed class CorrelationIdTests
+{
+    [Fact]
+    public void GetCorrelationId_WhenNoneSet_GeneratesNewCorrelationId()
+    {
+        // Arrange
+        var provider = new CorrelationIdProvider();
+
+        // Act
+        var correlationId = provider.GetCorrelationId();
+
+        // Assert
+        correlationId.Should().NotBeNullOrEmpty();
+        Guid.TryParse(correlationId, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetCorrelationId_WhenAlreadySet_ReturnsSameValue()
+    {
+        // Arrange
+        var provider = new CorrelationIdProvider();
+        provider.SetCorrelationId("custom-id");
+
+        // Act
+        var first = provider.GetCorrelationId();
+        var second = provider.GetCorrelationId();
+
+        // Assert
+        first.Should().Be("custom-id");
+        second.Should().Be("custom-id");
+    }
+
+    [Fact]
+    public void SetCorrelationId_WithValidId_StoresIt()
+    {
+        // Arrange
+        var provider = new CorrelationIdProvider();
+
+        // Act
+        provider.SetCorrelationId("trace-123");
+
+        // Assert
+        provider.GetCorrelationId().Should().Be("trace-123");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void SetCorrelationId_WithInvalidId_ThrowsArgumentException(string? invalid)
+    {
+        // Arrange
+        var provider = new CorrelationIdProvider();
+
+        // Act
+        var act = () => provider.SetCorrelationId(invalid!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Correlation ID cannot be null or empty*");
+    }
+
+    [Fact]
+    public void GenerateCorrelationId_ProducesNewIdAndSetsItAsCurrent()
+    {
+        // Arrange
+        var provider = new CorrelationIdProvider();
+
+        // Act
+        var generated = provider.GenerateCorrelationId();
+        var current = provider.GetCorrelationId();
+
+        // Assert
+        generated.Should().NotBeNullOrEmpty();
+        current.Should().Be(generated);
+        Guid.TryParse(generated, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GenerateCorrelationId_TwoCalls_ProduceDifferentValues()
+    {
+        // Arrange
+        var provider = new CorrelationIdProvider();
+
+        // Act
+        var first = provider.GenerateCorrelationId();
+        var second = provider.GenerateCorrelationId();
+
+        // Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public async Task CorrelationId_IsIsolatedAcrossAsyncFlows()
+    {
+        // Arrange
+        var provider = new CorrelationIdProvider();
+        provider.SetCorrelationId("outer");
+
+        string? innerCorrelationId = null;
+
+        // Act
+        await Task.Run(() =>
+        {
+            provider.SetCorrelationId("inner");
+            innerCorrelationId = provider.GetCorrelationId();
+        });
+
+        // Assert
+        innerCorrelationId.Should().Be("inner");
+        provider.GetCorrelationId().Should().Be("outer");
+    }
+
+    [Fact]
+    public void CorrelationIdScope_Constructor_NullProvider_Throws()
+    {
+        // Arrange / Act
+        var act = () => new CorrelationIdScope(null!, "id");
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("provider");
+    }
+
+    [Fact]
+    public void CorrelationIdScope_SetsCorrelationIdForScope()
+    {
+        // Arrange
+        var provider = new CorrelationIdProvider();
+        provider.SetCorrelationId("outer-id");
+
+        // Act
+        using (new CorrelationIdScope(provider, "scoped-id"))
+        {
+            provider.GetCorrelationId().Should().Be("scoped-id");
+        }
+
+        // Assert — restored after disposal
+        provider.GetCorrelationId().Should().Be("outer-id");
+    }
+
+    [Fact]
+    public void CorrelationIdScope_Dispose_RestoresPreviousId()
+    {
+        // Arrange
+        var provider = new CorrelationIdProvider();
+        provider.SetCorrelationId("first");
+        var scope = new CorrelationIdScope(provider, "second");
+
+        // Act
+        scope.Dispose();
+
+        // Assert
+        provider.GetCorrelationId().Should().Be("first");
+    }
+
+    [Fact]
+    public void CorrelationIdScope_NestedScopes_RestorePreviousIdsCorrectly()
+    {
+        // Arrange
+        var provider = new CorrelationIdProvider();
+        provider.SetCorrelationId("L0");
+
+        // Act / Assert
+        using (new CorrelationIdScope(provider, "L1"))
+        {
+            provider.GetCorrelationId().Should().Be("L1");
+            using (new CorrelationIdScope(provider, "L2"))
+            {
+                provider.GetCorrelationId().Should().Be("L2");
+            }
+
+            provider.GetCorrelationId().Should().Be("L1");
+        }
+
+        provider.GetCorrelationId().Should().Be("L0");
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Observability/InMemoryMetricsTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Observability/InMemoryMetricsTests.cs
@@ -1,0 +1,281 @@
+// -----------------------------------------------------------------------
+// <copyright file="InMemoryMetricsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Infrastructure.Tests.Observability;
+
+/// <summary>
+/// Unit tests for <see cref="InMemoryMetrics"/> covering all metric kinds and validation.
+/// </summary>
+public sealed class InMemoryMetricsTests
+{
+    private readonly ILogger<InMemoryMetrics> _logger = Substitute.For<ILogger<InMemoryMetrics>>();
+    private readonly InMemoryMetrics _sut;
+
+    public InMemoryMetricsTests()
+    {
+        // Arrange
+        _sut = new InMemoryMetrics(_logger);
+    }
+
+    [Fact]
+    public void Ctor_WithNullLogger_Throws()
+    {
+        // Arrange / Act
+        var act = () => new InMemoryMetrics(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("logger");
+    }
+
+    [Fact]
+    public void IncrementCounter_WithValidName_RecordsCounter()
+    {
+        // Arrange / Act
+        _sut.IncrementCounter("hits", 1);
+        _sut.IncrementCounter("hits", 2);
+
+        // Assert
+        var metrics = _sut.GetAllMetrics();
+        metrics.Should().ContainKey("hits");
+        metrics["hits"].Type.Should().Be(MetricType.Counter);
+        metrics["hits"].Value.Should().Be(3);
+    }
+
+    [Fact]
+    public void IncrementCounter_WithDifferentTags_KeepsSeparateEntries()
+    {
+        // Arrange / Act
+        _sut.IncrementCounter("hits", 1, new KeyValuePair<string, object?>("k", "a"));
+        _sut.IncrementCounter("hits", 1, new KeyValuePair<string, object?>("k", "b"));
+
+        // Assert
+        _sut.GetAllMetrics().Should().HaveCount(2);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IncrementCounter_WithEmptyName_Throws(string invalidName)
+    {
+        // Arrange / Act
+        var act = () => _sut.IncrementCounter(invalidName);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .And.ParamName.Should().Be("name");
+    }
+
+    [Fact]
+    public void RecordValue_WithValidName_RecordsGauge()
+    {
+        // Arrange / Act
+        _sut.RecordValue("temp", 42.5);
+
+        // Assert
+        var metrics = _sut.GetAllMetrics();
+        metrics["temp"].Type.Should().Be(MetricType.Gauge);
+        metrics["temp"].Value.Should().Be(42.5);
+    }
+
+    [Fact]
+    public void RecordValue_TwiceWithSameKey_OverridesValue()
+    {
+        // Arrange / Act
+        _sut.RecordValue("g", 1);
+        _sut.RecordValue("g", 7);
+
+        // Assert
+        _sut.GetAllMetrics()["g"].Value.Should().Be(7);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void RecordValue_WithEmptyName_Throws(string invalid)
+    {
+        // Arrange / Act
+        var act = () => _sut.RecordValue(invalid, 0);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void RecordDuration_WithValidName_RecordsHistogram()
+    {
+        // Arrange
+        var duration = TimeSpan.FromMilliseconds(250);
+
+        // Act
+        _sut.RecordDuration("op", duration);
+
+        // Assert
+        var metrics = _sut.GetAllMetrics();
+        metrics["op"].Type.Should().Be(MetricType.Histogram);
+        metrics["op"].Value.Should().Be(250);
+    }
+
+    [Fact]
+    public void RecordDuration_TwoCalls_AveragesValues()
+    {
+        // Arrange / Act
+        _sut.RecordDuration("op", TimeSpan.FromMilliseconds(100));
+        _sut.RecordDuration("op", TimeSpan.FromMilliseconds(200));
+
+        // Assert — implementation does running average
+        _sut.GetAllMetrics()["op"].Value.Should().Be(150);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RecordDuration_WithEmptyName_Throws(string invalid)
+    {
+        // Arrange / Act
+        var act = () => _sut.RecordDuration(invalid, TimeSpan.Zero);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void StartTimer_ReturnsDisposableThatRecordsDuration()
+    {
+        // Arrange / Act
+        using (_sut.StartTimer("scoped-op"))
+        {
+            // some work
+        }
+
+        // Assert
+        _sut.GetAllMetrics().Should().ContainKey("scoped-op");
+        _sut.GetAllMetrics()["scoped-op"].Type.Should().Be(MetricType.Histogram);
+    }
+
+    [Fact]
+    public void RecordEvent_RecordsCounterAndDuration()
+    {
+        // Arrange / Act
+        _sut.RecordEvent("OrderCreated", "order-1", "Order", 12.5);
+
+        // Assert
+        var metrics = _sut.GetAllMetrics();
+        metrics.Keys.Should().Contain(k => k.StartsWith("events.total"));
+        metrics.Keys.Should().Contain(k => k.StartsWith("events.processing.duration"));
+    }
+
+    [Fact]
+    public void RecordProjectionRebuild_RecordsCounterAndDuration()
+    {
+        // Arrange / Act
+        _sut.RecordProjectionRebuild("OrderProjection", 100);
+
+        // Assert
+        var metrics = _sut.GetAllMetrics();
+        metrics.Keys.Should().Contain(k => k.StartsWith("projections.rebuilds.total"));
+        metrics.Keys.Should().Contain(k => k.StartsWith("projections.rebuild.duration"));
+    }
+
+    [Fact]
+    public void RecordCircuitBreakerTrip_IncrementsCounter()
+    {
+        // Arrange / Act
+        _sut.RecordCircuitBreakerTrip("redis");
+
+        // Assert
+        _sut.GetAllMetrics().Keys.Should().Contain(k => k.StartsWith("circuitbreaker.trips.total"));
+    }
+
+    [Fact]
+    public void RecordEncryptionOperation_RecordsDuration()
+    {
+        // Arrange / Act
+        _sut.RecordEncryptionOperation("encrypt", 5);
+
+        // Assert
+        _sut.GetAllMetrics().Keys.Should().Contain(k => k.StartsWith("encryption.operation.duration"));
+    }
+
+    [Fact]
+    public void RecordConnectionSemaphoreWait_RecordsDuration()
+    {
+        // Arrange / Act
+        _sut.RecordConnectionSemaphoreWait(15, "select");
+
+        // Assert
+        _sut.GetAllMetrics().Keys.Should().Contain(k => k.StartsWith("connection.semaphore.wait"));
+    }
+
+    [Fact]
+    public void RecordConnectionAcquisition_RecordsDuration()
+    {
+        // Arrange / Act
+        _sut.RecordConnectionAcquisition(2, "insert");
+
+        // Assert
+        _sut.GetAllMetrics().Keys.Should().Contain(k => k.StartsWith("connection.acquisition.duration"));
+    }
+
+    [Fact]
+    public void RecordQueryExecution_RecordsDuration()
+    {
+        // Arrange / Act
+        _sut.RecordQueryExecution("select", 7, "list_users");
+
+        // Assert
+        _sut.GetAllMetrics().Keys.Should().Contain(k => k.StartsWith("database.query.duration"));
+    }
+
+    [Fact]
+    public void RecordActiveConnections_RecordsGauge()
+    {
+        // Arrange / Act
+        _sut.RecordActiveConnections(8);
+
+        // Assert
+        _sut.GetAllMetrics().Should().ContainKey("connection.active");
+        _sut.GetAllMetrics()["connection.active"].Value.Should().Be(8);
+    }
+
+    [Fact]
+    public void RecordSemaphoreQueueLength_RecordsGauge()
+    {
+        // Arrange / Act
+        _sut.RecordSemaphoreQueueLength(3);
+
+        // Assert
+        _sut.GetAllMetrics().Should().ContainKey("connection.semaphore.queue");
+        _sut.GetAllMetrics()["connection.semaphore.queue"].Value.Should().Be(3);
+    }
+
+    [Fact]
+    public void RecordConnectionError_IncrementsCounter()
+    {
+        // Arrange / Act
+        _sut.RecordConnectionError("timeout", "select");
+
+        // Assert
+        _sut.GetAllMetrics().Keys.Should().Contain(k => k.StartsWith("connection.errors.total"));
+    }
+
+    [Fact]
+    public void GetAllMetrics_ReturnsImmutableSnapshot()
+    {
+        // Arrange
+        _sut.IncrementCounter("a");
+        var snapshot1 = _sut.GetAllMetrics();
+
+        // Act
+        _sut.IncrementCounter("b");
+        var snapshot2 = _sut.GetAllMetrics();
+
+        // Assert
+        snapshot1.Should().HaveCount(1);
+        snapshot2.Should().HaveCount(2);
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Observability/InMemoryTracingTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Observability/InMemoryTracingTests.cs
@@ -1,0 +1,316 @@
+// -----------------------------------------------------------------------
+// <copyright file="InMemoryTracingTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+
+namespace Compendium.Infrastructure.Tests.Observability;
+
+/// <summary>
+/// Unit tests for <see cref="InMemoryTracing"/> span lifecycle and async-flow isolation.
+/// </summary>
+public sealed class InMemoryTracingTests
+{
+    private readonly ILogger<InMemoryTracing> _logger = Substitute.For<ILogger<InMemoryTracing>>();
+    private readonly InMemoryTracing _sut;
+
+    public InMemoryTracingTests()
+    {
+        // Arrange
+        _sut = new InMemoryTracing(_logger);
+    }
+
+    [Fact]
+    public void Ctor_WithNullLogger_Throws()
+    {
+        // Arrange / Act
+        var act = () => new InMemoryTracing(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("logger");
+    }
+
+    [Fact]
+    public void StartSpan_WithValidName_ReturnsActiveSpanAndSetsCurrent()
+    {
+        // Arrange / Act
+        using var span = _sut.StartSpan("op-1");
+
+        // Assert
+        span.Should().NotBeNull();
+        span.OperationName.Should().Be("op-1");
+        span.SpanId.Should().NotBeNullOrEmpty();
+        span.TraceId.Should().NotBeNullOrEmpty();
+        _sut.GetCurrentSpan().Should().BeSameAs(span);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void StartSpan_WithEmptyName_Throws(string invalid)
+    {
+        // Arrange / Act
+        var act = () => _sut.StartSpan(invalid);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .And.ParamName.Should().Be("operationName");
+    }
+
+    [Fact]
+    public void StartSpan_WithExplicitParent_SharesTraceId()
+    {
+        // Arrange
+        using var parent = _sut.StartSpan("parent");
+
+        // Act
+        using var child = _sut.StartSpan("child", parent);
+
+        // Assert
+        child.TraceId.Should().Be(parent.TraceId);
+        child.SpanId.Should().NotBe(parent.SpanId);
+    }
+
+    [Fact]
+    public void StartSpan_WithoutExplicitParent_UsesCurrentAsParent()
+    {
+        // Arrange
+        using var outer = _sut.StartSpan("outer");
+
+        // Act
+        using var inner = _sut.StartSpan("inner");
+
+        // Assert
+        inner.TraceId.Should().Be(outer.TraceId);
+    }
+
+    [Fact]
+    public void GetCurrentSpan_NoSpanStarted_ReturnsNull()
+    {
+        // Arrange / Act
+        var current = _sut.GetCurrentSpan();
+
+        // Assert
+        current.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetCurrentSpan_StoresValue()
+    {
+        // Arrange
+        using var span = _sut.StartSpan("op");
+
+        // Act
+        _sut.SetCurrentSpan(null);
+
+        // Assert
+        _sut.GetCurrentSpan().Should().BeNull();
+    }
+
+    [Fact]
+    public void StartActivity_PlaceholderImplementation_ReturnsNull()
+    {
+        // Arrange / Act
+        var activity = _sut.StartActivity("placeholder");
+
+        // Assert
+        activity.Should().BeNull();
+    }
+
+    [Fact]
+    public void AddEvent_PlaceholderImplementation_DoesNotThrow()
+    {
+        // Arrange / Act
+        var act = () => _sut.AddEvent(null, "evt", new Dictionary<string, object>());
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void SetStatus_PlaceholderImplementation_DoesNotThrow()
+    {
+        // Arrange / Act
+        var act = () =>
+        {
+            using var activity = new Activity("test");
+            _sut.SetStatus(activity, true, "ok");
+            _sut.SetStatus(null, false);
+        };
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Span_Dispose_SetsEndTimeAndStatusOk()
+    {
+        // Arrange
+        var span = _sut.StartSpan("disposable");
+
+        // Act
+        span.Dispose();
+
+        // Assert
+        span.EndTime.Should().NotBeNull();
+        span.Duration.Should().NotBeNull();
+        span.Status.Should().Be(TraceSpanStatus.Ok);
+    }
+
+    [Fact]
+    public void Span_Dispose_TwiceIsIdempotent()
+    {
+        // Arrange
+        var span = _sut.StartSpan("repeat-dispose");
+
+        // Act
+        span.Dispose();
+        var firstEnd = span.EndTime;
+        span.Dispose();
+
+        // Assert
+        span.EndTime.Should().Be(firstEnd);
+    }
+
+    [Fact]
+    public void Span_SetStatus_StoresStatus()
+    {
+        // Arrange
+        using var span = _sut.StartSpan("with-status");
+
+        // Act
+        span.SetStatus(TraceSpanStatus.Error, "boom");
+
+        // Assert
+        span.Status.Should().Be(TraceSpanStatus.Error);
+        span.Tags.Should().ContainKey("status.description");
+        span.Tags["status.description"].Should().Be("boom");
+    }
+
+    [Fact]
+    public void Span_SetStatus_Disposed_StaysAtSetStatus()
+    {
+        // Arrange
+        var span = _sut.StartSpan("error-then-dispose");
+        span.SetStatus(TraceSpanStatus.Error);
+
+        // Act
+        span.Dispose();
+
+        // Assert — when disposed and status already set (not Unset), it should stay
+        span.Status.Should().Be(TraceSpanStatus.Error);
+    }
+
+    [Fact]
+    public void Span_SetTag_StoresTag()
+    {
+        // Arrange
+        using var span = _sut.StartSpan("tagged");
+
+        // Act
+        span.SetTag("user", "alice");
+        span.SetTag("count", 42);
+
+        // Assert
+        span.Tags["user"].Should().Be("alice");
+        span.Tags["count"].Should().Be(42);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Span_SetTag_EmptyKey_Throws(string invalid)
+    {
+        // Arrange
+        using var span = _sut.StartSpan("invalid-tag");
+
+        // Act
+        var act = () => span.SetTag(invalid, "x");
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .And.ParamName.Should().Be("key");
+    }
+
+    [Fact]
+    public void Span_AddEvent_StoresEvent()
+    {
+        // Arrange
+        using var span = _sut.StartSpan("with-event");
+        var ts = DateTime.UtcNow.AddMinutes(-1);
+
+        // Act
+        span.AddEvent("evt-1", ts,
+            new KeyValuePair<string, object?>("k", "v"));
+        span.AddEvent("evt-2");
+
+        // Assert
+        span.Events.Should().HaveCount(2);
+        span.Events[0].Name.Should().Be("evt-1");
+        span.Events[0].Timestamp.Should().Be(ts);
+        span.Events[0].Attributes["k"].Should().Be("v");
+        span.Events[1].Name.Should().Be("evt-2");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Span_AddEvent_EmptyName_Throws(string invalid)
+    {
+        // Arrange
+        using var span = _sut.StartSpan("op");
+
+        // Act
+        var act = () => span.AddEvent(invalid);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .And.ParamName.Should().Be("name");
+    }
+
+    [Fact]
+    public void Span_RecordException_SetsErrorStatusAndAddsExceptionEvent()
+    {
+        // Arrange
+        using var span = _sut.StartSpan("failing");
+        var ex = new InvalidOperationException("kaboom");
+
+        // Act
+        span.RecordException(ex);
+
+        // Assert
+        span.Status.Should().Be(TraceSpanStatus.Error);
+        span.Events.Should().ContainSingle(e => e.Name == "exception");
+        var evt = span.Events.Single();
+        evt.Attributes["exception.type"].Should().Be(nameof(InvalidOperationException));
+        evt.Attributes["exception.message"].Should().Be("kaboom");
+    }
+
+    [Fact]
+    public void Span_RecordException_NullException_Throws()
+    {
+        // Arrange
+        using var span = _sut.StartSpan("op");
+
+        // Act
+        var act = () => span.RecordException(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Span_DurationWhileActive_IsNull()
+    {
+        // Arrange
+        using var span = _sut.StartSpan("active");
+
+        // Act / Assert
+        span.EndTime.Should().BeNull();
+        span.Duration.Should().BeNull();
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Observability/Logging/EventSourcingLogEnricherTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Observability/Logging/EventSourcingLogEnricherTests.cs
@@ -1,0 +1,157 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventSourcingLogEnricherTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Observability.Logging;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Compendium.Infrastructure.Tests.Observability.Logging;
+
+/// <summary>
+/// Unit tests for <see cref="EventSourcingLogEnricher"/> and <see cref="EventSourcingContext"/>.
+/// </summary>
+public sealed class EventSourcingLogEnricherTests
+{
+    private readonly ICorrelationIdProvider _correlationProvider;
+    private readonly EventSourcingLogEnricher _sut;
+
+    public EventSourcingLogEnricherTests()
+    {
+        // Arrange
+        _correlationProvider = Substitute.For<ICorrelationIdProvider>();
+        _correlationProvider.GetCorrelationId().Returns("corr-1");
+        _sut = new EventSourcingLogEnricher(_correlationProvider);
+
+        // Reset the AsyncLocal context to keep tests isolated.
+        EventSourcingContext.Clear();
+    }
+
+    [Fact]
+    public void Ctor_NullProvider_Throws()
+    {
+        // Arrange / Act
+        var act = () => new EventSourcingLogEnricher(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("correlationIdProvider");
+    }
+
+    [Fact]
+    public void Enrich_AddsCorrelationIdProperty()
+    {
+        // Arrange
+        var logEvent = CreateLogEvent();
+        var factory = new TestLogEventPropertyFactory();
+
+        // Act
+        _sut.Enrich(logEvent, factory);
+
+        // Assert
+        logEvent.Properties.Should().ContainKey("CorrelationId");
+        logEvent.Properties["CorrelationId"].ToString().Should().Contain("corr-1");
+    }
+
+    [Fact]
+    public void Enrich_WithFullContext_AddsAllProperties()
+    {
+        // Arrange
+        var logEvent = CreateLogEvent();
+        var factory = new TestLogEventPropertyFactory();
+        EventSourcingContext.Current = new EventSourcingContext
+        {
+            AggregateId = "agg-1",
+            TenantId = "ten-1",
+            EventType = "Created",
+            AggregateVersion = 5,
+        };
+
+        // Act
+        _sut.Enrich(logEvent, factory);
+
+        // Assert
+        logEvent.Properties.Should().ContainKey("AggregateId");
+        logEvent.Properties.Should().ContainKey("TenantId");
+        logEvent.Properties.Should().ContainKey("EventType");
+        logEvent.Properties.Should().ContainKey("AggregateVersion");
+    }
+
+    [Fact]
+    public void Enrich_WithEmptyContext_OnlyAddsCorrelationId()
+    {
+        // Arrange
+        var logEvent = CreateLogEvent();
+        var factory = new TestLogEventPropertyFactory();
+
+        // Act
+        _sut.Enrich(logEvent, factory);
+
+        // Assert
+        logEvent.Properties.Should().ContainKey("CorrelationId");
+        logEvent.Properties.Should().NotContainKey("AggregateId");
+        logEvent.Properties.Should().NotContainKey("TenantId");
+        logEvent.Properties.Should().NotContainKey("EventType");
+        logEvent.Properties.Should().NotContainKey("AggregateVersion");
+    }
+
+    [Fact]
+    public void EventSourcingContext_BeginScope_ChangesCurrentAndDisposeRestoresIt()
+    {
+        // Arrange
+        EventSourcingContext.Current = new EventSourcingContext { AggregateId = "outer" };
+
+        // Act
+        using (EventSourcingContext.BeginScope("inner-id", "tenant-x", "event-x", 9))
+        {
+            EventSourcingContext.Current.AggregateId.Should().Be("inner-id");
+            EventSourcingContext.Current.TenantId.Should().Be("tenant-x");
+            EventSourcingContext.Current.EventType.Should().Be("event-x");
+            EventSourcingContext.Current.AggregateVersion.Should().Be(9);
+        }
+
+        // Assert
+        EventSourcingContext.Current.AggregateId.Should().Be("outer");
+    }
+
+    [Fact]
+    public void EventSourcingContext_Clear_ResetsContext()
+    {
+        // Arrange
+        EventSourcingContext.Current = new EventSourcingContext
+        {
+            AggregateId = "agg",
+            TenantId = "ten",
+            EventType = "evt",
+            AggregateVersion = 1,
+        };
+
+        // Act
+        EventSourcingContext.Clear();
+
+        // Assert
+        EventSourcingContext.Current.AggregateId.Should().BeNull();
+        EventSourcingContext.Current.TenantId.Should().BeNull();
+        EventSourcingContext.Current.EventType.Should().BeNull();
+        EventSourcingContext.Current.AggregateVersion.Should().BeNull();
+    }
+
+    private static LogEvent CreateLogEvent() => new(
+        DateTimeOffset.UtcNow,
+        LogEventLevel.Information,
+        exception: null,
+        new MessageTemplate("test", Array.Empty<MessageTemplateToken>()),
+        Array.Empty<LogEventProperty>());
+
+    private sealed class TestLogEventPropertyFactory : ILogEventPropertyFactory
+    {
+        public LogEventProperty CreateProperty(string name, object? value, bool destructureObjects = false)
+        {
+            return new LogEventProperty(name, new ScalarValue(value));
+        }
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Observability/Logging/LoggingExtensionsTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Observability/Logging/LoggingExtensionsTests.cs
@@ -1,0 +1,209 @@
+// -----------------------------------------------------------------------
+// <copyright file="LoggingExtensionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Observability.Logging;
+
+namespace Compendium.Infrastructure.Tests.Observability.Logging;
+
+/// <summary>
+/// Unit tests for <see cref="LoggingExtensions"/> helpers that wrap log calls
+/// with <see cref="EventSourcingContext"/> scopes.
+/// </summary>
+public sealed class LoggingExtensionsTests
+{
+    private readonly ILogger _logger = Substitute.For<ILogger>();
+
+    public LoggingExtensionsTests()
+    {
+        EventSourcingContext.Clear();
+    }
+
+    [Fact]
+    public void BeginEventSourcingScope_WithValidArgs_ReturnsScopeAndPopulatesContext()
+    {
+        // Arrange / Act
+        using (_logger.BeginEventSourcingScope("agg-1", "tenant-1", "EventX", 3))
+        {
+            // Assert (inside scope)
+            EventSourcingContext.Current.AggregateId.Should().Be("agg-1");
+            EventSourcingContext.Current.TenantId.Should().Be("tenant-1");
+            EventSourcingContext.Current.EventType.Should().Be("EventX");
+            EventSourcingContext.Current.AggregateVersion.Should().Be(3);
+        }
+
+        // Assert (outside scope) — restored
+        EventSourcingContext.Current.AggregateId.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void BeginEventSourcingScope_WithEmptyAggregateId_Throws(string? invalid)
+    {
+        // Arrange / Act
+        var act = () => _logger.BeginEventSourcingScope(invalid!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void LogEventAppended_WithValidArgs_LogsInformation()
+    {
+        // Arrange / Act
+        _logger.LogEventAppended("agg-1", "Created", 1, "tenant-1");
+
+        // Assert
+        _logger.ReceivedCalls()
+            .Any(c => c.GetMethodInfo().Name == nameof(ILogger.Log))
+            .Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("", "evt")]
+    [InlineData("agg", "")]
+    public void LogEventAppended_WithEmptyArgs_Throws(string aggId, string eventType)
+    {
+        // Arrange / Act
+        var act = () => _logger.LogEventAppended(aggId, eventType, 1);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void LogEventsLoaded_WithToVersion_LogsRange()
+    {
+        // Arrange / Act
+        _logger.LogEventsLoaded("agg-1", 1, 10, "tenant-1");
+
+        // Assert
+        _logger.ReceivedCalls().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void LogEventsLoaded_WithoutToVersion_LogsFromOnly()
+    {
+        // Arrange / Act
+        _logger.LogEventsLoaded("agg-1", 1);
+
+        // Assert
+        _logger.ReceivedCalls().Should().NotBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void LogEventsLoaded_EmptyAggId_Throws(string? invalid)
+    {
+        // Arrange / Act
+        var act = () => _logger.LogEventsLoaded(invalid!, 1);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void LogProjectionRebuildStarted_WithValidArgs_Logs()
+    {
+        // Arrange / Act
+        _logger.LogProjectionRebuildStarted("Projection-A", 0);
+
+        // Assert
+        _logger.ReceivedCalls().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void LogProjectionRebuildStarted_EmptyName_Throws()
+    {
+        // Arrange / Act
+        var act = () => _logger.LogProjectionRebuildStarted("", 0);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void LogProjectionRebuildCompleted_WithValidArgs_Logs()
+    {
+        // Arrange / Act
+        _logger.LogProjectionRebuildCompleted("Projection-A", 100, 1500);
+
+        // Assert
+        _logger.ReceivedCalls().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void LogProjectionRebuildCompleted_EmptyName_Throws()
+    {
+        // Arrange / Act
+        var act = () => _logger.LogProjectionRebuildCompleted("", 1, 2);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void LogConcurrencyConflict_WithValidArgs_LogsWarning()
+    {
+        // Arrange / Act
+        _logger.LogConcurrencyConflict("agg-1", 1, 2, "tenant-1");
+
+        // Assert
+        _logger.ReceivedCalls().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void LogConcurrencyConflict_EmptyAggId_Throws()
+    {
+        // Arrange / Act
+        var act = () => _logger.LogConcurrencyConflict("", 1, 2);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void LogSnapshotSaved_WithValidArgs_Logs()
+    {
+        // Arrange / Act
+        _logger.LogSnapshotSaved("agg-1", 5, "tenant-1");
+
+        // Assert
+        _logger.ReceivedCalls().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void LogSnapshotSaved_EmptyAggId_Throws()
+    {
+        // Arrange / Act
+        var act = () => _logger.LogSnapshotSaved("", 1);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void LogSnapshotLoaded_WithValidArgs_Logs()
+    {
+        // Arrange / Act
+        _logger.LogSnapshotLoaded("agg-1", 5, "tenant-1");
+
+        // Assert
+        _logger.ReceivedCalls().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void LogSnapshotLoaded_EmptyAggId_Throws()
+    {
+        // Arrange / Act
+        var act = () => _logger.LogSnapshotLoaded("", 1);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Observability/Logging/SerilogConfigurationTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Observability/Logging/SerilogConfigurationTests.cs
@@ -1,0 +1,149 @@
+// -----------------------------------------------------------------------
+// <copyright file="SerilogConfigurationTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Observability.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace Compendium.Infrastructure.Tests.Observability.Logging;
+
+/// <summary>
+/// Unit tests for <see cref="SerilogConfiguration"/> covering minimum log level,
+/// environment-driven sinks and host-builder integration.
+/// </summary>
+public sealed class SerilogConfigurationTests
+{
+    [Fact]
+    public void ConfigureSerilog_DevelopmentEnvironment_BuildsValidLogger()
+    {
+        // Arrange
+        var environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(Environments.Development);
+        var configuration = BuildConfig(new Dictionary<string, string?>());
+        var loggerConfig = new LoggerConfiguration();
+
+        // Act
+        SerilogConfiguration.ConfigureSerilog(loggerConfig, configuration, environment);
+        using var logger = loggerConfig.CreateLogger();
+
+        // Assert
+        logger.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ConfigureSerilog_ProductionEnvironment_BuildsValidLogger()
+    {
+        // Arrange
+        var environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(Environments.Production);
+        var tempDir = Directory.CreateTempSubdirectory().FullName;
+        var logPath = Path.Combine(tempDir, "test-.log");
+        var configuration = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Logging:File:Path"] = logPath,
+        });
+        var loggerConfig = new LoggerConfiguration();
+
+        try
+        {
+            // Act
+            SerilogConfiguration.ConfigureSerilog(loggerConfig, configuration, environment);
+            using var logger = loggerConfig.CreateLogger();
+
+            // Assert
+            logger.Should().NotBeNull();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ConfigureSerilog_WithExplicitLogLevel_AppliesIt()
+    {
+        // Arrange
+        var environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(Environments.Development);
+        var configuration = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Logging:LogLevel:Default"] = "Warning",
+        });
+        var loggerConfig = new LoggerConfiguration();
+
+        // Act
+        SerilogConfiguration.ConfigureSerilog(loggerConfig, configuration, environment);
+        using var logger = loggerConfig.CreateLogger();
+
+        // Assert
+        logger.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ConfigureSerilog_WithSeqApiKey_BuildsValidLogger()
+    {
+        // Arrange
+        var environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(Environments.Development);
+        var configuration = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Logging:Seq:Url"] = "http://seq:5341",
+            ["Logging:Seq:ApiKey"] = "secret-key",
+        });
+        var loggerConfig = new LoggerConfiguration();
+
+        // Act
+        SerilogConfiguration.ConfigureSerilog(loggerConfig, configuration, environment);
+        using var logger = loggerConfig.CreateLogger();
+
+        // Assert
+        logger.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ConfigureSerilog_HostBuilderContextOverload_BuildsValidLogger()
+    {
+        // Arrange
+        var hostBuilder = Host.CreateDefaultBuilder()
+            .ConfigureAppConfiguration((_, c) =>
+            {
+                c.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Logging:Seq:Url"] = "http://seq:5341",
+                });
+            })
+            .UseEnvironment(Environments.Development);
+
+        // Act
+        hostBuilder.UseSerilog(SerilogConfiguration.ConfigureSerilog);
+        using var host = hostBuilder.Build();
+
+        // Assert
+        host.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void UseCompendiumSerilog_HostBuilderExtension_RegistersSerilog()
+    {
+        // Arrange
+        var hostBuilder = Host.CreateDefaultBuilder()
+            .UseEnvironment(Environments.Development);
+
+        // Act
+        hostBuilder.UseCompendiumSerilog();
+        using var host = hostBuilder.Build();
+
+        // Assert
+        host.Should().NotBeNull();
+    }
+
+    private static IConfiguration BuildConfig(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Projections/EnhancedProjectionManagerTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Projections/EnhancedProjectionManagerTests.cs
@@ -1,0 +1,444 @@
+// -----------------------------------------------------------------------
+// <copyright file="EnhancedProjectionManagerTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using Compendium.Infrastructure.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Compendium.Infrastructure.Tests.Projections;
+
+/// <summary>
+/// Unit tests for <see cref="EnhancedProjectionManager"/> exercising rebuild orchestration,
+/// progress reporting, lifecycle operations and statistics aggregation.
+/// </summary>
+public sealed class EnhancedProjectionManagerTests
+{
+    [Fact]
+    public void Ctor_NullEventStore_Throws()
+    {
+        // Arrange / Act
+        var act = () => new EnhancedProjectionManager(
+            null!,
+            Substitute.For<IProjectionStore>(),
+            BuildServiceProvider(),
+            NullLogger<EnhancedProjectionManager>.Instance,
+            Options.Create(new ProjectionOptions()));
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("eventStore");
+    }
+
+    [Fact]
+    public void Ctor_NullProjectionStore_Throws()
+    {
+        // Arrange / Act
+        var act = () => new EnhancedProjectionManager(
+            Substitute.For<IStreamingEventStore>(),
+            null!,
+            BuildServiceProvider(),
+            NullLogger<EnhancedProjectionManager>.Instance,
+            Options.Create(new ProjectionOptions()));
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("projectionStore");
+    }
+
+    [Fact]
+    public void Ctor_NullServiceProvider_Throws()
+    {
+        // Arrange / Act
+        var act = () => new EnhancedProjectionManager(
+            Substitute.For<IStreamingEventStore>(),
+            Substitute.For<IProjectionStore>(),
+            null!,
+            NullLogger<EnhancedProjectionManager>.Instance,
+            Options.Create(new ProjectionOptions()));
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("serviceProvider");
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_Throws()
+    {
+        // Arrange / Act
+        var act = () => new EnhancedProjectionManager(
+            Substitute.For<IStreamingEventStore>(),
+            Substitute.For<IProjectionStore>(),
+            BuildServiceProvider(),
+            null!,
+            Options.Create(new ProjectionOptions()));
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("logger");
+    }
+
+    [Fact]
+    public void Ctor_NullOptions_FallsBackToDefaults()
+    {
+        // Arrange / Act
+        using var sut = new EnhancedProjectionManager(
+            Substitute.For<IStreamingEventStore>(),
+            Substitute.For<IProjectionStore>(),
+            BuildServiceProvider(),
+            NullLogger<EnhancedProjectionManager>.Instance,
+            null!);
+
+        // Assert — default options keep things buildable
+        sut.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void RegisterProjection_AddsProjectionType()
+    {
+        // Arrange
+        using var sut = CreateSut(out _, out _);
+
+        // Act
+        sut.RegisterProjection<TestProjection>();
+
+        // Assert
+        var stats = sut.GetStatisticsAsync().GetAwaiter().GetResult();
+        stats.TotalProjections.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetStatisticsAsync_NoProjections_ReturnsZeroes()
+    {
+        // Arrange
+        using var sut = CreateSut(out _, out _);
+
+        // Act
+        var stats = await sut.GetStatisticsAsync();
+
+        // Assert
+        stats.TotalProjections.Should().Be(0);
+        stats.ActiveProjections.Should().Be(0);
+        stats.RebuildingProjections.Should().Be(0);
+        stats.PausedProjections.Should().Be(0);
+        stats.FailedProjections.Should().Be(0);
+        stats.ProjectionDetails.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetProjectionStateAsync_LoadsFromStoreWhenAvailable()
+    {
+        // Arrange
+        using var sut = CreateSut(out _, out var store);
+        var stored = new ProjectionState
+        {
+            ProjectionName = "TestProjection",
+            Status = ProjectionStatus.Building,
+        };
+        store.GetProjectionStateAsync("TestProjection", Arg.Any<CancellationToken>())
+            .Returns(stored);
+
+        // Act
+        var state = await sut.GetProjectionStateAsync("TestProjection");
+
+        // Assert
+        state.Should().BeSameAs(stored);
+    }
+
+    [Fact]
+    public async Task GetProjectionStateAsync_StoreReturnsNull_ReturnsDefaultIdleState()
+    {
+        // Arrange
+        using var sut = CreateSut(out _, out var store);
+        store.GetProjectionStateAsync("missing", Arg.Any<CancellationToken>())
+            .Returns((ProjectionState?)null);
+
+        // Act
+        var state = await sut.GetProjectionStateAsync("missing");
+
+        // Assert
+        state.Status.Should().Be(ProjectionStatus.Idle);
+        state.ProjectionName.Should().Be("missing");
+    }
+
+    [Fact]
+    public async Task GetProjectionStateAsync_SecondCall_ReturnsCachedState()
+    {
+        // Arrange
+        using var sut = CreateSut(out _, out var store);
+        var stored = new ProjectionState { ProjectionName = "P", Status = ProjectionStatus.Building };
+        store.GetProjectionStateAsync("P", Arg.Any<CancellationToken>())
+            .Returns(stored, (ProjectionState?)null);
+
+        // Act
+        var first = await sut.GetProjectionStateAsync("P");
+        var second = await sut.GetProjectionStateAsync("P");
+
+        // Assert
+        second.Should().BeSameAs(first);
+        await store.Received(1).GetProjectionStateAsync("P", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PauseProjectionAsync_SavesPausedState()
+    {
+        // Arrange
+        using var sut = CreateSut(out _, out var store);
+
+        // Act
+        await sut.PauseProjectionAsync("P");
+
+        // Assert
+        await store.Received(1).SaveProjectionStateAsync(
+            Arg.Is<ProjectionState>(s => s.ProjectionName == "P" && s.Status == ProjectionStatus.Paused),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResumeProjectionAsync_SavesBuildingState()
+    {
+        // Arrange
+        using var sut = CreateSut(out _, out var store);
+
+        // Act
+        await sut.ResumeProjectionAsync("P");
+
+        // Assert
+        await store.Received(1).SaveProjectionStateAsync(
+            Arg.Is<ProjectionState>(s => s.ProjectionName == "P" && s.Status == ProjectionStatus.Building),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteProjectionAsync_ClearsStateAndDelegatesToStore()
+    {
+        // Arrange
+        using var sut = CreateSut(out _, out var store);
+        sut.RegisterProjection<TestProjection>();
+
+        // Act
+        await sut.DeleteProjectionAsync("TestProjection");
+        var stats = await sut.GetStatisticsAsync();
+
+        // Assert
+        stats.TotalProjections.Should().Be(0);
+        await store.Received(1).DeleteProjectionDataAsync("TestProjection", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_NoEvents_CompletesAndUpdatesState()
+    {
+        // Arrange
+        using var sut = CreateSut(out var eventStore, out var store);
+        eventStore.GetEventCountAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(0);
+        eventStore.StreamEventsAsync(Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(EmptyEventStream());
+
+        // Act
+        await sut.RebuildProjectionAsync<TestProjection>();
+
+        // Assert
+        await store.Received().SaveProjectionStateAsync(
+            Arg.Is<ProjectionState>(s => s.Status == ProjectionStatus.Completed),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_StreamThrows_MarksAsFailedAndRethrows()
+    {
+        // Arrange
+        using var sut = CreateSut(out var eventStore, out var store);
+        eventStore.GetEventCountAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(0);
+        eventStore.StreamEventsAsync(Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(ThrowingEventStream());
+
+        // Act
+        Func<Task> act = async () => await sut.RebuildProjectionAsync<TestProjection>();
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("stream-fail");
+        await store.Received().SaveProjectionStateAsync(
+            Arg.Is<ProjectionState>(s => s.Status == ProjectionStatus.Failed),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_WithEvents_AppliesEventsAndReportsProgress()
+    {
+        // Arrange
+        using var sut = CreateSut(out var eventStore, out var store);
+        eventStore.GetEventCountAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(2L);
+        eventStore.StreamEventsAsync(Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(TwoEventStream());
+
+        var progressReports = new List<RebuildProgress>();
+        var progress = new Progress<RebuildProgress>(p => progressReports.Add(p));
+
+        // Act
+        await sut.RebuildProjectionAsync<TestProjection>(progress: progress);
+        await Task.Delay(50); // allow Progress<T> callbacks to dispatch
+
+        // Assert
+        await store.Received().SaveCheckpointAsync("TestProjection", Arg.Any<long>(), Arg.Any<CancellationToken>());
+        await store.Received().SaveProjectionStateAsync(
+            Arg.Is<ProjectionState>(s => s.Status == ProjectionStatus.Completed),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_WithSnapshotsEnabled_SavesSnapshot()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IStreamingEventStore>();
+        eventStore.GetEventCountAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(0L);
+        eventStore.StreamEventsAsync(Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(EmptyEventStream());
+
+        var store = Substitute.For<IProjectionStore>();
+        store.GetCheckpointAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((long?)null);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<TestProjection>();
+        var sp = services.BuildServiceProvider();
+        using var sut = new EnhancedProjectionManager(
+            eventStore,
+            store,
+            sp,
+            NullLogger<EnhancedProjectionManager>.Instance,
+            Options.Create(new ProjectionOptions { EnableSnapshots = true, RebuildBatchSize = 5 }));
+
+        // Act
+        await sut.RebuildProjectionAsync<TestProjection>();
+
+        // Assert
+        await store.Received().SaveSnapshotAsync(Arg.Any<TestProjection>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RebuildProjectionAsync_StreamThrowsCancellation_MarksAsPausedAndRethrows()
+    {
+        // Arrange
+        using var sut = CreateSut(out var eventStore, out var store);
+        eventStore.GetEventCountAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(0);
+        eventStore.StreamEventsAsync(Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(CancelledEventStream());
+
+        // Act
+        Func<Task> act = async () => await sut.RebuildProjectionAsync<TestProjection>();
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await store.Received().SaveProjectionStateAsync(
+            Arg.Is<ProjectionState>(s => s.Status == ProjectionStatus.Paused),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void Dispose_TwiceIsIdempotent()
+    {
+        // Arrange
+        var sut = CreateSut(out _, out _);
+
+        // Act / Assert
+        sut.Dispose();
+        sut.Dispose();
+    }
+
+    private static EnhancedProjectionManager CreateSut(out IStreamingEventStore eventStore, out IProjectionStore store)
+    {
+        eventStore = Substitute.For<IStreamingEventStore>();
+        eventStore.GetEventCountAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(0L);
+
+        store = Substitute.For<IProjectionStore>();
+        store.GetCheckpointAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((long?)null);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<TestProjection>();
+        var sp = services.BuildServiceProvider();
+
+        return new EnhancedProjectionManager(
+            eventStore,
+            store,
+            sp,
+            NullLogger<EnhancedProjectionManager>.Instance,
+            Options.Create(new ProjectionOptions { EnableSnapshots = false, ProgressReportInterval = 1, RebuildBatchSize = 10 }));
+    }
+
+    private static IServiceProvider BuildServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<TestProjection>();
+        return services.BuildServiceProvider();
+    }
+
+    private static async IAsyncEnumerable<EventData> EmptyEventStream(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<EventData> TwoEventStream(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+        yield return new EventData
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = "s",
+            StreamPosition = 1,
+            GlobalPosition = 1,
+            Timestamp = DateTime.UtcNow,
+            EventType = "e",
+            Event = new TestEvent(),
+        };
+        yield return new EventData
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = "s",
+            StreamPosition = 2,
+            GlobalPosition = 2,
+            Timestamp = DateTime.UtcNow,
+            EventType = "e",
+            Event = new TestEvent(),
+        };
+    }
+
+    private sealed class TestEvent : IDomainEvent
+    {
+        public Guid EventId { get; init; } = Guid.NewGuid();
+        public string AggregateId { get; init; } = "agg-1";
+        public string AggregateType { get; init; } = "Test";
+        public DateTimeOffset OccurredOn { get; init; } = DateTimeOffset.UtcNow;
+        public long AggregateVersion { get; init; } = 1;
+        public int EventVersion { get; init; } = 1;
+    }
+
+    private static async IAsyncEnumerable<EventData> ThrowingEventStream(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+        throw new InvalidOperationException("stream-fail");
+#pragma warning disable CS0162 // Unreachable
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    private static async IAsyncEnumerable<EventData> CancelledEventStream(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+        throw new OperationCanceledException("cancelled mid-stream");
+#pragma warning disable CS0162 // Unreachable
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    private sealed class TestProjection : Compendium.Infrastructure.Projections.IProjection
+    {
+        public string ProjectionName => "TestProjection";
+        public int Version => 1;
+        public Task ResetAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Projections/LiveProjectionProcessorTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Projections/LiveProjectionProcessorTests.cs
@@ -1,0 +1,360 @@
+// -----------------------------------------------------------------------
+// <copyright file="LiveProjectionProcessorTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Compendium.Infrastructure.Tests.Projections;
+
+/// <summary>
+/// Additional unit tests for <see cref="LiveProjectionProcessor"/> that exercise registration,
+/// unregistration, status reporting and lifecycle paths beyond the backfill tests.
+/// </summary>
+public sealed class LiveProjectionProcessorTests
+{
+    [Fact]
+    public void Ctor_NullEventStore_Throws()
+    {
+        // Arrange / Act
+        var act = () => new LiveProjectionProcessor(
+            null!,
+            Substitute.For<IProjectionStore>(),
+            new ServiceCollection().BuildServiceProvider(),
+            NullLogger<LiveProjectionProcessor>.Instance,
+            Options.Create(new ProjectionOptions()));
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("eventStore");
+    }
+
+    [Fact]
+    public void Ctor_NullProjectionStore_Throws()
+    {
+        // Arrange / Act
+        var act = () => new LiveProjectionProcessor(
+            Substitute.For<IStreamingEventStore>(),
+            null!,
+            new ServiceCollection().BuildServiceProvider(),
+            NullLogger<LiveProjectionProcessor>.Instance,
+            Options.Create(new ProjectionOptions()));
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("projectionStore");
+    }
+
+    [Fact]
+    public void Ctor_NullProvider_Throws()
+    {
+        // Arrange / Act
+        var act = () => new LiveProjectionProcessor(
+            Substitute.For<IStreamingEventStore>(),
+            Substitute.For<IProjectionStore>(),
+            null!,
+            NullLogger<LiveProjectionProcessor>.Instance,
+            Options.Create(new ProjectionOptions()));
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("serviceProvider");
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_Throws()
+    {
+        // Arrange / Act
+        var act = () => new LiveProjectionProcessor(
+            Substitute.For<IStreamingEventStore>(),
+            Substitute.For<IProjectionStore>(),
+            new ServiceCollection().BuildServiceProvider(),
+            null!,
+            Options.Create(new ProjectionOptions()));
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("logger");
+    }
+
+    [Fact]
+    public void Ctor_NullOptions_FallsBackToDefaults()
+    {
+        // Arrange / Act
+        using var sut = new LiveProjectionProcessor(
+            Substitute.For<IStreamingEventStore>(),
+            Substitute.For<IProjectionStore>(),
+            new ServiceCollection().BuildServiceProvider(),
+            NullLogger<LiveProjectionProcessor>.Instance,
+            null!);
+
+        // Assert
+        sut.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void RegisterProjection_AddsToInternalRegistry()
+    {
+        // Arrange
+        using var sut = CreateSut(out _, out _);
+
+        // Act
+        sut.RegisterProjection<TestProjection>();
+        var status = sut.GetStatus();
+
+        // Assert
+        status.RegisteredProjections.Should().Be(1);
+    }
+
+    [Fact]
+    public void UnregisterProjection_RemovesFromRegistry()
+    {
+        // Arrange
+        using var sut = CreateSut(out _, out _);
+        sut.RegisterProjection<TestProjection>();
+
+        // Act
+        sut.UnregisterProjection("TestProjection");
+        var status = sut.GetStatus();
+
+        // Assert
+        status.RegisteredProjections.Should().Be(0);
+        status.ActiveProjections.Should().Be(0);
+    }
+
+    [Fact]
+    public void GetStatus_NoActivity_ReturnsZeros()
+    {
+        // Arrange
+        using var sut = CreateSut(out _, out _);
+
+        // Act
+        var status = sut.GetStatus();
+
+        // Assert
+        status.IsRunning.Should().BeFalse();
+        status.RegisteredProjections.Should().Be(0);
+        status.ActiveProjections.Should().Be(0);
+        status.LastProcessedPosition.Should().Be(0);
+        status.TotalEventsProcessed.Should().Be(0);
+        status.EventsPerSecond.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task InitializeProjectionsAsync_LoadsSnapshotsWhenEnabled()
+    {
+        // Arrange
+        var (sut, _, store) = CreateSutWithSnapshots(snapshotsEnabled: true);
+        sut.RegisterProjection<TestProjection>();
+
+        // Act
+        await sut.InitializeProjectionsAsync(CancellationToken.None);
+
+        // Assert — LoadSnapshotAsync invoked via reflection (we just verify the path executed)
+        store.Received().GetCheckpointAsync("TestProjection", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InitializeProjectionsAsync_WhenSnapshotsDisabled_SkipsSnapshotLoad()
+    {
+        // Arrange
+        var (sut, _, _) = CreateSutWithSnapshots(snapshotsEnabled: false);
+        sut.RegisterProjection<TestProjection>();
+
+        // Act
+        await sut.InitializeProjectionsAsync(CancellationToken.None);
+
+        // Assert — call simply completes without reflection over snapshot store
+        sut.GetStatus().RegisteredProjections.Should().Be(1);
+    }
+
+    [Fact]
+    public void Dispose_AfterStartButNeverStarted_DoesNotThrow()
+    {
+        // Arrange
+        var sut = CreateSut(out _, out _);
+
+        // Act / Assert
+        sut.Dispose();
+        sut.Dispose();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RunsLoopAndProcessesEvents()
+    {
+        // Arrange — wire an in-memory store with a small set of events
+        var eventStore = Substitute.For<IStreamingEventStore>();
+        eventStore.GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>()).Returns(0L);
+        eventStore.StreamEventsAsync(Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => OneEventStreamThenEmpty(callInfo.Arg<long>()));
+
+        var store = Substitute.For<IProjectionStore>();
+        store.GetCheckpointAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((long?)null);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<TestProjection>();
+        var sp = services.BuildServiceProvider();
+        using var sut = new LiveProjectionProcessor(
+            eventStore,
+            store,
+            sp,
+            NullLogger<LiveProjectionProcessor>.Instance,
+            Options.Create(new ProjectionOptions { EnableSnapshots = true, SnapshotInterval = TimeSpan.Zero }));
+
+        sut.RegisterProjection<TestProjection>();
+        using var cts = new CancellationTokenSource();
+
+        // Act — start the background service, give it a beat, then stop
+        await sut.StartAsync(cts.Token);
+        await Task.Delay(150, cts.Token);
+        cts.Cancel();
+        try
+        {
+            await sut.StopAsync(CancellationToken.None);
+        }
+        catch (OperationCanceledException)
+        {
+            // expected when cancellation propagates from ExecuteAsync
+        }
+
+        // Assert — checkpoint(s) were saved as the loop processed at least one event
+        await store.Received().SaveCheckpointAsync(
+            "TestProjection", Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StreamingThrows_LoopCatchesAndContinues()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IStreamingEventStore>();
+        eventStore.GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>()).Returns(0L);
+        var attempt = 0;
+        eventStore.StreamEventsAsync(Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                attempt++;
+                return ThrowingStream();
+            });
+
+        var store = Substitute.For<IProjectionStore>();
+        store.GetCheckpointAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((long?)null);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<TestProjection>();
+        var sp = services.BuildServiceProvider();
+        using var sut = new LiveProjectionProcessor(
+            eventStore,
+            store,
+            sp,
+            NullLogger<LiveProjectionProcessor>.Instance,
+            Options.Create(new ProjectionOptions { EnableSnapshots = false }));
+
+        sut.RegisterProjection<TestProjection>();
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await Task.Delay(120, cts.Token);
+        cts.Cancel();
+        try
+        {
+            await sut.StopAsync(CancellationToken.None);
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
+
+        // Assert — the streaming throw was caught and the loop kept running for at least one attempt
+        attempt.Should().BeGreaterOrEqualTo(1);
+    }
+
+    private static async IAsyncEnumerable<EventData> OneEventStreamThenEmpty(long fromPosition)
+    {
+        await Task.CompletedTask;
+        if (fromPosition == 0)
+        {
+            yield return new EventData
+            {
+                EventId = Guid.NewGuid(),
+                StreamId = "s",
+                StreamPosition = 1,
+                GlobalPosition = 1,
+                Timestamp = DateTime.UtcNow,
+                EventType = "TestEvent",
+                Event = new TestEvent(),
+            };
+        }
+    }
+
+    private static async IAsyncEnumerable<EventData> ThrowingStream()
+    {
+        await Task.CompletedTask;
+        throw new InvalidOperationException("stream-fail");
+#pragma warning disable CS0162 // Unreachable
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    private sealed class TestEvent : IDomainEvent
+    {
+        public Guid EventId { get; init; } = Guid.NewGuid();
+        public string AggregateId { get; init; } = "agg";
+        public string AggregateType { get; init; } = "Test";
+        public DateTimeOffset OccurredOn { get; init; } = DateTimeOffset.UtcNow;
+        public long AggregateVersion { get; init; } = 1;
+        public int EventVersion { get; init; } = 1;
+    }
+
+    private static LiveProjectionProcessor CreateSut(out IStreamingEventStore eventStore, out IProjectionStore store)
+    {
+        eventStore = Substitute.For<IStreamingEventStore>();
+        eventStore.GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>()).Returns(0L);
+        store = Substitute.For<IProjectionStore>();
+        store.GetCheckpointAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((long?)null);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<TestProjection>();
+        var sp = services.BuildServiceProvider();
+        return new LiveProjectionProcessor(
+            eventStore,
+            store,
+            sp,
+            NullLogger<LiveProjectionProcessor>.Instance,
+            Options.Create(new ProjectionOptions { EnableSnapshots = false }));
+    }
+
+    private static (LiveProjectionProcessor sut, IStreamingEventStore eventStore, IProjectionStore store)
+        CreateSutWithSnapshots(bool snapshotsEnabled)
+    {
+        var eventStore = Substitute.For<IStreamingEventStore>();
+        eventStore.GetMaxGlobalPositionAsync(Arg.Any<CancellationToken>()).Returns(50L);
+        var store = Substitute.For<IProjectionStore>();
+        store.GetCheckpointAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((long?)null);
+        store.LoadSnapshotAsync<TestProjection>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((TestProjection?)null);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<TestProjection>();
+        var sp = services.BuildServiceProvider();
+
+        return (
+            new LiveProjectionProcessor(
+                eventStore,
+                store,
+                sp,
+                NullLogger<LiveProjectionProcessor>.Instance,
+                Options.Create(new ProjectionOptions { EnableSnapshots = snapshotsEnabled })),
+            eventStore,
+            store);
+    }
+
+    private sealed class TestProjection : Compendium.Infrastructure.Projections.IProjection
+    {
+        public string ProjectionName => "TestProjection";
+        public int Version => 1;
+        public Task ResetAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Projections/OrderProjectionsTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Projections/OrderProjectionsTests.cs
@@ -1,0 +1,307 @@
+// -----------------------------------------------------------------------
+// <copyright file="OrderProjectionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Projections;
+using Compendium.Infrastructure.Projections.Examples;
+
+namespace Compendium.Infrastructure.Tests.Projections;
+
+/// <summary>
+/// Unit tests for the example projections that ship with Compendium.
+/// </summary>
+public sealed class OrderProjectionsTests
+{
+    private static readonly EventMetadata Metadata = new(
+        "stream-1", 1, 1, DateTime.UtcNow, "user-1", "tenant-1", null);
+
+    [Fact]
+    public void OrderSummaryProjection_HasNameAndVersion()
+    {
+        // Arrange
+        var sut = new OrderSummaryProjection();
+
+        // Act / Assert
+        sut.ProjectionName.Should().Be("OrderSummary");
+        sut.Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task OrderSummary_OrderPlaced_AddsSummary()
+    {
+        // Arrange
+        var sut = new OrderSummaryProjection();
+        var orderId = Guid.NewGuid();
+        var customerId = Guid.NewGuid();
+        var evt = new OrderPlacedEvent
+        {
+            OrderId = orderId,
+            CustomerId = customerId,
+            Total = 99.99m,
+            Items = new List<OrderItem> { new() { ProductId = Guid.NewGuid(), Quantity = 2, Price = 50m } },
+        };
+
+        // Act
+        await sut.ApplyAsync(evt, Metadata);
+
+        // Assert
+        sut.Summaries.Should().ContainKey(orderId);
+        var summary = sut.Summaries[orderId];
+        summary.Status.Should().Be(OrderStatus.Placed);
+        summary.Total.Should().Be(99.99m);
+        summary.ItemCount.Should().Be(1);
+        summary.TenantId.Should().Be("tenant-1");
+    }
+
+    [Fact]
+    public async Task OrderSummary_OrderPlaced_WithoutItems_DefaultsItemCountToZero()
+    {
+        // Arrange
+        var sut = new OrderSummaryProjection();
+        var orderId = Guid.NewGuid();
+        var evt = new OrderPlacedEvent { OrderId = orderId, CustomerId = Guid.NewGuid(), Total = 0m };
+
+        // Act
+        await sut.ApplyAsync(evt, Metadata);
+
+        // Assert
+        sut.Summaries[orderId].ItemCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task OrderSummary_OrderShipped_UpdatesExistingSummary()
+    {
+        // Arrange
+        var sut = new OrderSummaryProjection();
+        var orderId = Guid.NewGuid();
+        await sut.ApplyAsync(new OrderPlacedEvent { OrderId = orderId, CustomerId = Guid.NewGuid(), Total = 1m }, Metadata);
+
+        // Act
+        await sut.ApplyAsync(
+            new OrderShippedEvent { OrderId = orderId, TrackingNumber = "TRK-1" },
+            Metadata);
+
+        // Assert
+        var summary = sut.Summaries[orderId];
+        summary.Status.Should().Be(OrderStatus.Shipped);
+        summary.TrackingNumber.Should().Be("TRK-1");
+        summary.ShippedAt.Should().NotBe(default);
+    }
+
+    [Fact]
+    public async Task OrderSummary_OrderShipped_UnknownOrder_DoesNothing()
+    {
+        // Arrange
+        var sut = new OrderSummaryProjection();
+
+        // Act
+        await sut.ApplyAsync(
+            new OrderShippedEvent { OrderId = Guid.NewGuid(), TrackingNumber = "TRK" },
+            Metadata);
+
+        // Assert
+        sut.Summaries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task OrderSummary_OrderCancelled_UpdatesExistingSummary()
+    {
+        // Arrange
+        var sut = new OrderSummaryProjection();
+        var orderId = Guid.NewGuid();
+        await sut.ApplyAsync(new OrderPlacedEvent { OrderId = orderId, CustomerId = Guid.NewGuid(), Total = 1m }, Metadata);
+
+        // Act
+        await sut.ApplyAsync(
+            new OrderCancelledEvent { OrderId = orderId, Reason = "fraud" },
+            Metadata);
+
+        // Assert
+        var summary = sut.Summaries[orderId];
+        summary.Status.Should().Be(OrderStatus.Cancelled);
+        summary.CancellationReason.Should().Be("fraud");
+        summary.CancelledAt.Should().NotBe(default);
+    }
+
+    [Fact]
+    public async Task OrderSummary_OrderCancelled_UnknownOrder_DoesNothing()
+    {
+        // Arrange
+        var sut = new OrderSummaryProjection();
+
+        // Act
+        await sut.ApplyAsync(
+            new OrderCancelledEvent { OrderId = Guid.NewGuid(), Reason = "no" },
+            Metadata);
+
+        // Assert
+        sut.Summaries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task OrderSummary_ResetAsync_ClearsSummaries()
+    {
+        // Arrange
+        var sut = new OrderSummaryProjection();
+        await sut.ApplyAsync(new OrderPlacedEvent { OrderId = Guid.NewGuid(), CustomerId = Guid.NewGuid(), Total = 1m }, Metadata);
+
+        // Act
+        await sut.ResetAsync();
+
+        // Assert
+        sut.Summaries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task OrderSummary_GetOrdersByCustomer_FiltersCorrectly()
+    {
+        // Arrange
+        var sut = new OrderSummaryProjection();
+        var customer = Guid.NewGuid();
+        await sut.ApplyAsync(new OrderPlacedEvent { OrderId = Guid.NewGuid(), CustomerId = customer, Total = 1m }, Metadata);
+        await sut.ApplyAsync(new OrderPlacedEvent { OrderId = Guid.NewGuid(), CustomerId = Guid.NewGuid(), Total = 1m }, Metadata);
+
+        // Act
+        var orders = sut.GetOrdersByCustomer(customer);
+
+        // Assert
+        orders.Should().HaveCount(1);
+        orders.Single().CustomerId.Should().Be(customer);
+    }
+
+    [Fact]
+    public async Task OrderSummary_GetOrdersByStatus_FiltersCorrectly()
+    {
+        // Arrange
+        var sut = new OrderSummaryProjection();
+        var orderId = Guid.NewGuid();
+        await sut.ApplyAsync(new OrderPlacedEvent { OrderId = orderId, CustomerId = Guid.NewGuid(), Total = 1m }, Metadata);
+        await sut.ApplyAsync(new OrderPlacedEvent { OrderId = Guid.NewGuid(), CustomerId = Guid.NewGuid(), Total = 1m }, Metadata);
+        await sut.ApplyAsync(new OrderShippedEvent { OrderId = orderId, TrackingNumber = "T" }, Metadata);
+
+        // Act
+        var shipped = sut.GetOrdersByStatus(OrderStatus.Shipped);
+        var placed = sut.GetOrdersByStatus(OrderStatus.Placed);
+
+        // Assert
+        shipped.Should().HaveCount(1);
+        placed.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void CustomerStatsProjection_HasNameAndVersion()
+    {
+        // Arrange
+        var sut = new CustomerStatsProjection();
+
+        // Act / Assert
+        sut.ProjectionName.Should().Be("CustomerStats");
+        sut.Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CustomerStats_OrderPlaced_FirstTime_CreatesAndUpdatesStats()
+    {
+        // Arrange
+        var sut = new CustomerStatsProjection();
+        var customerId = Guid.NewGuid();
+        var evt = new OrderPlacedEvent { OrderId = Guid.NewGuid(), CustomerId = customerId, Total = 100m };
+
+        // Act
+        await sut.ApplyAsync(evt, Metadata);
+
+        // Assert
+        sut.Stats.Should().ContainKey(customerId);
+        var stats = sut.Stats[customerId];
+        stats.TotalOrders.Should().Be(1);
+        stats.TotalSpent.Should().Be(100m);
+        stats.AverageOrderValue.Should().Be(100m);
+    }
+
+    [Fact]
+    public async Task CustomerStats_OrderPlaced_MultipleOrders_AggregatesCorrectly()
+    {
+        // Arrange
+        var sut = new CustomerStatsProjection();
+        var customerId = Guid.NewGuid();
+
+        // Act
+        await sut.ApplyAsync(new OrderPlacedEvent { OrderId = Guid.NewGuid(), CustomerId = customerId, Total = 100m }, Metadata);
+        await sut.ApplyAsync(new OrderPlacedEvent { OrderId = Guid.NewGuid(), CustomerId = customerId, Total = 200m }, Metadata);
+
+        // Assert
+        var stats = sut.Stats[customerId];
+        stats.TotalOrders.Should().Be(2);
+        stats.TotalSpent.Should().Be(300m);
+        stats.AverageOrderValue.Should().Be(150m);
+    }
+
+    [Fact]
+    public async Task CustomerStats_OrderShipped_IncrementsShippedOrders()
+    {
+        // Arrange
+        var sut = new CustomerStatsProjection();
+        var customerId = Guid.NewGuid();
+        await sut.ApplyAsync(new OrderPlacedEvent { OrderId = Guid.NewGuid(), CustomerId = customerId, Total = 1m }, Metadata);
+
+        // Act
+        await sut.ApplyAsync(new OrderShippedEvent { OrderId = Guid.NewGuid(), TrackingNumber = "T" }, Metadata);
+
+        // Assert
+        sut.Stats[customerId].ShippedOrders.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CustomerStats_ResetAsync_ClearsStats()
+    {
+        // Arrange
+        var sut = new CustomerStatsProjection();
+        await sut.ApplyAsync(new OrderPlacedEvent { OrderId = Guid.NewGuid(), CustomerId = Guid.NewGuid(), Total = 1m }, Metadata);
+
+        // Act
+        await sut.ResetAsync();
+
+        // Assert
+        sut.Stats.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CustomerStats_GetTopCustomers_OrdersByTotalSpentDescending()
+    {
+        // Arrange
+        var sut = new CustomerStatsProjection();
+        var c1 = Guid.NewGuid();
+        var c2 = Guid.NewGuid();
+        var c3 = Guid.NewGuid();
+        await sut.ApplyAsync(new OrderPlacedEvent { CustomerId = c1, Total = 100m }, Metadata);
+        await sut.ApplyAsync(new OrderPlacedEvent { CustomerId = c2, Total = 200m }, Metadata);
+        await sut.ApplyAsync(new OrderPlacedEvent { CustomerId = c3, Total = 50m }, Metadata);
+
+        // Act
+        var top = sut.GetTopCustomers(2).ToList();
+
+        // Assert
+        top.Should().HaveCount(2);
+        top[0].CustomerId.Should().Be(c2);
+        top[1].CustomerId.Should().Be(c1);
+    }
+
+    [Fact]
+    public void OrderEventBase_OccurredOn_AndAggregateInfo_AreInitialized()
+    {
+        // Arrange
+        var placed = new OrderPlacedEvent();
+        var shipped = new OrderShippedEvent();
+        var cancelled = new OrderCancelledEvent();
+
+        // Act / Assert
+        placed.AggregateType.Should().Be("Order");
+        shipped.AggregateType.Should().Be("Order");
+        cancelled.AggregateType.Should().Be("Order");
+        placed.EventId.Should().NotBe(Guid.Empty);
+        placed.OccurredOn.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(2));
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Projections/ProjectionRegistrationServiceTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Projections/ProjectionRegistrationServiceTests.cs
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProjectionRegistrationServiceTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using Compendium.Infrastructure.Projections;
+using Microsoft.Extensions.Hosting;
+
+namespace Compendium.Infrastructure.Tests.Projections;
+
+/// <summary>
+/// Unit tests for the internal <c>ProjectionRegistrationService</c> hosted service that registers
+/// projections at startup. Reflection is used to instantiate it because it lives in an internal
+/// namespace, but its surface is small (StartAsync, StopAsync) and is exercised here.
+/// </summary>
+public sealed class ProjectionRegistrationServiceTests
+{
+    private static readonly Assembly InfraAssembly = typeof(ProjectionOptions).Assembly;
+
+    [Fact]
+    public async Task StartAsync_NoProjections_DoesNothing()
+    {
+        // Arrange
+        var manager = Substitute.For<Compendium.Infrastructure.Projections.IProjectionManager>();
+        var liveProcessor = Substitute.For<ILiveProjectionProcessor>();
+        var sut = CreateService(manager, liveProcessor);
+
+        // Act
+        await ((IHostedService)sut).StartAsync(CancellationToken.None);
+        await ((IHostedService)sut).StopAsync(CancellationToken.None);
+
+        // Assert
+        manager.ReceivedCalls().Where(c => c.GetMethodInfo().Name == "RegisterProjection").Should().BeEmpty();
+        liveProcessor.ReceivedCalls().Where(c => c.GetMethodInfo().Name == "RegisterProjection").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StopAsync_AlwaysReturnsCompletedTask()
+    {
+        // Arrange
+        var manager = Substitute.For<Compendium.Infrastructure.Projections.IProjectionManager>();
+        var liveProcessor = Substitute.For<ILiveProjectionProcessor>();
+        var sut = CreateService(manager, liveProcessor);
+
+        // Act
+        Func<Task> act = () => ((IHostedService)sut).StopAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    private static object CreateService(
+        Compendium.Infrastructure.Projections.IProjectionManager manager,
+        ILiveProjectionProcessor liveProcessor)
+    {
+        var serviceType = InfraAssembly.GetType("Compendium.Infrastructure.Projections.ProjectionRegistrationService")!;
+        var optionsType = InfraAssembly.GetType("Compendium.Infrastructure.Projections.ProjectionRegistrationOptions")!;
+        var optionsValue = Activator.CreateInstance(optionsType)!;
+        var iOptionsType = typeof(Microsoft.Extensions.Options.Options)
+            .GetMethod(nameof(Microsoft.Extensions.Options.Options.Create))!
+            .MakeGenericMethod(optionsType);
+        var iOptions = iOptionsType.Invoke(null, new[] { optionsValue })!;
+
+        var ctor = serviceType.GetConstructors().Single();
+        return ctor.Invoke(new[] { manager, liveProcessor, iOptions });
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Projections/ProjectionTypesTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Projections/ProjectionTypesTests.cs
@@ -1,0 +1,146 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProjectionTypesTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Projections;
+
+namespace Compendium.Infrastructure.Tests.Projections;
+
+/// <summary>
+/// Tests for simple projection record/POCO types whose coverage was 0%
+/// (constructors, init-only properties, default values, derived metrics).
+/// </summary>
+public sealed class ProjectionTypesTests
+{
+    [Fact]
+    public void RebuildProgress_PercentComplete_NoEvents_IsZero()
+    {
+        // Arrange
+        var progress = new RebuildProgress { TotalEvents = 0, ProcessedEvents = 0 };
+
+        // Act / Assert
+        progress.PercentComplete.Should().Be(0);
+    }
+
+    [Fact]
+    public void RebuildProgress_PercentComplete_PartiallyDone_ReturnsPercentage()
+    {
+        // Arrange
+        var progress = new RebuildProgress { TotalEvents = 200, ProcessedEvents = 50 };
+
+        // Act / Assert
+        progress.PercentComplete.Should().Be(25);
+    }
+
+    [Fact]
+    public void RebuildProgress_DefaultsAreSensible()
+    {
+        // Arrange
+        var progress = new RebuildProgress();
+
+        // Act / Assert
+        progress.ProjectionName.Should().Be(string.Empty);
+        progress.TotalEvents.Should().Be(0);
+        progress.ProcessedEvents.Should().Be(0);
+        progress.ElapsedTime.Should().Be(TimeSpan.Zero);
+        progress.EventsPerSecond.Should().Be(0);
+        progress.EstimatedTimeRemaining.Should().Be(TimeSpan.Zero);
+        progress.CurrentBatch.Should().Be(0);
+        progress.BatchSize.Should().Be(0);
+    }
+
+    [Fact]
+    public void EventData_DefaultsAreSensible()
+    {
+        // Arrange
+        var ev = new EventData();
+
+        // Act / Assert
+        ev.EventId.Should().Be(Guid.Empty);
+        ev.StreamId.Should().Be(string.Empty);
+        ev.StreamPosition.Should().Be(0);
+        ev.GlobalPosition.Should().Be(0);
+        ev.EventType.Should().Be(string.Empty);
+        ev.EventDataJson.Should().Be(string.Empty);
+        ev.UserId.Should().BeNull();
+        ev.TenantId.Should().BeNull();
+        ev.Headers.Should().BeNull();
+    }
+
+    [Fact]
+    public void EventData_SettersThroughInitializers_StoreValues()
+    {
+        // Arrange / Act
+        var ev = new EventData
+        {
+            EventId = Guid.NewGuid(),
+            StreamId = "stream-1",
+            StreamPosition = 1,
+            GlobalPosition = 100,
+            EventType = "Created",
+            EventDataJson = "{}",
+            Timestamp = DateTime.UtcNow,
+            UserId = "u-1",
+            TenantId = "t-1",
+            Headers = new Dictionary<string, object> { ["k"] = "v" },
+        };
+
+        // Assert
+        ev.StreamId.Should().Be("stream-1");
+        ev.GlobalPosition.Should().Be(100);
+        ev.Headers.Should().ContainKey("k");
+    }
+
+    [Fact]
+    public void ProjectionState_DefaultsAreSensible()
+    {
+        // Arrange
+        var state = new ProjectionState();
+
+        // Act / Assert
+        state.ProjectionName.Should().Be(string.Empty);
+        state.Status.Should().Be(ProjectionStatus.Idle);
+        state.LastProcessedPosition.Should().Be(0);
+        state.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void ProjectionState_AllStatusesAreReachable()
+    {
+        // Arrange / Act / Assert
+        Enum.GetValues<ProjectionStatus>()
+            .Should()
+            .Contain(new[]
+            {
+                ProjectionStatus.Idle,
+                ProjectionStatus.Building,
+                ProjectionStatus.Rebuilding,
+                ProjectionStatus.Paused,
+                ProjectionStatus.Failed,
+                ProjectionStatus.Completed,
+            });
+    }
+
+    [Fact]
+    public void EventMetadata_StoresAllFields()
+    {
+        // Arrange
+        var ts = DateTime.UtcNow;
+        var headers = new Dictionary<string, object> { ["h"] = 1 };
+
+        // Act
+        var metadata = new EventMetadata("s", 1, 2, ts, "u", "t", headers);
+
+        // Assert
+        metadata.StreamId.Should().Be("s");
+        metadata.StreamPosition.Should().Be(1);
+        metadata.GlobalPosition.Should().Be(2);
+        metadata.Timestamp.Should().Be(ts);
+        metadata.UserId.Should().Be("u");
+        metadata.TenantId.Should().Be("t");
+        metadata.Headers.Should().BeSameAs(headers);
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Projections/ProjectionsServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Projections/ProjectionsServiceCollectionExtensionsTests.cs
@@ -1,0 +1,135 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProjectionsServiceCollectionExtensionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Projections;
+using Compendium.Infrastructure.Projections.Examples;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Compendium.Infrastructure.Tests.Projections;
+
+/// <summary>
+/// Unit tests for the projections-namespace <c>ServiceCollectionExtensions</c>.
+/// </summary>
+public sealed class ProjectionsServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddProjections_DefaultOverload_RegistersManagerAndProcessor()
+    {
+        // Arrange
+        var services = CreateBaseServices();
+
+        // Act
+        var returned = services.AddProjections();
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        returned.Should().BeSameAs(services);
+        provider.GetRequiredService<Compendium.Infrastructure.Projections.IProjectionManager>().Should().BeOfType<EnhancedProjectionManager>();
+        provider.GetRequiredService<ILiveProjectionProcessor>().Should().BeOfType<LiveProjectionProcessor>();
+        provider.GetServices<IHostedService>().Should().Contain(s => s is LiveProjectionProcessor);
+    }
+
+    [Fact]
+    public void AddProjections_WithConfigureOptions_AppliesAction()
+    {
+        // Arrange
+        var services = CreateBaseServices();
+
+        // Act
+        services.AddProjections(opt => opt.RebuildBatchSize = 17);
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<ProjectionOptions>>().Value;
+
+        // Assert
+        options.RebuildBatchSize.Should().Be(17);
+    }
+
+    [Fact]
+    public void AddPostgreSqlProjections_ReturnsSameCollection()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        var returned = services.AddPostgreSqlProjections();
+
+        // Assert
+        returned.Should().BeSameAs(services);
+    }
+
+    [Fact]
+    public void AddProjection_RegistersTypeAsSingleton()
+    {
+        // Arrange
+        var services = CreateBaseServices();
+        services.AddProjections();
+
+        // Act
+        services.AddProjection<OrderSummaryProjection>();
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        provider.GetService<OrderSummaryProjection>().Should().NotBeNull();
+        var first = provider.GetService<OrderSummaryProjection>();
+        var second = provider.GetService<OrderSummaryProjection>();
+        first.Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public void AddProjection_DoesNotOverrideExistingRegistration()
+    {
+        // Arrange
+        var services = CreateBaseServices();
+        var customInstance = new OrderSummaryProjection();
+        services.AddSingleton(customInstance);
+
+        // Act
+        services.AddProjection<OrderSummaryProjection>();
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        provider.GetRequiredService<OrderSummaryProjection>().Should().BeSameAs(customInstance);
+    }
+
+    [Fact]
+    public void AddProjection_AddsTypeToRegistrationOptions()
+    {
+        // Arrange
+        var services = CreateBaseServices();
+
+        // Act
+        services.AddProjection<OrderSummaryProjection>();
+        services.AddProjection<CustomerStatsProjection>();
+        using var provider = services.BuildServiceProvider();
+
+        // Resolve internal options via reflection — type is internal but accessible at runtime via OptionsManager
+        var optionsType = typeof(ServiceCollectionExtensions).Assembly
+            .GetType("Compendium.Infrastructure.Projections.ProjectionRegistrationOptions");
+        optionsType.Should().NotBeNull();
+        var optionsResolverGeneric = typeof(IOptions<>).MakeGenericType(optionsType!);
+        var optionsResolver = provider.GetRequiredService(optionsResolverGeneric);
+        var optionsValue = optionsResolverGeneric.GetProperty("Value")!.GetValue(optionsResolver);
+        var typesProperty = optionsType!.GetProperty("ProjectionTypes")!;
+        var types = (List<Type>)typesProperty.GetValue(optionsValue)!;
+
+        // Assert
+        types.Should().Contain(typeof(OrderSummaryProjection));
+        types.Should().Contain(typeof(CustomerStatsProjection));
+    }
+
+    private static IServiceCollection CreateBaseServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<IStreamingEventStore>(_ => Substitute.For<IStreamingEventStore>());
+        services.AddSingleton<IProjectionStore>(_ => Substitute.For<IProjectionStore>());
+        return services;
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Repositories/EventSourcedRepositoryTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Repositories/EventSourcedRepositoryTests.cs
@@ -1,0 +1,504 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventSourcedRepositoryTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.EventSourcing;
+using Compendium.Core.Domain.Primitives;
+using Compendium.Core.Domain.Specifications;
+using Compendium.Infrastructure.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Compendium.Infrastructure.Tests.Repositories;
+
+/// <summary>
+/// Unit tests for the abstract <see cref="EventSourcedRepository{TAggregate, TId}"/>
+/// using a minimal concrete subclass for verification.
+/// </summary>
+public sealed class EventSourcedRepositoryTests
+{
+    [Fact]
+    public void Ctor_NullEventStore_Throws()
+    {
+        // Arrange / Act
+        var act = () => new TestRepository(null!, NullLogger.Instance);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("eventStore");
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_Throws()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+
+        // Act
+        var act = () => new TestRepository(eventStore, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("logger");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_NoSnapshotNoEvents_ReturnsNotFound()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.GetEventsAsync("a-1", Arg.Any<CancellationToken>())
+            .Returns(Result.Success<IReadOnlyList<IDomainEvent>>(Array.Empty<IDomainEvent>()));
+        var sut = new TestRepository(eventStore, NullLogger.Instance);
+
+        // Act
+        var result = await sut.GetByIdAsync("a-1");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Repository.AggregateNotFound");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_EventsExist_BuildsAggregate()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        IReadOnlyList<IDomainEvent> events = new IDomainEvent[] { new TestEvent { AggregateVersion = 1 } };
+        eventStore.GetEventsAsync("a-1", Arg.Any<CancellationToken>())
+            .Returns(Result.Success(events));
+        var sut = new TestRepository(eventStore, NullLogger.Instance);
+
+        // Act
+        var result = await sut.GetByIdAsync("a-1");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Id.Should().Be("a-1");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_EventStoreFailure_PropagatesError()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.GetEventsAsync("a-1", Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<IReadOnlyList<IDomainEvent>>(Error.Failure("es.fail", "boom")));
+        var sut = new TestRepository(eventStore, NullLogger.Instance);
+
+        // Act
+        var result = await sut.GetByIdAsync("a-1");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("es.fail");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_BuildAggregateFails_PropagatesError()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        IReadOnlyList<IDomainEvent> events = new IDomainEvent[] { new TestEvent() };
+        eventStore.GetEventsAsync("a-1", Arg.Any<CancellationToken>())
+            .Returns(Result.Success(events));
+        var sut = new FailingBuildRepository(eventStore, NullLogger.Instance);
+
+        // Act
+        var result = await sut.GetByIdAsync("a-1");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("build.fail");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WithSnapshot_LoadsFromSnapshotAndAppliesSubsequentEvents()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        var snapshotStore = Substitute.For<ISnapshotStore>();
+
+        var snapshot = new Snapshot<TestAggregate>(new TestAggregate("a-1", version: 5), 5, DateTimeOffset.UtcNow);
+        snapshotStore
+            .GetLatestSnapshotAsync<TestAggregate>("a-1", Arg.Any<CancellationToken>())
+            .Returns(Result.Success(snapshot));
+
+        IReadOnlyList<IDomainEvent> events = new IDomainEvent[] { new TestEvent { AggregateVersion = 6 } };
+        eventStore.GetEventsAsync("a-1", 6L, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(events));
+
+        var sut = new TestRepository(eventStore, NullLogger.Instance, snapshotStore, new NeverSnapshotStrategy());
+
+        // Act
+        var result = await sut.GetByIdAsync("a-1");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await eventStore.Received().GetEventsAsync("a-1", 6L, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WithSnapshotButFailedEventLoad_ReturnsFailure()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        var snapshotStore = Substitute.For<ISnapshotStore>();
+        var snapshot = new Snapshot<TestAggregate>(new TestAggregate("a-1", version: 5), 5, DateTimeOffset.UtcNow);
+        snapshotStore
+            .GetLatestSnapshotAsync<TestAggregate>("a-1", Arg.Any<CancellationToken>())
+            .Returns(Result.Success(snapshot));
+
+        eventStore.GetEventsAsync("a-1", 6L, Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<IReadOnlyList<IDomainEvent>>(Error.Failure("es.fail", "x")));
+
+        var sut = new TestRepository(eventStore, NullLogger.Instance, snapshotStore);
+
+        // Act
+        var result = await sut.GetByIdAsync("a-1");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("es.fail");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WithSnapshotLoadException_FallsBackToEventStream()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        var snapshotStore = Substitute.For<ISnapshotStore>();
+        snapshotStore
+            .GetLatestSnapshotAsync<TestAggregate>("a-1", Arg.Any<CancellationToken>())
+            .Returns<Result<Snapshot<TestAggregate>>>(_ => throw new InvalidOperationException("snap.fail"));
+
+        IReadOnlyList<IDomainEvent> events = new IDomainEvent[] { new TestEvent { AggregateVersion = 1 } };
+        eventStore.GetEventsAsync("a-1", Arg.Any<CancellationToken>())
+            .Returns(Result.Success(events));
+
+        var sut = new TestRepository(eventStore, NullLogger.Instance, snapshotStore);
+
+        // Act
+        var result = await sut.GetByIdAsync("a-1");
+
+        // Assert — repository swallowed the snapshot error and fell back to events
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_EventStoreThrows_ReturnsFailure()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.GetEventsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Result<IReadOnlyList<IDomainEvent>>>(_ => throw new InvalidOperationException("kaboom"));
+        var sut = new TestRepository(eventStore, NullLogger.Instance);
+
+        // Act
+        var result = await sut.GetByIdAsync("a-1");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Repository.LoadFailed");
+    }
+
+    [Fact]
+    public async Task FindAsync_AlwaysReturnsNotSupported()
+    {
+        // Arrange
+        var sut = new TestRepository(Substitute.For<IEventStore>(), NullLogger.Instance);
+
+        // Act
+        var result = await sut.FindAsync(new NoOpSpecification());
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Repository.FindNotSupported");
+    }
+
+    private sealed class NoOpSpecification : Specification<TestAggregate>
+    {
+        public NoOpSpecification() : base(_ => true)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsync_NoUncommittedEvents_ReturnsSuccessWithoutCallingStore()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        var sut = new TestRepository(eventStore, NullLogger.Instance);
+        using var aggregate = new TestAggregate("a-1");
+
+        // Act
+        var result = await sut.SaveAsync(aggregate);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await eventStore.DidNotReceive().AppendEventsAsync(
+            Arg.Any<string>(),
+            Arg.Any<IEnumerable<IDomainEvent>>(),
+            Arg.Any<long>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithEvents_AppendsAndClearsEvents()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.AppendEventsAsync(Arg.Any<string>(), Arg.Any<IEnumerable<IDomainEvent>>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        var sut = new TestRepository(eventStore, NullLogger.Instance);
+        using var aggregate = new TestAggregate("a-1");
+        aggregate.AddTestEvent();
+
+        // Act
+        var result = await sut.SaveAsync(aggregate);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        aggregate.HasDomainEvents.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SaveAsync_AppendFails_ReturnsFailure()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.AppendEventsAsync(Arg.Any<string>(), Arg.Any<IEnumerable<IDomainEvent>>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(Error.Failure("es.fail", "x")));
+        var sut = new TestRepository(eventStore, NullLogger.Instance);
+        using var aggregate = new TestAggregate("a-1");
+        aggregate.AddTestEvent();
+
+        // Act
+        var result = await sut.SaveAsync(aggregate);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("es.fail");
+    }
+
+    [Fact]
+    public async Task SaveAsync_AppendThrows_ReturnsSaveFailedError()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.AppendEventsAsync(Arg.Any<string>(), Arg.Any<IEnumerable<IDomainEvent>>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns<Result>(_ => throw new InvalidOperationException("kaboom"));
+        var sut = new TestRepository(eventStore, NullLogger.Instance);
+        using var aggregate = new TestAggregate("a-1");
+        aggregate.AddTestEvent();
+
+        // Act
+        var result = await sut.SaveAsync(aggregate);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Repository.SaveFailed");
+    }
+
+    [Fact]
+    public async Task AddAsync_DelegatesToSaveAsync()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.AppendEventsAsync(Arg.Any<string>(), Arg.Any<IEnumerable<IDomainEvent>>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        var sut = new TestRepository(eventStore, NullLogger.Instance);
+        using var aggregate = new TestAggregate("a-1");
+        aggregate.AddTestEvent();
+
+        // Act
+        var result = await sut.AddAsync(aggregate);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_DelegatesToSaveAsync()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.AppendEventsAsync(Arg.Any<string>(), Arg.Any<IEnumerable<IDomainEvent>>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        var sut = new TestRepository(eventStore, NullLogger.Instance);
+        using var aggregate = new TestAggregate("a-1");
+        aggregate.AddTestEvent();
+
+        // Act
+        var result = await sut.UpdateAsync(aggregate);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RemoveAsync_DefaultImplementation_ReturnsDeleteNotSupported()
+    {
+        // Arrange
+        var sut = new TestRepository(Substitute.For<IEventStore>(), NullLogger.Instance);
+        using var aggregate = new TestAggregate("a-1");
+
+        // Act
+        var result = await sut.RemoveAsync(aggregate);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Repository.DeleteNotSupported");
+    }
+
+    [Fact]
+    public async Task SaveAsync_StrategyRequestsSnapshot_SavesSnapshot()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.AppendEventsAsync(Arg.Any<string>(), Arg.Any<IEnumerable<IDomainEvent>>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        eventStore.GetEventsAsync("a-1", Arg.Any<CancellationToken>())
+            .Returns(Result.Success<IReadOnlyList<IDomainEvent>>(new IDomainEvent[] { new TestEvent() }));
+
+        var snapshotStore = Substitute.For<ISnapshotStore>();
+        snapshotStore.SaveSnapshotAsync(Arg.Any<string>(), Arg.Any<TestAggregate>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+
+        var sut = new TestRepository(eventStore, NullLogger.Instance, snapshotStore, new AlwaysSnapshotStrategy());
+        using var aggregate = new TestAggregate("a-1");
+        aggregate.AddTestEvent();
+
+        // Act
+        var result = await sut.SaveAsync(aggregate);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await snapshotStore.Received().SaveSnapshotAsync(
+            "a-1", Arg.Any<TestAggregate>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SaveAsync_SnapshotSaveFails_StillReturnsSuccess()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.AppendEventsAsync(Arg.Any<string>(), Arg.Any<IEnumerable<IDomainEvent>>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        eventStore.GetEventsAsync("a-1", Arg.Any<CancellationToken>())
+            .Returns(Result.Success<IReadOnlyList<IDomainEvent>>(new IDomainEvent[] { new TestEvent() }));
+
+        var snapshotStore = Substitute.For<ISnapshotStore>();
+        snapshotStore.SaveSnapshotAsync(Arg.Any<string>(), Arg.Any<TestAggregate>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(Error.Failure("snap.fail", "x")));
+
+        var sut = new TestRepository(eventStore, NullLogger.Instance, snapshotStore, new AlwaysSnapshotStrategy());
+        using var aggregate = new TestAggregate("a-1");
+        aggregate.AddTestEvent();
+
+        // Act
+        var result = await sut.SaveAsync(aggregate);
+
+        // Assert — snapshot is best-effort; save still succeeds
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SaveAsync_SnapshotThrows_StillReturnsSuccess()
+    {
+        // Arrange
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.AppendEventsAsync(Arg.Any<string>(), Arg.Any<IEnumerable<IDomainEvent>>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        eventStore.GetEventsAsync("a-1", Arg.Any<CancellationToken>())
+            .Returns(Result.Success<IReadOnlyList<IDomainEvent>>(new IDomainEvent[] { new TestEvent() }));
+
+        var snapshotStore = Substitute.For<ISnapshotStore>();
+        snapshotStore.SaveSnapshotAsync(Arg.Any<string>(), Arg.Any<TestAggregate>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns<Result>(_ => throw new InvalidOperationException("kaboom"));
+
+        var sut = new TestRepository(eventStore, NullLogger.Instance, snapshotStore, new AlwaysSnapshotStrategy());
+        using var aggregate = new TestAggregate("a-1");
+        aggregate.AddTestEvent();
+
+        // Act
+        var result = await sut.SaveAsync(aggregate);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    private sealed class TestEvent : IDomainEvent
+    {
+        public Guid EventId { get; init; } = Guid.NewGuid();
+        public string AggregateId { get; init; } = "a-1";
+        public string AggregateType { get; init; } = "Test";
+        public DateTimeOffset OccurredOn { get; init; } = DateTimeOffset.UtcNow;
+        public long AggregateVersion { get; init; }
+        public int EventVersion { get; init; } = 1;
+    }
+
+    private sealed class TestAggregate : AggregateRoot<string>
+    {
+        public TestAggregate(string id, long version = 0) : base(id)
+        {
+            for (var i = 0; i < version; i++)
+            {
+                IncrementVersion();
+            }
+        }
+
+        public void AddTestEvent()
+        {
+            AddDomainEvent(new TestEvent { AggregateVersion = Version + 1 });
+            IncrementVersion();
+        }
+    }
+
+    private sealed class TestRepository : EventSourcedRepository<TestAggregate, string>
+    {
+        public TestRepository(IEventStore eventStore, ILogger logger, ISnapshotStore? snapshotStore = null, ISnapshotStrategy? strategy = null)
+            : base(eventStore, logger, snapshotStore, strategy)
+        {
+        }
+
+        protected override Task<Result<TestAggregate>> BuildAggregateFromEvents(IReadOnlyList<IDomainEvent> events)
+        {
+            return Task.FromResult(Result.Success(new TestAggregate("a-1", version: events.Count)));
+        }
+
+        protected override Task<Result<TestAggregate>> ApplyEventsToAggregate(TestAggregate aggregate, IReadOnlyList<IDomainEvent> events)
+        {
+            return Task.FromResult(Result.Success(aggregate));
+        }
+    }
+
+    private sealed class FailingBuildRepository : EventSourcedRepository<TestAggregate, string>
+    {
+        public FailingBuildRepository(IEventStore eventStore, ILogger logger)
+            : base(eventStore, logger)
+        {
+        }
+
+        protected override Task<Result<TestAggregate>> BuildAggregateFromEvents(IReadOnlyList<IDomainEvent> events)
+        {
+            return Task.FromResult(Result.Failure<TestAggregate>(Error.Failure("build.fail", "boom")));
+        }
+
+        protected override Task<Result<TestAggregate>> ApplyEventsToAggregate(TestAggregate aggregate, IReadOnlyList<IDomainEvent> events)
+        {
+            return Task.FromResult(Result.Success(aggregate));
+        }
+    }
+
+    private sealed class AlwaysSnapshotStrategy : ISnapshotStrategy
+    {
+        public bool ShouldTakeSnapshot(string aggregateId, long version, int eventCount) => true;
+    }
+
+    private sealed class NeverSnapshotStrategy : ISnapshotStrategy
+    {
+        public bool ShouldTakeSnapshot(string aggregateId, long version, int eventCount) => false;
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Resilience/CircuitBreakerRegistryTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Resilience/CircuitBreakerRegistryTests.cs
@@ -1,0 +1,163 @@
+// -----------------------------------------------------------------------
+// <copyright file="CircuitBreakerRegistryTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Resilience;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Compendium.Infrastructure.Tests.Resilience;
+
+/// <summary>
+/// Unit tests for <see cref="CircuitBreakerRegistry"/> covering caching and DI failure modes.
+/// </summary>
+public sealed class CircuitBreakerRegistryTests
+{
+    [Fact]
+    public void Ctor_NullProvider_Throws()
+    {
+        // Arrange / Act
+        var act = () => new CircuitBreakerRegistry(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("serviceProvider");
+    }
+
+    [Fact]
+    public void GetOrCreate_FirstCall_CreatesNewBreaker()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var breaker = sut.GetOrCreate("redis");
+
+        // Assert
+        breaker.Should().NotBeNull();
+        breaker.State.Should().Be(CircuitBreakerState.Closed);
+    }
+
+    [Fact]
+    public void GetOrCreate_SecondCall_ReturnsCachedInstance()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var first = sut.GetOrCreate("redis");
+        var second = sut.GetOrCreate("redis");
+
+        // Assert
+        second.Should().BeSameAs(first);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetOrCreate_EmptyName_Throws(string invalid)
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.GetOrCreate(invalid);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .And.ParamName.Should().Be("name");
+    }
+
+    [Fact]
+    public void GetOrCreate_DifferentNames_ReturnDifferentInstances()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var redis = sut.GetOrCreate("redis");
+        var postgres = sut.GetOrCreate("postgres");
+
+        // Assert
+        redis.Should().NotBeSameAs(postgres);
+    }
+
+    [Fact]
+    public void GetOrCreate_WithCustomOptions_UsesOptions()
+    {
+        // Arrange
+        var sut = CreateSut();
+        var options = new CircuitBreakerOptions { FailureThreshold = 99 };
+
+        // Act
+        var breaker = sut.GetOrCreate("custom", options);
+
+        // Assert
+        breaker.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void GetOrCreate_LoggerNotRegistered_ThrowsInvalidOperation()
+    {
+        // Arrange
+        var emptyProvider = new ServiceCollection().BuildServiceProvider();
+        var sut = new CircuitBreakerRegistry(emptyProvider);
+
+        // Act
+        var act = () => sut.GetOrCreate("any");
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Logger<CircuitBreaker>*");
+    }
+
+    [Fact]
+    public void CircuitBreakerOptions_Defaults_AreSensible()
+    {
+        // Arrange / Act
+        var options = new CircuitBreakerOptions();
+
+        // Assert
+        options.FailureThreshold.Should().Be(5);
+        options.OpenTimeout.Should().Be(TimeSpan.FromSeconds(60));
+        options.ShouldTripOnError.Should().NotBeNull();
+        options.ShouldTripOnException.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CircuitBreakerOptions_DefaultShouldTripOnError_TripsOnFailure()
+    {
+        // Arrange
+        var options = new CircuitBreakerOptions();
+
+        // Act / Assert
+        options.ShouldTripOnError(Error.Failure("x", "y")).Should().BeTrue();
+        options.ShouldTripOnError(Error.Validation("v", "v")).Should().BeFalse();
+        options.ShouldTripOnError(Error.NotFound("n", "n")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CircuitBreakerOptions_DefaultShouldTripOnException_DoesNotTripOnArgument()
+    {
+        // Arrange
+        var options = new CircuitBreakerOptions();
+
+        // Act / Assert
+        options.ShouldTripOnException(new ArgumentException("x")).Should().BeFalse();
+        options.ShouldTripOnException(new ArgumentNullException("x")).Should().BeFalse();
+        options.ShouldTripOnException(new InvalidOperationException("x")).Should().BeFalse();
+        options.ShouldTripOnException(new TimeoutException("x")).Should().BeTrue();
+    }
+
+    private static CircuitBreakerRegistry CreateSut()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(NullLogger<CircuitBreaker>.Instance);
+        services.AddSingleton<ILogger<CircuitBreaker>>(sp => NullLogger<CircuitBreaker>.Instance);
+        var provider = services.BuildServiceProvider();
+        return new CircuitBreakerRegistry(provider);
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Resilience/ResilienceTelemetryListenerTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Resilience/ResilienceTelemetryListenerTests.cs
@@ -1,0 +1,107 @@
+// -----------------------------------------------------------------------
+// <copyright file="ResilienceTelemetryListenerTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Resilience;
+
+namespace Compendium.Infrastructure.Tests.Resilience;
+
+/// <summary>
+/// Unit tests for <see cref="ResilienceTelemetryListener"/> covering all logging methods.
+/// </summary>
+public sealed class ResilienceTelemetryListenerTests
+{
+    private readonly ILogger<ResilienceTelemetryListener> _logger = Substitute.For<ILogger<ResilienceTelemetryListener>>();
+
+    [Fact]
+    public void Ctor_NullLogger_Throws()
+    {
+        // Arrange / Act
+        var act = () => new ResilienceTelemetryListener(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("logger");
+    }
+
+    [Fact]
+    public void OnCircuitBreakerStateChange_LogsInformation()
+    {
+        // Arrange
+        var sut = new ResilienceTelemetryListener(_logger);
+
+        // Act
+        sut.OnCircuitBreakerStateChange("postgres", "Open");
+
+        // Assert
+        _logger.ReceivedCalls().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void OnRetry_LogsWarning()
+    {
+        // Arrange
+        var sut = new ResilienceTelemetryListener(_logger);
+
+        // Act
+        sut.OnRetry("postgres", 1, TimeSpan.FromMilliseconds(100));
+
+        // Assert
+        _logger.ReceivedCalls().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void OnTimeout_LogsError()
+    {
+        // Arrange
+        var sut = new ResilienceTelemetryListener(_logger);
+
+        // Act
+        sut.OnTimeout("redis", TimeSpan.FromSeconds(2));
+
+        // Assert
+        _logger.ReceivedCalls().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void PollyResilienceOptions_PostgreSqlDefaults_HasExpectedValues()
+    {
+        // Arrange / Act
+        var options = PollyResilienceOptions.PostgreSqlDefaults();
+
+        // Assert
+        options.Timeout.Should().Be(TimeSpan.FromSeconds(5));
+        options.MaxRetryAttempts.Should().Be(3);
+        options.BaseRetryDelay.Should().Be(TimeSpan.FromMilliseconds(100));
+        options.CircuitBreakerFailureThreshold.Should().Be(0.5);
+        options.CircuitBreakerSamplingDuration.Should().Be(TimeSpan.FromSeconds(30));
+        options.CircuitBreakerMinimumThroughput.Should().Be(10);
+        options.CircuitBreakerBreakDuration.Should().Be(TimeSpan.FromSeconds(60));
+    }
+
+    [Fact]
+    public void PollyResilienceOptions_RedisDefaults_HasShorterTimeouts()
+    {
+        // Arrange / Act
+        var options = PollyResilienceOptions.RedisDefaults();
+
+        // Assert
+        options.Timeout.Should().Be(TimeSpan.FromSeconds(2));
+        options.BaseRetryDelay.Should().Be(TimeSpan.FromMilliseconds(50));
+        options.CircuitBreakerMinimumThroughput.Should().Be(20);
+        options.CircuitBreakerBreakDuration.Should().Be(TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public void PollyResilienceOptions_DefaultCtor_HasSafeDefaults()
+    {
+        // Arrange / Act
+        var options = new PollyResilienceOptions();
+
+        // Assert
+        options.Timeout.Should().Be(TimeSpan.FromSeconds(5));
+        options.MaxRetryAttempts.Should().Be(3);
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Resilience/ServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Resilience/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,79 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Resilience;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Polly;
+
+namespace Compendium.Infrastructure.Tests.Resilience;
+
+/// <summary>
+/// Unit tests for <see cref="ServiceCollectionExtensions"/> in the Resilience namespace.
+/// </summary>
+public sealed class ResilienceServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddPollyResilience_DefaultOverload_RegistersPipelineFactoryAndPipeline()
+    {
+        // Arrange
+        var services = CreateServiceCollection();
+
+        // Act
+        var returned = services.AddPollyResilience();
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        returned.Should().BeSameAs(services);
+        provider.GetService<PollyResiliencePipelineFactory>().Should().NotBeNull();
+        provider.GetService<ResilienceTelemetryListener>().Should().NotBeNull();
+        provider.GetService<ResiliencePipeline>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddPollyResilience_WithConfigurePostgreSqlAction_AppliesConfiguration()
+    {
+        // Arrange
+        var services = CreateServiceCollection();
+        var configured = false;
+
+        // Act
+        services.AddPollyResilience(configurePostgreSql: _ => configured = true);
+        using var provider = services.BuildServiceProvider();
+        // Force resolution to invoke factory delegate
+        _ = provider.GetService<ResiliencePipeline>();
+
+        // Assert
+        configured.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddPollyResilience_WithCustomOptionsOverload_RegistersFactoryAndOptions()
+    {
+        // Arrange
+        var services = CreateServiceCollection();
+        var pgOptions = PollyResilienceOptions.PostgreSqlDefaults();
+        var redisOptions = PollyResilienceOptions.RedisDefaults();
+
+        // Act
+        var returned = services.AddPollyResilience(pgOptions, redisOptions);
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        returned.Should().BeSameAs(services);
+        provider.GetService<PollyResiliencePipelineFactory>().Should().NotBeNull();
+        provider.GetService<ResilienceTelemetryListener>().Should().NotBeNull();
+        provider.GetServices<PollyResilienceOptions>().Should().Contain(new[] { pgOptions, redisOptions });
+    }
+
+    private static IServiceCollection CreateServiceCollection()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        return services;
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Resilience/TokenBucketRateLimiterTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Resilience/TokenBucketRateLimiterTests.cs
@@ -1,0 +1,249 @@
+// -----------------------------------------------------------------------
+// <copyright file="TokenBucketRateLimiterTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Resilience;
+
+namespace Compendium.Infrastructure.Tests.Resilience;
+
+/// <summary>
+/// Unit tests for <see cref="TokenBucketRateLimiter"/> covering happy path, exhaustion,
+/// validation failures, and the simple <see cref="Result"/> overload.
+/// </summary>
+public sealed class TokenBucketRateLimiterTests
+{
+    private readonly ILogger<TokenBucketRateLimiter> _logger = Substitute.For<ILogger<TokenBucketRateLimiter>>();
+
+    [Fact]
+    public void Ctor_NullOptions_Throws()
+    {
+        // Arrange / Act
+        var act = () => new TokenBucketRateLimiter(null!, _logger);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("options");
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_Throws()
+    {
+        // Arrange
+        var options = new RateLimitOptions();
+
+        // Act
+        var act = () => new TokenBucketRateLimiter(options, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("logger");
+    }
+
+    [Fact]
+    public async Task IsAllowedAsync_FreshBucket_ReturnsTrue()
+    {
+        // Arrange
+        var sut = CreateSut(maxRequests: 10);
+
+        // Act
+        var allowed = await sut.IsAllowedAsync("user-1");
+
+        // Assert
+        allowed.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task IsAllowedAsync_EmptyKey_ReturnsFalse(string invalid)
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var allowed = await sut.IsAllowedAsync(invalid);
+
+        // Assert
+        allowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsAllowedAsync_BucketExhausted_ReturnsFalse()
+    {
+        // Arrange
+        var sut = CreateSut(maxRequests: 2);
+
+        // Act
+        var first = await sut.IsAllowedAsync("user-1");
+        var second = await sut.IsAllowedAsync("user-1");
+        var third = await sut.IsAllowedAsync("user-1");
+
+        // Assert
+        first.Should().BeTrue();
+        second.Should().BeTrue();
+        third.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncT_WithinLimit_RunsOperation()
+    {
+        // Arrange
+        var sut = CreateSut(maxRequests: 5);
+
+        // Act
+        var result = await sut.ExecuteAsync<int>("user-1", () => Task.FromResult(Result.Success(42)));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncT_WhenLimitExceeded_ReturnsTooManyRequestsFailure()
+    {
+        // Arrange
+        var sut = CreateSut(maxRequests: 1);
+
+        // Act
+        await sut.ExecuteAsync<int>("user-1", () => Task.FromResult(Result.Success(1)));
+        var rejected = await sut.ExecuteAsync<int>("user-1", () => Task.FromResult(Result.Success(2)));
+
+        // Assert
+        rejected.IsFailure.Should().BeTrue();
+        rejected.Error.Code.Should().Be("RateLimit.Exceeded");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExecuteAsyncT_EmptyKey_ReturnsValidationFailure(string invalid)
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.ExecuteAsync<int>(invalid, () => Task.FromResult(Result.Success(0)));
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("RateLimit.KeyEmpty");
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncT_NullOperation_Throws()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        Func<Task> act = async () => await sut.ExecuteAsync<int>("k", null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonGeneric_DelegatesToGenericOverload()
+    {
+        // Arrange
+        var sut = CreateSut(maxRequests: 2);
+
+        // Act
+        var ok = await sut.ExecuteAsync("user-x", () => Task.FromResult(Result.Success()));
+        var ok2 = await sut.ExecuteAsync("user-x", () => Task.FromResult(Result.Success()));
+        var rejected = await sut.ExecuteAsync("user-x", () => Task.FromResult(Result.Success()));
+
+        // Assert
+        ok.IsSuccess.Should().BeTrue();
+        ok2.IsSuccess.Should().BeTrue();
+        rejected.IsFailure.Should().BeTrue();
+        rejected.Error.Code.Should().Be("RateLimit.Exceeded");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonGeneric_OperationFailure_PropagatesError()
+    {
+        // Arrange
+        var sut = CreateSut(maxRequests: 5);
+
+        // Act
+        var result = await sut.ExecuteAsync(
+            "user-x",
+            () => Task.FromResult(Result.Failure(Error.Failure("op.fail", "boom"))));
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("op.fail");
+    }
+
+    [Fact]
+    public async Task IsAllowedAsync_WithDifferentKeys_BucketsAreIndependent()
+    {
+        // Arrange
+        var sut = CreateSut(maxRequests: 1);
+
+        // Act
+        var aFirst = await sut.IsAllowedAsync("a");
+        var bFirst = await sut.IsAllowedAsync("b");
+        var aSecond = await sut.IsAllowedAsync("a");
+
+        // Assert
+        aFirst.Should().BeTrue();
+        bFirst.Should().BeTrue();
+        aSecond.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RateLimitOptions_Defaults_HaveSensibleValues()
+    {
+        // Arrange / Act
+        var options = new RateLimitOptions();
+
+        // Assert
+        options.MaxRequests.Should().Be(100);
+        options.Window.Should().Be(TimeSpan.FromMinutes(1));
+        options.RefillInterval.Should().Be(TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task Refill_AfterRefillInterval_RestoresTokens()
+    {
+        // Arrange
+        var options = new RateLimitOptions
+        {
+            MaxRequests = 4,
+            Window = TimeSpan.FromMilliseconds(40),
+            RefillInterval = TimeSpan.FromMilliseconds(10),
+        };
+        var sut = new TokenBucketRateLimiter(options, _logger);
+
+        // Drain the bucket
+        for (var i = 0; i < 4; i++)
+        {
+            await sut.IsAllowedAsync("k");
+        }
+
+        (await sut.IsAllowedAsync("k")).Should().BeFalse();
+
+        // Act
+        await Task.Delay(50);
+        var allowedAfterRefill = await sut.IsAllowedAsync("k");
+
+        // Assert
+        allowedAfterRefill.Should().BeTrue();
+    }
+
+    private TokenBucketRateLimiter CreateSut(int maxRequests = 100)
+    {
+        var options = new RateLimitOptions
+        {
+            MaxRequests = maxRequests,
+            Window = TimeSpan.FromSeconds(60),
+            RefillInterval = TimeSpan.FromSeconds(1),
+        };
+        return new TokenBucketRateLimiter(options, _logger);
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Security/InMemoryKeyVaultTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Security/InMemoryKeyVaultTests.cs
@@ -1,0 +1,296 @@
+// -----------------------------------------------------------------------
+// <copyright file="InMemoryKeyVaultTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using System.Security.Cryptography;
+using Compendium.Infrastructure.Security;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Compendium.Infrastructure.Tests.Security;
+
+/// <summary>
+/// Unit tests for <see cref="InMemoryKeyVault"/> covering the secret lifecycle, validation,
+/// expiration handling, and listing semantics.
+/// </summary>
+public sealed class InMemoryKeyVaultTests
+{
+    private readonly IEncryptionService _encryption;
+    private readonly InMemoryKeyVault _sut;
+
+    public InMemoryKeyVaultTests()
+    {
+        // Arrange
+        _encryption = CreateRealEncryptionService();
+        _sut = new InMemoryKeyVault(_encryption, NullLogger<InMemoryKeyVault>.Instance);
+    }
+
+    [Fact]
+    public void Ctor_NullEncryption_Throws()
+    {
+        // Arrange / Act
+        var act = () => new InMemoryKeyVault(null!, NullLogger<InMemoryKeyVault>.Instance);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("encryptionService");
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_Throws()
+    {
+        // Arrange / Act
+        var act = () => new InMemoryKeyVault(_encryption, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("logger");
+    }
+
+    [Fact]
+    public async Task SetSecretAsync_ThenGetSecretAsync_ReturnsOriginalValue()
+    {
+        // Arrange / Act
+        var setResult = await _sut.SetSecretAsync("api-key", "super-secret");
+        var getResult = await _sut.GetSecretAsync("api-key");
+
+        // Assert
+        setResult.IsSuccess.Should().BeTrue();
+        getResult.IsSuccess.Should().BeTrue();
+        getResult.Value.Should().Be("super-secret");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SetSecretAsync_EmptyName_ReturnsValidationFailure(string invalid)
+    {
+        // Arrange / Act
+        var result = await _sut.SetSecretAsync(invalid, "value");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("KeyVault.EmptyName");
+    }
+
+    [Fact]
+    public async Task SetSecretAsync_EmptyValue_ReturnsValidationFailure()
+    {
+        // Arrange / Act
+        var result = await _sut.SetSecretAsync("name", "");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("KeyVault.EmptyValue");
+    }
+
+    [Fact]
+    public async Task SetSecretAsync_OverwritesExistingValue()
+    {
+        // Arrange
+        await _sut.SetSecretAsync("k", "v1");
+
+        // Act
+        await _sut.SetSecretAsync("k", "v2");
+        var get = await _sut.GetSecretAsync("k");
+
+        // Assert
+        get.IsSuccess.Should().BeTrue();
+        get.Value.Should().Be("v2");
+    }
+
+    [Fact]
+    public async Task SetSecretAsync_EncryptionFailure_PropagatesError()
+    {
+        // Arrange
+        var failingEncryption = Substitute.For<IEncryptionService>();
+        failingEncryption.EncryptAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<string>(Error.Failure("enc.fail", "boom")));
+        var sut = new InMemoryKeyVault(failingEncryption, NullLogger<InMemoryKeyVault>.Instance);
+
+        // Act
+        var result = await sut.SetSecretAsync("k", "v");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("enc.fail");
+    }
+
+    [Fact]
+    public async Task GetSecretAsync_UnknownSecret_ReturnsNotFound()
+    {
+        // Arrange / Act
+        var result = await _sut.GetSecretAsync("missing");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("KeyVault.SecretNotFound");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GetSecretAsync_EmptyName_ReturnsValidationFailure(string invalid)
+    {
+        // Arrange / Act
+        var result = await _sut.GetSecretAsync(invalid);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("KeyVault.EmptyName");
+    }
+
+    [Fact]
+    public async Task GetSecretAsync_DecryptionFailure_PropagatesError()
+    {
+        // Arrange
+        var failingEncryption = Substitute.For<IEncryptionService>();
+        failingEncryption.EncryptAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success("ciphertext"));
+        failingEncryption.DecryptAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<string>(Error.Failure("dec.fail", "boom")));
+        var sut = new InMemoryKeyVault(failingEncryption, NullLogger<InMemoryKeyVault>.Instance);
+        await sut.SetSecretAsync("k", "v");
+
+        // Act
+        var result = await sut.GetSecretAsync("k");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("dec.fail");
+    }
+
+    [Fact]
+    public async Task DeleteSecretAsync_ExistingSecret_ReturnsSuccess()
+    {
+        // Arrange
+        await _sut.SetSecretAsync("k", "v");
+
+        // Act
+        var deleted = await _sut.DeleteSecretAsync("k");
+        var get = await _sut.GetSecretAsync("k");
+
+        // Assert
+        deleted.IsSuccess.Should().BeTrue();
+        get.IsFailure.Should().BeTrue();
+        get.Error.Code.Should().Be("KeyVault.SecretNotFound");
+    }
+
+    [Fact]
+    public async Task DeleteSecretAsync_UnknownSecret_ReturnsNotFound()
+    {
+        // Arrange / Act
+        var result = await _sut.DeleteSecretAsync("ghost");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("KeyVault.SecretNotFound");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task DeleteSecretAsync_EmptyName_ReturnsValidationFailure(string invalid)
+    {
+        // Arrange / Act
+        var result = await _sut.DeleteSecretAsync(invalid);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("KeyVault.EmptyName");
+    }
+
+    [Fact]
+    public async Task ListSecretsAsync_ReturnsSortedNames()
+    {
+        // Arrange
+        await _sut.SetSecretAsync("z", "1");
+        await _sut.SetSecretAsync("a", "1");
+        await _sut.SetSecretAsync("m", "1");
+
+        // Act
+        var result = await _sut.ListSecretsAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(new[] { "a", "m", "z" }, opt => opt.WithStrictOrdering());
+    }
+
+    [Fact]
+    public async Task ListSecretsAsync_EmptyVault_ReturnsEmptyList()
+    {
+        // Arrange / Act
+        var result = await _sut.ListSecretsAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSecretAsync_ExpiredSecret_ReturnsExpiredAndRemoves()
+    {
+        // Arrange — store secret then mutate the underlying SecretEntry record to set ExpiresAt in the past.
+        await _sut.SetSecretAsync("k", "v");
+        ForceSecretExpiration(_sut, "k");
+
+        // Act
+        var result = await _sut.GetSecretAsync("k");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("KeyVault.SecretExpired");
+    }
+
+    [Fact]
+    public async Task ListSecretsAsync_FiltersExpiredSecrets()
+    {
+        // Arrange
+        await _sut.SetSecretAsync("active", "v1");
+        await _sut.SetSecretAsync("expired", "v2");
+        ForceSecretExpiration(_sut, "expired");
+
+        // Act
+        var result = await _sut.ListSecretsAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Contain("active");
+        result.Value.Should().NotContain("expired");
+    }
+
+    private static void ForceSecretExpiration(InMemoryKeyVault vault, string name)
+    {
+        var dictField = typeof(InMemoryKeyVault).GetField("_secrets", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var dict = dictField.GetValue(vault)!;
+        var entryType = typeof(InMemoryKeyVault).Assembly.GetType("Compendium.Infrastructure.Security.SecretEntry")!;
+
+        // Read existing entry from the ConcurrentDictionary<string, SecretEntry>
+        var indexer = dict.GetType().GetProperty("Item")!;
+        var existing = indexer.GetValue(dict, new object[] { name })!;
+
+        // Construct a replacement entry with ExpiresAt in the past
+        var newEntry = Activator.CreateInstance(entryType)!;
+        entryType.GetProperty("Name")!.SetValue(newEntry, name);
+        entryType.GetProperty("EncryptedValue")!.SetValue(newEntry, entryType.GetProperty("EncryptedValue")!.GetValue(existing));
+        entryType.GetProperty("CreatedAt")!.SetValue(newEntry, DateTime.UtcNow.AddMinutes(-5));
+        entryType.GetProperty("ExpiresAt")!.SetValue(newEntry, DateTime.UtcNow.AddSeconds(-1));
+
+        indexer.SetValue(dict, newEntry, new object[] { name });
+    }
+
+    private static AesEncryptionService CreateRealEncryptionService()
+    {
+        using var aes = Aes.Create();
+        aes.GenerateKey();
+        var options = new EncryptionOptions
+        {
+            Key = Convert.ToBase64String(aes.Key),
+            Salt = "salt-value",
+        };
+        return new AesEncryptionService(options, NullLogger<AesEncryptionService>.Instance);
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Telemetry/OpenTelemetryServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Telemetry/OpenTelemetryServiceCollectionExtensionsTests.cs
@@ -1,0 +1,99 @@
+// -----------------------------------------------------------------------
+// <copyright file="OpenTelemetryServiceCollectionExtensionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Telemetry;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Compendium.Infrastructure.Tests.Telemetry;
+
+/// <summary>
+/// Unit tests for <see cref="OpenTelemetryServiceCollectionExtensions"/> covering registrations.
+/// </summary>
+public sealed class OpenTelemetryServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddCompendiumTelemetry_RegistersTracerAndMeterProviders()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        var returned = services.AddCompendiumTelemetry("MyService", "1.2.3");
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        returned.Should().BeSameAs(services);
+        provider.GetService<TracerProvider>().Should().NotBeNull();
+        provider.GetService<MeterProvider>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddCompendiumTelemetry_NullVersion_DefaultsTo1_0_0()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddCompendiumTelemetry("ServiceWithoutVersion");
+        using var provider = services.BuildServiceProvider();
+
+        // Assert — provider should still resolve
+        provider.GetService<TracerProvider>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddCompendiumConsoleExporter_AfterTelemetry_RegistersAndResolves()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddCompendiumTelemetry("ServiceA");
+
+        // Act
+        var returned = services.AddCompendiumConsoleExporter();
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        returned.Should().BeSameAs(services);
+        provider.GetService<TracerProvider>().Should().NotBeNull();
+        provider.GetService<MeterProvider>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddCompendiumOtlpExporter_AfterTelemetry_RegistersAndResolves()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddCompendiumTelemetry("ServiceB");
+
+        // Act
+        var returned = services.AddCompendiumOtlpExporter("http://localhost:4317");
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        returned.Should().BeSameAs(services);
+        provider.GetService<TracerProvider>().Should().NotBeNull();
+        provider.GetService<MeterProvider>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddCompendiumPrometheusExporter_AfterTelemetry_RegistersAndResolves()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddCompendiumTelemetry("ServiceC");
+
+        // Act
+        var returned = services.AddCompendiumPrometheusExporter();
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        returned.Should().BeSameAs(services);
+        provider.GetService<MeterProvider>().Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
Tops up `Compendium.Infrastructure` from **43.7 % → 90.8 %** line coverage (branch **18.2 % → 80.5 %**). Part of the testing campaign (sub-task of the Core/Infrastructure/Multitenancy/AI top-up bundle).

## Coverage report — Compendium.Infrastructure
- **Line coverage**: 43.7 % → **90.8 %**
- **Branch coverage**: 18.2 % → **80.5 %**
- **Tests added**: 282 (existing 245 + new 282 = **527 passing**, 2 pre-existing skipped)
- **Test files added**: 21
  - `EventSourcing/InMemoryEventStoreSupplementaryTests.cs`
  - `EventSourcing/InMemorySnapshotStoreSupplementaryTests.cs`
  - `EventSourcing/ProjectionManagerRebuildTests.cs`
  - `EventSourcing/ProjectionManagerTypesTests.cs`
  - `Observability/CorrelationIdTests.cs`
  - `Observability/InMemoryMetricsTests.cs`
  - `Observability/InMemoryTracingTests.cs`
  - `Observability/Logging/EventSourcingLogEnricherTests.cs`
  - `Observability/Logging/LoggingExtensionsTests.cs`
  - `Observability/Logging/SerilogConfigurationTests.cs`
  - `Projections/EnhancedProjectionManagerTests.cs`
  - `Projections/LiveProjectionProcessorTests.cs`
  - `Projections/OrderProjectionsTests.cs`
  - `Projections/ProjectionRegistrationServiceTests.cs`
  - `Projections/ProjectionTypesTests.cs`
  - `Projections/ProjectionsServiceCollectionExtensionsTests.cs`
  - `Repositories/EventSourcedRepositoryTests.cs`
  - `Resilience/CircuitBreakerRegistryTests.cs`
  - `Resilience/ResilienceTelemetryListenerTests.cs`
  - `Resilience/ServiceCollectionExtensionsTests.cs`
  - `Resilience/TokenBucketRateLimiterTests.cs`
  - `Security/InMemoryKeyVaultTests.cs`
  - `Telemetry/OpenTelemetryServiceCollectionExtensionsTests.cs`
- **Bugs surfaced**: 0
- **Types excluded as integration-only**: none — all in-process types testable in unit scope; flaky timing-sensitive Polly pipeline integration tests remain `[Skip]` as before.

### Per-class line coverage (highlights)
| Class | Before | After |
|---|---|---|
| `CorrelationIdProvider` / `CorrelationIdScope` | 0 % | 100 % |
| `InMemoryMetrics` | 0 % | 100 % |
| `InMemoryTracing` / `InMemoryTraceSpan` | 0 / 98 % | 100 / 100 % |
| `EventSourcingLogEnricher` / `LoggingExtensions` / `SerilogConfiguration` | 0 % | 100 % |
| `TokenBucketRateLimiter` / `TokenBucket` | 0 % | 100 % |
| `CircuitBreakerRegistry` | 0 % | 100 % |
| `ResilienceTelemetryListener` | 25 % | 100 % |
| `ServiceCollectionExtensions` (Resilience/Projections) | 0 % | 100 % |
| `EventSourcedRepository<,>` | 0 % | 96.6 % |
| `EnhancedProjectionManager` | 0 % | 90.6 % |
| `LiveProjectionProcessor` | 27 % | 83.2 % |
| `InMemoryKeyVault` | 0 % | 82.8 % |
| `OpenTelemetryServiceCollectionExtensions` | 0 % | 100 % |
| `ProjectionManager` (EventSourcing) | 66.6 % | 95.6 % |
| `InMemorySnapshotStore` | 70.3 % | 87.2 % |
| Order/CustomerStats example projections | 0 % | 100 % |

## Test plan
- [x] `dotnet build Compendium.sln -c Release` green (0 errors).
- [x] `dotnet test tests/Unit/Compendium.Infrastructure.Tests -c Release` green: 527 passed, 2 skipped, 0 failed (consistent across two runs — no flakiness).
- [x] No prod code modified (`git diff origin/main..HEAD --name-only -- 'src/**'` is empty).
- [x] No version bumps in `Directory.Packages.props`.
- [x] No Moq, no `Assert.*`, no `Thread.Sleep` introduced; NSubstitute + FluentAssertions only, AAA comments throughout.
- [ ] CI green