### PR TITLE
test: add unit tests for Adapters.Shared and Testing helpers

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -108,8 +108,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Application.Tests", "tests\Unit\Compendium.Application.Tests\Compendium.Application.Tests.csproj", "{4F876BBF-5817-4488-AD7C-1F4348DDCD15}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.Redis.Tests", "tests\Unit\Compendium.Adapters.Redis.Tests\Compendium.Adapters.Redis.Tests.csproj", "{C63EF05F-7C94-449F-92D1-51E3367395D1}"
-=======
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.AspNetCore.Tests", "tests\Unit\Compendium.Adapters.AspNetCore.Tests\Compendium.Adapters.AspNetCore.Tests.csproj", "{84C5728A-8843-4FFF-B2AB-98AF3838D820}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.Shared.Tests", "tests\Unit\Compendium.Adapters.Shared.Tests\Compendium.Adapters.Shared.Tests.csproj", "{3BFB6A86-8972-4003-9C52-7DFD5D956BAF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Testing.Tests", "tests\Unit\Compendium.Testing.Tests\Compendium.Testing.Tests.csproj", "{E5232EFA-E06C-4975-B5A7-91A241D029CB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -272,11 +274,18 @@ Global
 		{C63EF05F-7C94-449F-92D1-51E3367395D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C63EF05F-7C94-449F-92D1-51E3367395D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C63EF05F-7C94-449F-92D1-51E3367395D1}.Release|Any CPU.Build.0 = Release|Any CPU
-=======
 		{84C5728A-8843-4FFF-B2AB-98AF3838D820}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{84C5728A-8843-4FFF-B2AB-98AF3838D820}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{84C5728A-8843-4FFF-B2AB-98AF3838D820}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{84C5728A-8843-4FFF-B2AB-98AF3838D820}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BFB6A86-8972-4003-9C52-7DFD5D956BAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BFB6A86-8972-4003-9C52-7DFD5D956BAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BFB6A86-8972-4003-9C52-7DFD5D956BAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BFB6A86-8972-4003-9C52-7DFD5D956BAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5232EFA-E06C-4975-B5A7-91A241D029CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5232EFA-E06C-4975-B5A7-91A241D029CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5232EFA-E06C-4975-B5A7-91A241D029CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5232EFA-E06C-4975-B5A7-91A241D029CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -329,7 +338,8 @@ Global
 		{15D89214-41A9-41BA-BA39-5C1574757B62} = {7C29FF8B-D400-4FF4-85BB-76D23C8A5159}
 		{4F876BBF-5817-4488-AD7C-1F4348DDCD15} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{C63EF05F-7C94-449F-92D1-51E3367395D1} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
-=======
 		{84C5728A-8843-4FFF-B2AB-98AF3838D820} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{3BFB6A86-8972-4003-9C52-7DFD5D956BAF} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{E5232EFA-E06C-4975-B5A7-91A241D029CB} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/tests/Unit/Compendium.Adapters.Shared.Tests/Compendium.Adapters.Shared.Tests.csproj
+++ b/tests/Unit/Compendium.Adapters.Shared.Tests/Compendium.Adapters.Shared.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Adapters.Shared.Tests</AssemblyName>
+    <RootNamespace>Compendium.Adapters.Shared.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Adapters\Compendium.Adapters.Shared\Compendium.Adapters.Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Adapters.Shared.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Adapters.Shared.Tests/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Xunit;

--- a/tests/Unit/Compendium.Adapters.Shared.Tests/Logging/PiiMaskingTests.cs
+++ b/tests/Unit/Compendium.Adapters.Shared.Tests/Logging/PiiMaskingTests.cs
@@ -1,0 +1,161 @@
+// -----------------------------------------------------------------------
+// <copyright file="PiiMaskingTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Adapters.Shared.Logging;
+using FluentAssertions;
+
+namespace Compendium.Adapters.Shared.Tests.Logging;
+
+/// <summary>
+/// Unit tests for the <see cref="PiiMasking"/> static helpers.
+/// </summary>
+public class PiiMaskingTests
+{
+    [Fact]
+    public void MaskEmail_WhenNull_ReturnsEmptyPlaceholder()
+    {
+        // Arrange
+        string? email = null;
+
+        // Act
+        var result = PiiMasking.MaskEmail(email);
+
+        // Assert
+        result.Should().Be("<empty>");
+    }
+
+    [Fact]
+    public void MaskEmail_WhenEmptyString_ReturnsEmptyPlaceholder()
+    {
+        // Arrange
+        var email = string.Empty;
+
+        // Act
+        var result = PiiMasking.MaskEmail(email);
+
+        // Assert
+        result.Should().Be("<empty>");
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void MaskEmail_WhenWhitespaceOnly_ReturnsEmptyPlaceholder(string email)
+    {
+        // Arrange / Act
+        var result = PiiMasking.MaskEmail(email);
+
+        // Assert
+        result.Should().Be("<empty>");
+    }
+
+    [Theory]
+    [InlineData("@acme.com")]
+    [InlineData("@")]
+    public void MaskEmail_WhenAtSignAtStartOrOnly_ReturnsTripleStar(string email)
+    {
+        // Arrange / Act
+        var result = PiiMasking.MaskEmail(email);
+
+        // Assert
+        result.Should().Be("***");
+    }
+
+    [Theory]
+    [InlineData("notanemail")]
+    [InlineData("plainstring")]
+    [InlineData("john.doe")]
+    public void MaskEmail_WhenNoAtSign_ReturnsTripleStar(string email)
+    {
+        // Arrange / Act
+        var result = PiiMasking.MaskEmail(email);
+
+        // Assert
+        result.Should().Be("***");
+    }
+
+    [Fact]
+    public void MaskEmail_WhenStandardEmail_MasksLocalPartExceptFirstChar()
+    {
+        // Arrange
+        var email = "john.doe@acme.com";
+
+        // Act
+        var result = PiiMasking.MaskEmail(email);
+
+        // Assert
+        result.Should().Be("j***@acme.com");
+    }
+
+    [Fact]
+    public void MaskEmail_WhenSingleCharLocalPart_MasksToFirstCharThenStars()
+    {
+        // Arrange
+        var email = "a@example.com";
+
+        // Act
+        var result = PiiMasking.MaskEmail(email);
+
+        // Assert
+        result.Should().Be("a***@example.com");
+    }
+
+    [Fact]
+    public void MaskEmail_WhenMultipleAtSigns_UsesFirstAtSignAsBoundary()
+    {
+        // Arrange
+        var email = "user@inner@example.com";
+
+        // Act
+        var result = PiiMasking.MaskEmail(email);
+
+        // Assert
+        result.Should().Be("u***@inner@example.com");
+    }
+
+    [Fact]
+    public void MaskEmail_WhenEmailHasUnicode_PreservesFirstCharAndDomain()
+    {
+        // Arrange
+        var email = "élise@éxample.com";
+
+        // Act
+        var result = PiiMasking.MaskEmail(email);
+
+        // Assert
+        result.Should().Be("é***@éxample.com");
+    }
+
+    [Fact]
+    public void MaskEmail_WhenLongLocalPart_StillReturnsFirstCharAndStars()
+    {
+        // Arrange
+        var email = "verylongemailaddress@acme.com";
+
+        // Act
+        var result = PiiMasking.MaskEmail(email);
+
+        // Assert
+        result.Should().Be("v***@acme.com");
+        result.Should().NotContain("erylongemailaddress");
+    }
+
+    [Fact]
+    public void MaskEmail_WhenSubdomainPresent_PreservesEntireDomain()
+    {
+        // Arrange
+        var email = "alice@mail.acme.co.uk";
+
+        // Act
+        var result = PiiMasking.MaskEmail(email);
+
+        // Assert
+        result.Should().Be("a***@mail.acme.co.uk");
+    }
+}

--- a/tests/Unit/Compendium.Testing.Tests/Compendium.Testing.Tests.csproj
+++ b/tests/Unit/Compendium.Testing.Tests/Compendium.Testing.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Testing.Tests</AssemblyName>
+    <RootNamespace>Compendium.Testing.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Testing\Compendium.Testing\Compendium.Testing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Testing.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Testing.Tests/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Xunit;

--- a/tests/Unit/Compendium.Testing.Tests/TestHelpers/ApplicationTestHelpersTests.cs
+++ b/tests/Unit/Compendium.Testing.Tests/TestHelpers/ApplicationTestHelpersTests.cs
@@ -1,0 +1,95 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApplicationTestHelpersTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Testing.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Compendium.Testing.Tests.TestHelpers;
+
+/// <summary>
+/// Unit tests for the <see cref="ApplicationTestHelpers"/> extension methods.
+/// </summary>
+public class ApplicationTestHelpersTests
+{
+    [Fact]
+    public void AddTestApplication_OnEmptyServiceCollection_ReturnsSameInstance()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        var result = services.AddTestApplication();
+
+        // Assert
+        result.Should().BeSameAs(services);
+    }
+
+    [Fact]
+    public void AddTestApplication_OnEmptyServiceCollection_DoesNotAddRegistrations()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var initialCount = services.Count;
+
+        // Act
+        services.AddTestApplication();
+
+        // Assert
+        services.Count.Should().Be(initialCount);
+    }
+
+    [Fact]
+    public void AddTestApplication_OnPopulatedServiceCollection_PreservesExistingRegistrations()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<ISampleService, SampleService>();
+        var initialCount = services.Count;
+
+        // Act
+        services.AddTestApplication();
+
+        // Assert
+        services.Count.Should().Be(initialCount);
+        services.Should().ContainSingle(d => d.ServiceType == typeof(ISampleService));
+    }
+
+    [Fact]
+    public void AddTestApplication_AllowsBuildingServiceProvider()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddTestApplication();
+
+        // Act
+        var provider = services.BuildServiceProvider();
+
+        // Assert
+        provider.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddTestApplication_IsChainable_ReturnsBuilderForFluentRegistration()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        var result = services
+            .AddTestApplication()
+            .AddSingleton<ISampleService, SampleService>();
+
+        // Assert
+        result.Should().BeSameAs(services);
+        result.Should().ContainSingle(d => d.ServiceType == typeof(ISampleService));
+    }
+
+    private interface ISampleService;
+
+    private sealed class SampleService : ISampleService;
+}

--- a/tests/Unit/Compendium.Testing.Tests/TestHelpers/InMemoryTestStoreTests.cs
+++ b/tests/Unit/Compendium.Testing.Tests/TestHelpers/InMemoryTestStoreTests.cs
@@ -1,0 +1,251 @@
+// -----------------------------------------------------------------------
+// <copyright file="InMemoryTestStoreTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Testing.TestHelpers;
+using FluentAssertions;
+
+namespace Compendium.Testing.Tests.TestHelpers;
+
+/// <summary>
+/// Unit tests for the <see cref="InMemoryTestStore"/> helper.
+/// </summary>
+public class InMemoryTestStoreTests
+{
+    [Fact]
+    public async Task ExistsAsync_WhenKeyMissing_ReturnsFalse()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+
+        // Act
+        var exists = await store.ExistsAsync("missing-key");
+
+        // Assert
+        exists.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_WhenKeyPresent_ReturnsTrue()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+        await store.SetAsync("key-1", "value", TimeSpan.FromMinutes(1));
+
+        // Act
+        var exists = await store.ExistsAsync("key-1");
+
+        // Assert
+        exists.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_WithCancellationToken_ReturnsFalseForMissingKey()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        var exists = await store.ExistsAsync("missing-key", cts.Token);
+
+        // Assert
+        exists.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenKeyMissing_ReturnsDefault()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+
+        // Act
+        var value = await store.GetAsync<string>("missing-key");
+
+        // Assert
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenKeyMissingForValueType_ReturnsDefault()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+
+        // Act
+        var value = await store.GetAsync<int>("missing-key");
+
+        // Assert
+        value.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenKeyPresentWithMatchingType_ReturnsStoredValue()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+        await store.SetAsync("key-1", "stored-value", TimeSpan.FromMinutes(1));
+
+        // Act
+        var value = await store.GetAsync<string>("key-1");
+
+        // Assert
+        value.Should().Be("stored-value");
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenKeyPresentButTypeMismatch_ReturnsDefault()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+        await store.SetAsync("key-1", "stored-string", TimeSpan.FromMinutes(1));
+
+        // Act
+        var value = await store.GetAsync<int>("key-1");
+
+        // Assert
+        value.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenStoredValueIsNull_ReturnsDefault()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+        await store.SetAsync<string?>("key-1", null, TimeSpan.FromMinutes(1));
+
+        // Act
+        var value = await store.GetAsync<string>("key-1");
+
+        // Assert
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_WithCancellationToken_ReturnsValue()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+        await store.SetAsync("key-1", 42, TimeSpan.FromMinutes(1));
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        var value = await store.GetAsync<int>("key-1", cts.Token);
+
+        // Assert
+        value.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task SetAsync_WhenCalledTwiceWithSameKey_OverwritesValue()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+
+        // Act
+        await store.SetAsync("key-1", "first", TimeSpan.FromMinutes(1));
+        await store.SetAsync("key-1", "second", TimeSpan.FromMinutes(1));
+
+        // Assert
+        var value = await store.GetAsync<string>("key-1");
+        value.Should().Be("second");
+    }
+
+    [Fact]
+    public async Task SetAsync_WithComplexType_RoundTripsValue()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+        var payload = new SamplePayload("alice", 42);
+
+        // Act
+        await store.SetAsync("payload", payload, TimeSpan.FromMinutes(1));
+        var roundTrip = await store.GetAsync<SamplePayload>("payload");
+
+        // Assert
+        roundTrip.Should().NotBeNull();
+        roundTrip!.Name.Should().Be("alice");
+        roundTrip.Count.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task SetAsync_WithCancellationToken_StoresValue()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        await store.SetAsync("key-1", "value", TimeSpan.FromMinutes(1), cts.Token);
+
+        // Assert
+        (await store.ExistsAsync("key-1")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SetAsync_WithZeroExpiration_StillStoresValue()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+
+        // Act
+        await store.SetAsync("key-1", "value", TimeSpan.Zero);
+
+        // Assert — TTL is not enforced by this in-memory helper.
+        (await store.ExistsAsync("key-1")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Clear_WhenStorePopulated_RemovesAllEntries()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+        await store.SetAsync("key-1", "a", TimeSpan.FromMinutes(1));
+        await store.SetAsync("key-2", "b", TimeSpan.FromMinutes(1));
+
+        // Act
+        store.Clear();
+
+        // Assert
+        (await store.ExistsAsync("key-1")).Should().BeFalse();
+        (await store.ExistsAsync("key-2")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Clear_WhenStoreEmpty_DoesNotThrow()
+    {
+        // Arrange
+        var store = new InMemoryTestStore();
+
+        // Act
+        var act = () => store.Clear();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task IdempotencyScenario_SecondSetWithSameKey_DoesNotDuplicate()
+    {
+        // Arrange — simulates an idempotency-key store
+        var store = new InMemoryTestStore();
+        var key = "idem-key-1";
+
+        // Act
+        var firstExists = await store.ExistsAsync(key);
+        await store.SetAsync(key, "result-payload", TimeSpan.FromMinutes(5));
+        var secondExists = await store.ExistsAsync(key);
+        await store.SetAsync(key, "result-payload", TimeSpan.FromMinutes(5));
+        var stored = await store.GetAsync<string>(key);
+
+        // Assert
+        firstExists.Should().BeFalse();
+        secondExists.Should().BeTrue();
+        stored.Should().Be("result-payload");
+    }
+
+    private sealed record SamplePayload(string Name, int Count);
+}


### PR DESCRIPTION
## Summary
Adds unit tests for the two small helper projects. Part of the testing campaign (VK POM-475).

## Coverage report
- Compendium.Adapters.Shared : 100 % line, 17 tests
- Compendium.Testing : 100 % line, 21 tests
- Bugs surfaced: 0

Tests added cover every public type and method, including null / empty / whitespace inputs, type-mismatch fallback, cancellation tokens, multi-`@` edge cases, unicode local parts, and idempotency-style scenarios. NSubstitute + FluentAssertions only (no Moq, no `Assert.*`, no `Thread.Sleep`).

## Test plan
- [x] `dotnet build Compendium.sln -c Release` green (0 errors)
- [x] `dotnet test tests/Unit/Compendium.Adapters.Shared.Tests -c Release` green (17/17)
- [x] `dotnet test tests/Unit/Compendium.Testing.Tests -c Release` green (21/21)
- [x] No prod code modified, no version bumps
- [x] Coverage measured via ReportGenerator on cobertura output: both projects 100 % line
- [ ] CI green