### PR TITLE
test(adapters/stripe): top up coverage to 90%

### DIFF
--- a/tests/Unit/Compendium.Adapters.Stripe.Tests/Compendium.Adapters.Stripe.Tests.csproj
+++ b/tests/Unit/Compendium.Adapters.Stripe.Tests/Compendium.Adapters.Stripe.Tests.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Stripe.net" />
+    <PackageReference Include="RichardSzalay.MockHttp" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Unit/Compendium.Adapters.Stripe.Tests/Services/StripeBillingServiceTests.cs
+++ b/tests/Unit/Compendium.Adapters.Stripe.Tests/Services/StripeBillingServiceTests.cs
@@ -1,0 +1,704 @@
+// -----------------------------------------------------------------------
+// <copyright file="StripeBillingServiceTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using Compendium.Abstractions.Billing;
+using Compendium.Abstractions.Billing.Models;
+using Compendium.Adapters.Stripe.Configuration;
+using Compendium.Adapters.Stripe.Tests.TestSupport;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Stripe;
+
+namespace Compendium.Adapters.Stripe.Tests.Services;
+
+/// <summary>
+/// Unit tests for the internal <c>StripeBillingService</c>. They drive the
+/// service through its <see cref="IBillingService"/> contract while replacing
+/// the global <see cref="StripeConfiguration.StripeClient"/> with a stub
+/// <see cref="StubStripeHttpClient"/> so HTTP calls are intercepted without
+/// hitting the real Stripe API.
+/// </summary>
+[Collection(StripeGlobalStateCollection.Name)]
+public sealed class StripeBillingServiceTests : IDisposable
+{
+    private readonly IStripeClient? _previousClient = StripeConfiguration.StripeClient;
+    private readonly StubStripeHttpClient _http = new();
+
+    public StripeBillingServiceTests()
+    {
+        // Arrange — install the stub IHttpClient on the shared StripeConfiguration
+        // singleton; every SDK service constructed during this test instance routes
+        // through it.
+        StripeConfiguration.StripeClient = new StripeClient("sk_test_unit", httpClient: _http);
+    }
+
+    public void Dispose()
+    {
+        StripeConfiguration.StripeClient = _previousClient;
+    }
+
+    // ---------------------------------------------------------------------
+    // CreateCheckoutSessionAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateCheckoutSessionAsync_ValidRequest_ReturnsMappedSession()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/checkout/sessions",
+            CheckoutSessionJson("cs_test_1", "price_abc"));
+
+        var request = new CreateCheckoutRequest
+        {
+            VariantId = "price_abc",
+            SuccessUrl = "https://example.com/ok",
+            CancelUrl = "https://example.com/cancel",
+            Email = "buyer@example.com",
+            UserId = "u-1",
+            CustomData = new Dictionary<string, object> { ["plan"] = "pro" }
+        };
+
+        // Act
+        var result = await sut.CreateCheckoutSessionAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be("cs_test_1");
+        result.Value.VariantId.Should().Be("price_abc");
+        result.Value.CheckoutUrl.Should().Be("https://stripe.test/co/cs_test_1");
+
+        var body = _http.Recorded[0].Content!;
+        body.Should().Contain("mode=subscription");
+        body.Should().Contain("line_items[0][price]=price_abc");
+        body.Should().Contain("customer_email=buyer%40example.com");
+        body.Should().Contain("metadata[user_id]=u-1");
+        body.Should().Contain("metadata[plan]=pro");
+    }
+
+    [Fact]
+    public async Task CreateCheckoutSessionAsync_WithDiscountCode_AppendsPromotionCodeToBody()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/checkout/sessions",
+            CheckoutSessionJson("cs_test_2", "price_xyz"));
+
+        var request = new CreateCheckoutRequest
+        {
+            VariantId = "price_xyz",
+            SuccessUrl = "https://e.com/s",
+            CancelUrl = "https://e.com/c",
+            Email = "x@e.com",
+            DiscountCode = "promo_50"
+        };
+
+        // Act
+        var result = await sut.CreateCheckoutSessionAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _http.Recorded[0].Content!.Should().Contain("discounts[0][promotion_code]=promo_50");
+    }
+
+    [Fact]
+    public async Task CreateCheckoutSessionAsync_StripeFailure_ReturnsCheckoutFailedError()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/checkout/sessions",
+            ErrorJson("invalid_request_error", "Bad price."),
+            System.Net.HttpStatusCode.BadRequest);
+
+        // Act
+        var result = await sut.CreateCheckoutSessionAsync(
+            new CreateCheckoutRequest
+            {
+                VariantId = "price_bad",
+                SuccessUrl = "https://e.com/s",
+                CancelUrl = "https://e.com/c",
+                Email = "x@e.com"
+            },
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.CheckoutFailed");
+        result.Error.Message.Should().Contain("Bad price.");
+    }
+
+    [Fact]
+    public async Task CreateCheckoutSessionAsync_NullRequest_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.CreateCheckoutSessionAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // GetCustomerAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetCustomerAsync_ExistingCustomer_ReturnsMappedBillingCustomer()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/customers/cus_123",
+            CustomerJson("cus_123", "alice@example.com", name: "Alice"));
+
+        // Act
+        var result = await sut.GetCustomerAsync("cus_123", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be("cus_123");
+        result.Value.Email.Should().Be("alice@example.com");
+        result.Value.Name.Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task GetCustomerAsync_NotFound_ReturnsCustomerNotFoundError()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/customers/cus_missing",
+            ErrorJson("invalid_request_error", "No such customer.", "resource_missing"),
+            System.Net.HttpStatusCode.NotFound);
+
+        // Act
+        var result = await sut.GetCustomerAsync("cus_missing", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.CustomerNotFound");
+    }
+
+    [Fact]
+    public async Task GetCustomerAsync_StripeFailure_ReturnsGetCustomerFailedError()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/customers/cus_err",
+            ErrorJson("api_error", "Boom"),
+            System.Net.HttpStatusCode.InternalServerError);
+
+        // Act
+        var result = await sut.GetCustomerAsync("cus_err", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.GetCustomerFailed");
+        result.Error.Message.Should().Contain("Boom");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GetCustomerAsync_WhitespaceCustomerId_ThrowsArgumentException(string customerId)
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.GetCustomerAsync(customerId, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // GetCustomerByEmailAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetCustomerByEmailAsync_FoundOne_ReturnsMappedCustomer()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/customers",
+            CustomerListJson(CustomerJsonFragment("cus_email", "found@example.com")));
+
+        // Act
+        var result = await sut.GetCustomerByEmailAsync("found@example.com", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be("cus_email");
+        result.Value.Email.Should().Be("found@example.com");
+    }
+
+    [Fact]
+    public async Task GetCustomerByEmailAsync_EmptyResult_ReturnsCustomerNotFoundByEmail()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(HttpMethod.Get, "/v1/customers", CustomerListJson());
+
+        // Act
+        var result = await sut.GetCustomerByEmailAsync("absent@example.com", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.CustomerNotFoundByEmail");
+    }
+
+    [Fact]
+    public async Task GetCustomerByEmailAsync_StripeFailure_ReturnsGetCustomerByEmailFailedError()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/customers",
+            ErrorJson("api_error", "Throttled"),
+            System.Net.HttpStatusCode.TooManyRequests);
+
+        // Act
+        var result = await sut.GetCustomerByEmailAsync("rate@example.com", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.GetCustomerByEmailFailed");
+    }
+
+    [Fact]
+    public async Task GetCustomerByEmailAsync_BlankEmail_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.GetCustomerByEmailAsync("  ", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // UpsertCustomerAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpsertCustomerAsync_CustomerExists_UpdatesAndReturnsMapped()
+    {
+        // Arrange — list returns one customer; SDK then issues an UPDATE on that id.
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/customers",
+            CustomerListJson(CustomerJsonFragment("cus_existing", "u@example.com")));
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/customers/cus_existing",
+            CustomerJson("cus_existing", "u@example.com", name: "Updated"));
+
+        // Act
+        var result = await sut.UpsertCustomerAsync(
+            new UpsertCustomerRequest
+            {
+                Email = "u@example.com",
+                Name = "Updated",
+                City = "Paris",
+                Region = "IDF",
+                Country = "FR",
+                TenantId = "t-1",
+                UserId = "u-1",
+                CustomData = new Dictionary<string, object> { ["seg"] = "vip" }
+            },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be("cus_existing");
+        result.Value.Name.Should().Be("Updated");
+
+        var update = _http.Recorded[1];
+        update.Content!.Should().Contain("name=Updated");
+        update.Content!.Should().Contain("metadata[tenant_id]=t-1");
+        update.Content!.Should().Contain("metadata[seg]=vip");
+        update.Content!.Should().Contain("address[city]=Paris");
+    }
+
+    [Fact]
+    public async Task UpsertCustomerAsync_NoMatch_CreatesNewCustomer()
+    {
+        // Arrange — empty list triggers CREATE path.
+        var sut = CreateSut();
+        _http.Expect(HttpMethod.Get, "/v1/customers", CustomerListJson());
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/customers",
+            CustomerJson("cus_new", "new@example.com", name: "New"));
+
+        // Act
+        var result = await sut.UpsertCustomerAsync(
+            new UpsertCustomerRequest { Email = "new@example.com", Name = "New" },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be("cus_new");
+        _http.Recorded.Should().HaveCount(2);
+        _http.Recorded[1].Method.Should().Be(HttpMethod.Post);
+        _http.Recorded[1].Uri.AbsolutePath.Should().EndWith("/v1/customers");
+    }
+
+    [Fact]
+    public async Task UpsertCustomerAsync_NoAddressFields_OmitsAddressOptions()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(HttpMethod.Get, "/v1/customers", CustomerListJson());
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/customers",
+            CustomerJson("cus_no_addr", "noaddr@example.com"));
+
+        // Act
+        var result = await sut.UpsertCustomerAsync(
+            new UpsertCustomerRequest { Email = "noaddr@example.com" },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _http.Recorded[1].Content!.Should().NotContain("address[");
+    }
+
+    [Fact]
+    public async Task UpsertCustomerAsync_NoMetadata_OmitsMetadataParameters()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(HttpMethod.Get, "/v1/customers", CustomerListJson());
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/customers",
+            CustomerJson("cus_no_meta", "nometa@example.com"));
+
+        // Act
+        var result = await sut.UpsertCustomerAsync(
+            new UpsertCustomerRequest { Email = "nometa@example.com" },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _http.Recorded[1].Content!.Should().NotContain("metadata[");
+    }
+
+    [Fact]
+    public async Task UpsertCustomerAsync_StripeFailure_ReturnsUpsertCustomerFailedError()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/customers",
+            ErrorJson("api_error", "boom"),
+            System.Net.HttpStatusCode.BadGateway);
+
+        // Act
+        var result = await sut.UpsertCustomerAsync(
+            new UpsertCustomerRequest { Email = "fail@example.com" },
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.UpsertCustomerFailed");
+    }
+
+    [Fact]
+    public async Task UpsertCustomerAsync_NullRequest_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.UpsertCustomerAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task UpsertCustomerAsync_BlankEmail_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.UpsertCustomerAsync(
+            new UpsertCustomerRequest { Email = "  " },
+            CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // CreateCustomerPortalUrlAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateCustomerPortalUrlAsync_HappyPath_ReturnsUrl()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/billing_portal/sessions",
+            BillingPortalSessionJson("bps_1", "https://billing.stripe.test/p/bps_1"));
+
+        // Act
+        var result = await sut.CreateCustomerPortalUrlAsync(
+            "cus_123",
+            "https://example.com/back",
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("https://billing.stripe.test/p/bps_1");
+        _http.Recorded[0].Content!.Should().Contain("customer=cus_123");
+        _http.Recorded[0].Content!.Should().Contain("return_url=https%3A%2F%2Fexample.com%2Fback");
+    }
+
+    [Fact]
+    public async Task CreateCustomerPortalUrlAsync_NullReturnUrl_UsesFallback()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/billing_portal/sessions",
+            BillingPortalSessionJson("bps_2", "https://billing.stripe.test/p/bps_2"));
+
+        // Act
+        var result = await sut.CreateCustomerPortalUrlAsync("cus_456", returnUrl: null, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _http.Recorded[0].Content!.Should().Contain("return_url=https%3A%2F%2Fexample.com%2Freturn");
+    }
+
+    [Fact]
+    public async Task CreateCustomerPortalUrlAsync_NotFound_ReturnsCustomerNotFound()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/billing_portal/sessions",
+            ErrorJson("invalid_request_error", "No such customer."),
+            System.Net.HttpStatusCode.NotFound);
+
+        // Act
+        var result = await sut.CreateCustomerPortalUrlAsync("cus_missing", returnUrl: null, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.CustomerNotFound");
+    }
+
+    [Fact]
+    public async Task CreateCustomerPortalUrlAsync_StripeFailure_ReturnsPortalSessionFailed()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/billing_portal/sessions",
+            ErrorJson("api_error", "service_down"),
+            System.Net.HttpStatusCode.InternalServerError);
+
+        // Act
+        var result = await sut.CreateCustomerPortalUrlAsync("cus_err", "https://e.com/back", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.PortalSessionFailed");
+    }
+
+    [Fact]
+    public async Task CreateCustomerPortalUrlAsync_BlankCustomerId_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.CreateCustomerPortalUrlAsync("", "https://e.com/back", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // Constructor null-guards
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Ctor_NullOptions_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var handlerType = ServiceType();
+
+        // Act
+        var act = () => Activator.CreateInstance(
+            handlerType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new object?[] { null, NullLoggerInstance(handlerType) },
+            culture: null);
+
+        // Assert
+        act.Should().Throw<TargetInvocationException>()
+           .WithInnerException<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var handlerType = ServiceType();
+        var options = Options.Create(new StripeOptions { SecretKey = "sk_test_x" });
+
+        // Act
+        var act = () => Activator.CreateInstance(
+            handlerType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new object?[] { options, null },
+            culture: null);
+
+        // Assert
+        act.Should().Throw<TargetInvocationException>()
+           .WithInnerException<ArgumentNullException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static IBillingService CreateSut()
+    {
+        var handlerType = ServiceType();
+        var options = Options.Create(new StripeOptions { SecretKey = "sk_test_unit" });
+        var logger = NullLoggerInstance(handlerType);
+
+        var instance = Activator.CreateInstance(
+            handlerType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new[] { (object)options, logger },
+            culture: null)!;
+
+        return (IBillingService)instance;
+    }
+
+    private static Type ServiceType() => typeof(StripeOptions).Assembly
+        .GetType("Compendium.Adapters.Stripe.Services.StripeBillingService", throwOnError: true)!;
+
+    private static object NullLoggerInstance(Type serviceType) =>
+        Activator.CreateInstance(typeof(NullLogger<>).MakeGenericType(serviceType))!;
+
+    private static string CheckoutSessionJson(string id, string priceId) => $$"""
+        {
+          "id": "{{id}}",
+          "object": "checkout.session",
+          "url": "https://stripe.test/co/{{id}}",
+          "created": 1700000000,
+          "expires_at": 1700003600,
+          "line_items": {
+            "object": "list",
+            "data": [
+              {
+                "id": "li_1",
+                "object": "item",
+                "price": { "id": "{{priceId}}", "object": "price" }
+              }
+            ]
+          },
+          "metadata": {}
+        }
+        """;
+
+    private static string CustomerJson(string id, string email, string? name = null) => $$"""
+        {
+          "id": "{{id}}",
+          "object": "customer",
+          "email": "{{email}}",
+          "name": {{(name is null ? "null" : $"\"{name}\"")}},
+          "created": 1700000000,
+          "metadata": {}
+        }
+        """;
+
+    private static string CustomerJsonFragment(string id, string email) => $$"""
+        {
+          "id": "{{id}}",
+          "object": "customer",
+          "email": "{{email}}",
+          "created": 1700000000,
+          "metadata": {}
+        }
+        """;
+
+    private static string CustomerListJson(params string[] customerJsonFragments)
+    {
+        var data = string.Join(",", customerJsonFragments);
+        return $$"""
+            {
+              "object": "list",
+              "url": "/v1/customers",
+              "has_more": false,
+              "data": [{{data}}]
+            }
+            """;
+    }
+
+    private static string BillingPortalSessionJson(string id, string url) => $$"""
+        {
+          "id": "{{id}}",
+          "object": "billing_portal.session",
+          "url": "{{url}}",
+          "customer": "cus_test"
+        }
+        """;
+
+    private static string ErrorJson(string type, string message, string? code = null)
+    {
+        var codeFragment = code is null ? string.Empty : $",\"code\":\"{code}\"";
+        return $$"""
+            {
+              "error": {
+                "type": "{{type}}",
+                "message": "{{message}}"{{codeFragment}}
+              }
+            }
+            """;
+    }
+}

--- a/tests/Unit/Compendium.Adapters.Stripe.Tests/Services/StripeMapperBehaviorTests.cs
+++ b/tests/Unit/Compendium.Adapters.Stripe.Tests/Services/StripeMapperBehaviorTests.cs
@@ -1,0 +1,450 @@
+// -----------------------------------------------------------------------
+// <copyright file="StripeMapperBehaviorTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using Compendium.Abstractions.Billing.Models;
+using Compendium.Adapters.Stripe.Configuration;
+using FluentAssertions;
+using Stripe;
+
+namespace Compendium.Adapters.Stripe.Tests.Services;
+
+/// <summary>
+/// Behavioural tests for the internal <c>StripeMapper</c>. Exercises the full
+/// mapping surface (<c>ToBillingCustomer</c>, <c>ToSubscription</c>,
+/// <c>ToCheckoutSession</c>, <c>ToUtcOffset</c>) via reflection because the
+/// mapper is intentionally <c>internal</c>.
+/// </summary>
+public sealed class StripeMapperBehaviorTests
+{
+    // ---------------------------------------------------------------------
+    // ToUtcOffset
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void ToUtcOffset_DateTime_ReturnsUtcOffset()
+    {
+        // Arrange
+        var input = new DateTime(2025, 1, 15, 12, 0, 0, DateTimeKind.Unspecified);
+
+        // Act
+        var actual = (DateTimeOffset)InvokeStatic("ToUtcOffset", new Type[] { typeof(DateTime) }, input)!;
+
+        // Assert
+        actual.Offset.Should().Be(TimeSpan.Zero);
+        actual.UtcDateTime.Should().Be(DateTime.SpecifyKind(input, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void ToUtcOffset_NullableDateTimeWithValue_ReturnsUtcOffset()
+    {
+        // Arrange
+        DateTime? input = new DateTime(2025, 1, 15, 12, 0, 0, DateTimeKind.Unspecified);
+
+        // Act
+        var actual = (DateTimeOffset?)InvokeStatic("ToUtcOffset", new Type[] { typeof(DateTime?) }, input)!;
+
+        // Assert
+        actual.Should().NotBeNull();
+        actual!.Value.Offset.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void ToUtcOffset_NullDateTime_ReturnsNull()
+    {
+        // Arrange
+        DateTime? input = null;
+
+        // Act
+        var actual = (DateTimeOffset?)InvokeStatic("ToUtcOffset", new Type[] { typeof(DateTime?) }, input);
+
+        // Assert
+        actual.Should().BeNull();
+    }
+
+    // ---------------------------------------------------------------------
+    // ToBillingCustomer
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void ToBillingCustomer_FullCustomer_MapsAllFields()
+    {
+        // Arrange
+        var customer = new Customer
+        {
+            Id = "cus_full",
+            Email = "alice@example.com",
+            Name = "Alice",
+            Address = new Address { City = "Lyon", State = "ARA", Country = "FR" },
+            Created = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            Metadata = new Dictionary<string, string>
+            {
+                ["tenant_id"] = "tenant-7",
+                ["user_id"] = "user-7",
+                ["plan"] = "enterprise"
+            }
+        };
+
+        // Act
+        var actual = (BillingCustomer)InvokeStatic(
+            "ToBillingCustomer",
+            new Type[] { typeof(Customer) },
+            customer)!;
+
+        // Assert
+        actual.Id.Should().Be("cus_full");
+        actual.Email.Should().Be("alice@example.com");
+        actual.Name.Should().Be("Alice");
+        actual.City.Should().Be("Lyon");
+        actual.Region.Should().Be("ARA");
+        actual.Country.Should().Be("FR");
+        actual.TenantId.Should().Be("tenant-7");
+        actual.UserId.Should().Be("user-7");
+        actual.CustomData!["plan"].Should().Be("enterprise");
+        actual.CreatedAt.Offset.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void ToBillingCustomer_NoEmailNoMetadataNoAddress_FillsDefaults()
+    {
+        // Arrange — minimal customer envelope.
+        var customer = new Customer
+        {
+            Id = "cus_min",
+            Email = null,
+            Created = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Metadata = null
+        };
+
+        // Act
+        var actual = (BillingCustomer)InvokeStatic(
+            "ToBillingCustomer",
+            new Type[] { typeof(Customer) },
+            customer)!;
+
+        // Assert
+        actual.Email.Should().BeEmpty();
+        actual.Name.Should().BeNull();
+        actual.City.Should().BeNull();
+        actual.Region.Should().BeNull();
+        actual.Country.Should().BeNull();
+        actual.TenantId.Should().BeNull();
+        actual.UserId.Should().BeNull();
+        actual.CustomData.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToBillingCustomer_EmptyMetadataDict_StillReturnsNullCustomData()
+    {
+        // Arrange — metadata is present but empty: ToCustomData() should return null.
+        var customer = new Customer
+        {
+            Id = "cus_empty_meta",
+            Email = "x@example.com",
+            Created = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Metadata = new Dictionary<string, string>()
+        };
+
+        // Act
+        var actual = (BillingCustomer)InvokeStatic(
+            "ToBillingCustomer",
+            new Type[] { typeof(Customer) },
+            customer)!;
+
+        // Assert
+        actual.CustomData.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToBillingCustomer_NullCustomer_ThrowsArgumentNullException()
+    {
+        // Arrange / Act
+        var act = () => InvokeStatic("ToBillingCustomer", new Type[] { typeof(Customer) }, (Customer?)null);
+
+        // Assert
+        act.Should().Throw<TargetInvocationException>()
+           .WithInnerException<ArgumentNullException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // ToSubscription
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void ToSubscription_FullSubscription_MapsItemPriceAndTimestamps()
+    {
+        // Arrange
+        var item = new SubscriptionItem
+        {
+            Id = "si_1",
+            Price = new Price
+            {
+                Id = "price_1",
+                ProductId = "prod_1",
+                Currency = "eur",
+                UnitAmount = 999,
+                Recurring = new PriceRecurring { Interval = "month", IntervalCount = 1 }
+            },
+            CurrentPeriodStart = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            CurrentPeriodEnd = new DateTime(2025, 2, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var sub = new global::Stripe.Subscription
+        {
+            Id = "sub_1",
+            CustomerId = "cus_1",
+            Status = "active",
+            Created = new DateTime(2024, 12, 15, 0, 0, 0, DateTimeKind.Utc),
+            CanceledAt = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            CancelAt = new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+            EndedAt = null,
+            TrialEnd = new DateTime(2025, 1, 7, 0, 0, 0, DateTimeKind.Utc),
+            Items = new StripeList<SubscriptionItem> { Data = new List<SubscriptionItem> { item } },
+            Metadata = new Dictionary<string, string> { ["tenant_id"] = "t-77", ["origin"] = "campaign-x" }
+        };
+
+        // Act
+        var actual = (Compendium.Abstractions.Billing.Models.Subscription)InvokeStatic(
+            "ToSubscription",
+            new Type[] { typeof(global::Stripe.Subscription) },
+            sub)!;
+
+        // Assert
+        actual.Id.Should().Be("sub_1");
+        actual.CustomerId.Should().Be("cus_1");
+        actual.ProductId.Should().Be("prod_1");
+        actual.VariantId.Should().Be("price_1");
+        actual.Currency.Should().Be("EUR");
+        actual.PriceAmountCents.Should().Be(999);
+        actual.BillingInterval.Should().Be("month");
+        actual.BillingIntervalCount.Should().Be(1);
+        actual.Status.Should().Be(BillingSubscriptionStatus.Active);
+        actual.CanceledAt.Should().NotBeNull();
+        actual.CancelAt.Should().NotBeNull();
+        actual.EndedAt.Should().BeNull();
+        actual.TrialEndsAt.Should().NotBeNull();
+        actual.PausedAt.Should().BeNull();
+        actual.CurrentPeriodStart.Should().NotBeNull();
+        actual.CurrentPeriodEnd.Should().NotBeNull();
+        actual.TenantId.Should().Be("t-77");
+        actual.CustomData!["origin"].Should().Be("campaign-x");
+    }
+
+    [Fact]
+    public void ToSubscription_PausedStatus_SetsPausedAt()
+    {
+        // Arrange
+        var sub = new global::Stripe.Subscription
+        {
+            Id = "sub_paused",
+            CustomerId = "cus_p",
+            Status = "paused",
+            Created = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc),
+            Items = new StripeList<SubscriptionItem> { Data = new List<SubscriptionItem>() }
+        };
+
+        // Act
+        var actual = (Compendium.Abstractions.Billing.Models.Subscription)InvokeStatic(
+            "ToSubscription",
+            new Type[] { typeof(global::Stripe.Subscription) },
+            sub)!;
+
+        // Assert
+        actual.Status.Should().Be(BillingSubscriptionStatus.Paused);
+        actual.PausedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ToSubscription_NoItems_LeavesProductAndVariantEmpty()
+    {
+        // Arrange
+        var sub = new global::Stripe.Subscription
+        {
+            Id = "sub_empty",
+            CustomerId = "cus_e",
+            Status = "active",
+            Created = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Items = new StripeList<SubscriptionItem> { Data = new List<SubscriptionItem>() }
+        };
+
+        // Act
+        var actual = (Compendium.Abstractions.Billing.Models.Subscription)InvokeStatic(
+            "ToSubscription",
+            new Type[] { typeof(global::Stripe.Subscription) },
+            sub)!;
+
+        // Assert
+        actual.ProductId.Should().BeEmpty();
+        actual.VariantId.Should().BeEmpty();
+        actual.Currency.Should().BeNull();
+        actual.PriceAmountCents.Should().BeNull();
+        actual.BillingInterval.Should().BeNull();
+        actual.BillingIntervalCount.Should().BeNull();
+        actual.CurrentPeriodStart.Should().BeNull();
+        actual.CurrentPeriodEnd.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToSubscription_NullCustomerId_DefaultsToEmpty()
+    {
+        // Arrange
+        var sub = new global::Stripe.Subscription
+        {
+            Id = "sub_no_cus",
+            CustomerId = null,
+            Status = "active",
+            Created = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Items = new StripeList<SubscriptionItem> { Data = new List<SubscriptionItem>() }
+        };
+
+        // Act
+        var actual = (Compendium.Abstractions.Billing.Models.Subscription)InvokeStatic(
+            "ToSubscription",
+            new Type[] { typeof(global::Stripe.Subscription) },
+            sub)!;
+
+        // Assert
+        actual.CustomerId.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToSubscription_NullSubscription_ThrowsArgumentNullException()
+    {
+        // Arrange / Act
+        var act = () => InvokeStatic("ToSubscription", new Type[] { typeof(global::Stripe.Subscription) }, (global::Stripe.Subscription?)null);
+
+        // Assert
+        act.Should().Throw<TargetInvocationException>()
+           .WithInnerException<ArgumentNullException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // ToCheckoutSession
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void ToCheckoutSession_WithLineItems_MapsVariantId()
+    {
+        // Arrange
+        var session = new global::Stripe.Checkout.Session
+        {
+            Id = "cs_1",
+            Url = "https://stripe.test/co/cs_1",
+            Created = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ExpiresAt = new DateTime(2025, 1, 1, 1, 0, 0, DateTimeKind.Utc),
+            LineItems = new StripeList<global::Stripe.LineItem>
+            {
+                Data = new List<global::Stripe.LineItem>
+                {
+                    new()
+                    {
+                        Id = "li_1",
+                        Price = new Price { Id = "price_1" }
+                    }
+                }
+            },
+            Metadata = new Dictionary<string, string> { ["promo"] = "yes" }
+        };
+
+        // Act
+        var actual = (CheckoutSession)InvokeStatic(
+            "ToCheckoutSession",
+            new Type[] { typeof(global::Stripe.Checkout.Session) },
+            session)!;
+
+        // Assert
+        actual.Id.Should().Be("cs_1");
+        actual.CheckoutUrl.Should().Be("https://stripe.test/co/cs_1");
+        actual.VariantId.Should().Be("price_1");
+        actual.CustomData!["promo"].Should().Be("yes");
+        actual.CreatedAt.Offset.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void ToCheckoutSession_NoLineItems_LeavesVariantIdNullAndUrlDefaultsToEmpty()
+    {
+        // Arrange
+        var session = new global::Stripe.Checkout.Session
+        {
+            Id = "cs_2",
+            Url = null,
+            Created = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ExpiresAt = new DateTime(2025, 1, 1, 1, 0, 0, DateTimeKind.Utc),
+            LineItems = null,
+            Metadata = null
+        };
+
+        // Act
+        var actual = (CheckoutSession)InvokeStatic(
+            "ToCheckoutSession",
+            new Type[] { typeof(global::Stripe.Checkout.Session) },
+            session)!;
+
+        // Assert
+        actual.VariantId.Should().BeNull();
+        actual.CheckoutUrl.Should().BeEmpty();
+        actual.CustomData.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToCheckoutSession_EmptyLineItems_LeavesVariantIdNull()
+    {
+        // Arrange — Data list exists but is empty.
+        var session = new global::Stripe.Checkout.Session
+        {
+            Id = "cs_3",
+            Url = "https://stripe.test/co/cs_3",
+            Created = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ExpiresAt = new DateTime(2025, 1, 1, 1, 0, 0, DateTimeKind.Utc),
+            LineItems = new StripeList<global::Stripe.LineItem>
+            {
+                Data = new List<global::Stripe.LineItem>()
+            },
+            Metadata = null
+        };
+
+        // Act
+        var actual = (CheckoutSession)InvokeStatic(
+            "ToCheckoutSession",
+            new Type[] { typeof(global::Stripe.Checkout.Session) },
+            session)!;
+
+        // Assert
+        actual.VariantId.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToCheckoutSession_NullSession_ThrowsArgumentNullException()
+    {
+        // Arrange / Act
+        var act = () => InvokeStatic(
+            "ToCheckoutSession",
+            new Type[] { typeof(global::Stripe.Checkout.Session) },
+            (global::Stripe.Checkout.Session?)null);
+
+        // Assert
+        act.Should().Throw<TargetInvocationException>()
+           .WithInnerException<ArgumentNullException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static object? InvokeStatic(string methodName, Type[] argTypes, params object?[] args)
+    {
+        var adapterAssembly = typeof(StripeOptions).Assembly;
+        var mapperType = adapterAssembly.GetType("Compendium.Adapters.Stripe.Services.StripeMapper", throwOnError: true)!;
+        var method = mapperType.GetMethod(
+            methodName,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+            binder: null,
+            types: argTypes,
+            modifiers: null)!;
+        return method.Invoke(null, args);
+    }
+}

--- a/tests/Unit/Compendium.Adapters.Stripe.Tests/Services/StripeSubscriptionServiceTests.cs
+++ b/tests/Unit/Compendium.Adapters.Stripe.Tests/Services/StripeSubscriptionServiceTests.cs
@@ -1,0 +1,698 @@
+// -----------------------------------------------------------------------
+// <copyright file="StripeSubscriptionServiceTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using Compendium.Abstractions.Billing;
+using Compendium.Abstractions.Billing.Models;
+using Compendium.Adapters.Stripe.Configuration;
+using Compendium.Adapters.Stripe.Tests.TestSupport;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Stripe;
+
+namespace Compendium.Adapters.Stripe.Tests.Services;
+
+/// <summary>
+/// Unit tests for the internal <c>StripeSubscriptionService</c>.
+/// </summary>
+[Collection(StripeGlobalStateCollection.Name)]
+public sealed class StripeSubscriptionServiceTests : IDisposable
+{
+    private readonly IStripeClient? _previousClient = StripeConfiguration.StripeClient;
+    private readonly StubStripeHttpClient _http = new();
+
+    public StripeSubscriptionServiceTests()
+    {
+        // Arrange — install the stub IHttpClient on the shared singleton.
+        StripeConfiguration.StripeClient = new StripeClient("sk_test_unit", httpClient: _http);
+    }
+
+    public void Dispose()
+    {
+        StripeConfiguration.StripeClient = _previousClient;
+    }
+
+    // ---------------------------------------------------------------------
+    // GetSubscriptionAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetSubscriptionAsync_Existing_ReturnsMappedSubscription()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/subscriptions/sub_1",
+            SubscriptionJson("sub_1", "cus_1", "price_1", "active"));
+
+        // Act
+        var result = await sut.GetSubscriptionAsync("sub_1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be("sub_1");
+        result.Value.CustomerId.Should().Be("cus_1");
+        result.Value.VariantId.Should().Be("price_1");
+        result.Value.Status.Should().Be(BillingSubscriptionStatus.Active);
+    }
+
+    [Fact]
+    public async Task GetSubscriptionAsync_NotFound_ReturnsSubscriptionNotFoundError()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/subscriptions/sub_missing",
+            ErrorJson("invalid_request_error", "No such subscription."),
+            System.Net.HttpStatusCode.NotFound);
+
+        // Act
+        var result = await sut.GetSubscriptionAsync("sub_missing", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.SubscriptionNotFound");
+    }
+
+    [Fact]
+    public async Task GetSubscriptionAsync_StripeFailure_ReturnsGetSubscriptionFailedError()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/subscriptions/sub_err",
+            ErrorJson("api_error", "boom"),
+            System.Net.HttpStatusCode.InternalServerError);
+
+        // Act
+        var result = await sut.GetSubscriptionAsync("sub_err", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.GetSubscriptionFailed");
+    }
+
+    [Fact]
+    public async Task GetSubscriptionAsync_BlankId_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.GetSubscriptionAsync(" ", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // GetActiveSubscriptionAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetActiveSubscriptionAsync_FoundOne_ReturnsMappedSubscription()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/subscriptions",
+            SubscriptionListJson(SubscriptionJson("sub_active", "cus_a", "price_a", "active")));
+
+        // Act
+        var result = await sut.GetActiveSubscriptionAsync("cus_a", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Id.Should().Be("sub_active");
+        result.Value.Status.Should().Be(BillingSubscriptionStatus.Active);
+    }
+
+    [Fact]
+    public async Task GetActiveSubscriptionAsync_NoneFound_ReturnsSuccessWithNull()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(HttpMethod.Get, "/v1/subscriptions", SubscriptionListJson());
+
+        // Act
+        var result = await sut.GetActiveSubscriptionAsync("cus_no_sub", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetActiveSubscriptionAsync_StripeFailure_ReturnsActiveSubscriptionFailed()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/subscriptions",
+            ErrorJson("api_error", "rate_limited"),
+            System.Net.HttpStatusCode.TooManyRequests);
+
+        // Act
+        var result = await sut.GetActiveSubscriptionAsync("cus_x", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.GetActiveSubscriptionFailed");
+    }
+
+    [Fact]
+    public async Task GetActiveSubscriptionAsync_BlankCustomerId_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.GetActiveSubscriptionAsync("", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // ListSubscriptionsAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListSubscriptionsAsync_MultipleResults_MapsAll()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/subscriptions",
+            SubscriptionListJson(
+                SubscriptionJson("sub_a", "cus_x", "price_a", "active"),
+                SubscriptionJson("sub_b", "cus_x", "price_b", "trialing")));
+
+        // Act
+        var result = await sut.ListSubscriptionsAsync("cus_x", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+        result.Value[0].Id.Should().Be("sub_a");
+        result.Value[1].Status.Should().Be(BillingSubscriptionStatus.OnTrial);
+    }
+
+    [Fact]
+    public async Task ListSubscriptionsAsync_Empty_ReturnsEmptyList()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(HttpMethod.Get, "/v1/subscriptions", SubscriptionListJson());
+
+        // Act
+        var result = await sut.ListSubscriptionsAsync("cus_empty", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListSubscriptionsAsync_StripeFailure_ReturnsListSubscriptionsFailed()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/subscriptions",
+            ErrorJson("api_error", "down"),
+            System.Net.HttpStatusCode.InternalServerError);
+
+        // Act
+        var result = await sut.ListSubscriptionsAsync("cus_x", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.ListSubscriptionsFailed");
+    }
+
+    [Fact]
+    public async Task ListSubscriptionsAsync_BlankCustomerId_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.ListSubscriptionsAsync("", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // CancelSubscriptionAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task CancelSubscriptionAsync_ExistingSubscription_ReturnsSuccess()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Delete,
+            "/v1/subscriptions/sub_cancel",
+            SubscriptionJson("sub_cancel", "cus_y", "price_y", "canceled"));
+
+        // Act
+        var result = await sut.CancelSubscriptionAsync("sub_cancel", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CancelSubscriptionAsync_NotFound_ReturnsSubscriptionNotFound()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Delete,
+            "/v1/subscriptions/sub_missing",
+            ErrorJson("invalid_request_error", "no_such_subscription"),
+            System.Net.HttpStatusCode.NotFound);
+
+        // Act
+        var result = await sut.CancelSubscriptionAsync("sub_missing", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.SubscriptionNotFound");
+    }
+
+    [Fact]
+    public async Task CancelSubscriptionAsync_StripeFailure_ReturnsCancelSubscriptionFailed()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Delete,
+            "/v1/subscriptions/sub_err",
+            ErrorJson("api_error", "down"),
+            System.Net.HttpStatusCode.InternalServerError);
+
+        // Act
+        var result = await sut.CancelSubscriptionAsync("sub_err", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.CancelSubscriptionFailed");
+    }
+
+    [Fact]
+    public async Task CancelSubscriptionAsync_BlankId_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.CancelSubscriptionAsync("", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // PauseSubscriptionAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task PauseSubscriptionAsync_ExistingSubscription_ReturnsSuccessAndSendsPauseCollection()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/subscriptions/sub_pause",
+            SubscriptionJson("sub_pause", "cus_p", "price_p", "active"));
+
+        // Act
+        var result = await sut.PauseSubscriptionAsync("sub_pause", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _http.Recorded[0].Content!.Should().Contain("pause_collection[behavior]=mark_uncollectible");
+    }
+
+    [Fact]
+    public async Task PauseSubscriptionAsync_NotFound_ReturnsSubscriptionNotFound()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/subscriptions/sub_missing",
+            ErrorJson("invalid_request_error", "no_such_subscription"),
+            System.Net.HttpStatusCode.NotFound);
+
+        // Act
+        var result = await sut.PauseSubscriptionAsync("sub_missing", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.SubscriptionNotFound");
+    }
+
+    [Fact]
+    public async Task PauseSubscriptionAsync_StripeFailure_ReturnsPauseSubscriptionFailed()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/subscriptions/sub_err",
+            ErrorJson("api_error", "down"),
+            System.Net.HttpStatusCode.InternalServerError);
+
+        // Act
+        var result = await sut.PauseSubscriptionAsync("sub_err", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.PauseSubscriptionFailed");
+    }
+
+    [Fact]
+    public async Task PauseSubscriptionAsync_BlankId_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.PauseSubscriptionAsync(" ", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // ResumeSubscriptionAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task ResumeSubscriptionAsync_ExistingSubscription_ClearsPauseCollection()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/subscriptions/sub_resume",
+            SubscriptionJson("sub_resume", "cus_r", "price_r", "active"));
+
+        // Act
+        var result = await sut.ResumeSubscriptionAsync("sub_resume", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        // The service clears pause_collection by sending an empty raw value.
+        _http.Recorded[0].Content!.Should().Contain("pause_collection=");
+    }
+
+    [Fact]
+    public async Task ResumeSubscriptionAsync_NotFound_ReturnsSubscriptionNotFound()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/subscriptions/sub_missing",
+            ErrorJson("invalid_request_error", "no_such_subscription"),
+            System.Net.HttpStatusCode.NotFound);
+
+        // Act
+        var result = await sut.ResumeSubscriptionAsync("sub_missing", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.SubscriptionNotFound");
+    }
+
+    [Fact]
+    public async Task ResumeSubscriptionAsync_StripeFailure_ReturnsResumeSubscriptionFailed()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/subscriptions/sub_err",
+            ErrorJson("api_error", "down"),
+            System.Net.HttpStatusCode.InternalServerError);
+
+        // Act
+        var result = await sut.ResumeSubscriptionAsync("sub_err", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.ResumeSubscriptionFailed");
+    }
+
+    [Fact]
+    public async Task ResumeSubscriptionAsync_BlankId_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.ResumeSubscriptionAsync("", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // UpdateSubscriptionAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateSubscriptionAsync_HappyPath_UpdatesItemPriceAndReturnsMapped()
+    {
+        // Arrange — first the SDK reads the current subscription, then issues an UPDATE.
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/subscriptions/sub_up",
+            SubscriptionJson("sub_up", "cus_z", "price_old", "active", subscriptionItemId: "si_first"));
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/subscriptions/sub_up",
+            SubscriptionJson("sub_up", "cus_z", "price_new", "active", subscriptionItemId: "si_first"));
+
+        // Act
+        var result = await sut.UpdateSubscriptionAsync("sub_up", "price_new", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.VariantId.Should().Be("price_new");
+        var updateBody = _http.Recorded[1].Content!;
+        updateBody.Should().Contain("items[0][id]=si_first");
+        updateBody.Should().Contain("items[0][price]=price_new");
+    }
+
+    [Fact]
+    public async Task UpdateSubscriptionAsync_NoItems_ReturnsUpdateSubscriptionFailed()
+    {
+        // Arrange — current subscription has no items at all.
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/subscriptions/sub_nope",
+            SubscriptionJsonNoItems("sub_nope", "cus_z", "active"));
+
+        // Act
+        var result = await sut.UpdateSubscriptionAsync("sub_nope", "price_new", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.UpdateSubscriptionFailed");
+        result.Error.Message.Should().Contain("Subscription has no items");
+    }
+
+    [Fact]
+    public async Task UpdateSubscriptionAsync_NotFound_ReturnsSubscriptionNotFound()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/subscriptions/sub_missing",
+            ErrorJson("invalid_request_error", "no_such_subscription"),
+            System.Net.HttpStatusCode.NotFound);
+
+        // Act
+        var result = await sut.UpdateSubscriptionAsync("sub_missing", "price_new", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.SubscriptionNotFound");
+    }
+
+    [Fact]
+    public async Task UpdateSubscriptionAsync_StripeFailureOnUpdate_ReturnsUpdateSubscriptionFailed()
+    {
+        // Arrange
+        var sut = CreateSut();
+        _http.Expect(
+            HttpMethod.Get,
+            "/v1/subscriptions/sub_up_err",
+            SubscriptionJson("sub_up_err", "cus_e", "price_old", "active", subscriptionItemId: "si_a"));
+        _http.Expect(
+            HttpMethod.Post,
+            "/v1/subscriptions/sub_up_err",
+            ErrorJson("api_error", "down"),
+            System.Net.HttpStatusCode.InternalServerError);
+
+        // Act
+        var result = await sut.UpdateSubscriptionAsync("sub_up_err", "price_new", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Billing.Stripe.UpdateSubscriptionFailed");
+    }
+
+    [Theory]
+    [InlineData("", "price_new")]
+    [InlineData("sub_a", "")]
+    [InlineData(" ", "price_new")]
+    [InlineData("sub_a", " ")]
+    public async Task UpdateSubscriptionAsync_BlankInputs_ThrowsArgumentException(string subscriptionId, string variantId)
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.UpdateSubscriptionAsync(subscriptionId, variantId, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Ctor_NullLogger_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var serviceType = ServiceType();
+
+        // Act
+        var act = () => Activator.CreateInstance(
+            serviceType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new object?[] { null },
+            culture: null);
+
+        // Assert
+        act.Should().Throw<TargetInvocationException>()
+           .WithInnerException<ArgumentNullException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static ISubscriptionService CreateSut()
+    {
+        var serviceType = ServiceType();
+        var logger = Activator.CreateInstance(typeof(NullLogger<>).MakeGenericType(serviceType))!;
+
+        var instance = Activator.CreateInstance(
+            serviceType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new[] { logger },
+            culture: null)!;
+
+        return (ISubscriptionService)instance;
+    }
+
+    private static Type ServiceType() => typeof(StripeOptions).Assembly
+        .GetType("Compendium.Adapters.Stripe.Services.StripeSubscriptionService", throwOnError: true)!;
+
+    private static string SubscriptionJson(
+        string id,
+        string customerId,
+        string priceId,
+        string status,
+        string subscriptionItemId = "si_default") => $$"""
+        {
+          "id": "{{id}}",
+          "object": "subscription",
+          "customer": "{{customerId}}",
+          "status": "{{status}}",
+          "created": 1700000000,
+          "items": {
+            "object": "list",
+            "data": [
+              {
+                "id": "{{subscriptionItemId}}",
+                "object": "subscription_item",
+                "current_period_start": 1700000000,
+                "current_period_end": 1702592000,
+                "price": {
+                  "id": "{{priceId}}",
+                  "object": "price",
+                  "product": "prod_{{priceId}}",
+                  "currency": "usd",
+                  "unit_amount": 1500,
+                  "recurring": { "interval": "month", "interval_count": 1 }
+                }
+              }
+            ]
+          },
+          "metadata": {}
+        }
+        """;
+
+    private static string SubscriptionJsonNoItems(string id, string customerId, string status) => $$"""
+        {
+          "id": "{{id}}",
+          "object": "subscription",
+          "customer": "{{customerId}}",
+          "status": "{{status}}",
+          "created": 1700000000,
+          "items": { "object": "list", "data": [] },
+          "metadata": {}
+        }
+        """;
+
+    private static string SubscriptionListJson(params string[] subscriptionFragments)
+    {
+        var data = string.Join(",", subscriptionFragments);
+        return $$"""
+            {
+              "object": "list",
+              "url": "/v1/subscriptions",
+              "has_more": false,
+              "data": [{{data}}]
+            }
+            """;
+    }
+
+    private static string ErrorJson(string type, string message) => $$"""
+        {
+          "error": {
+            "type": "{{type}}",
+            "message": "{{message}}"
+          }
+        }
+        """;
+}

--- a/tests/Unit/Compendium.Adapters.Stripe.Tests/TestSupport/StripeGlobalStateCollection.cs
+++ b/tests/Unit/Compendium.Adapters.Stripe.Tests/TestSupport/StripeGlobalStateCollection.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+// <copyright file="StripeGlobalStateCollection.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Adapters.Stripe.Tests.TestSupport;
+
+/// <summary>
+/// xUnit test collection ensuring tests that mutate the process-wide
+/// <see cref="global::Stripe.StripeConfiguration.StripeClient"/> singleton run
+/// serially. Without this, parallel execution would race on the shared
+/// global and cause flaky failures.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class StripeGlobalStateCollection
+{
+    /// <summary>Collection name used by [Collection(...)] attributes.</summary>
+    public const string Name = "stripe-global-state";
+}

--- a/tests/Unit/Compendium.Adapters.Stripe.Tests/TestSupport/StubStripeHttpClient.cs
+++ b/tests/Unit/Compendium.Adapters.Stripe.Tests/TestSupport/StubStripeHttpClient.cs
@@ -1,0 +1,99 @@
+// -----------------------------------------------------------------------
+// <copyright file="StubStripeHttpClient.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http;
+using Stripe;
+
+namespace Compendium.Adapters.Stripe.Tests.TestSupport;
+
+/// <summary>
+/// Stub implementation of <see cref="IHttpClient"/> used to drive the Stripe.net
+/// SDK in unit tests without performing real network I/O. Each request is matched
+/// against a queue of pre-registered canned responses keyed by HTTP method and
+/// URL path suffix.
+/// </summary>
+internal sealed class StubStripeHttpClient : IHttpClient
+{
+    private readonly Queue<RequestRecord> _recorded = new();
+    private readonly List<Handler> _handlers = new();
+
+    /// <summary>
+    /// Gets the chronological sequence of requests handled by this stub.
+    /// </summary>
+    public IReadOnlyList<RequestRecord> Recorded => _recorded.ToArray();
+
+    /// <summary>
+    /// Registers a canned JSON response for the given <paramref name="method"/> and
+    /// path suffix (e.g. <c>"/v1/customers"</c>). Each registered handler is one-shot
+    /// FIFO: the first matching handler wins and is removed after a hit, allowing the
+    /// caller to script multi-step flows.
+    /// </summary>
+    public void Expect(HttpMethod method, string pathSuffix, string jsonBody, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _handlers.Add(new Handler(method, pathSuffix, jsonBody, statusCode, OneShot: true));
+    }
+
+    /// <summary>
+    /// Registers a canned JSON response that will keep matching for every request
+    /// (does not consume on hit). Useful when several SDK methods share one path.
+    /// </summary>
+    public void ExpectPersistent(HttpMethod method, string pathSuffix, string jsonBody, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _handlers.Add(new Handler(method, pathSuffix, jsonBody, statusCode, OneShot: false));
+    }
+
+    /// <inheritdoc />
+    public async Task<StripeResponse> MakeRequestAsync(StripeRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var path = request.Uri.AbsolutePath;
+        var bodyText = request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        _recorded.Enqueue(new RequestRecord(request.Method, request.Uri, bodyText));
+
+        for (var i = 0; i < _handlers.Count; i++)
+        {
+            var handler = _handlers[i];
+            if (handler.Method == request.Method && path.EndsWith(handler.PathSuffix, StringComparison.Ordinal))
+            {
+                if (handler.OneShot)
+                {
+                    _handlers.RemoveAt(i);
+                }
+
+                using var msg = new HttpResponseMessage(handler.StatusCode);
+                return new StripeResponse(handler.StatusCode, msg.Headers, handler.JsonBody);
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"StubStripeHttpClient: unexpected request {request.Method} {path}. Registered handlers: "
+            + string.Join("; ", _handlers.ConvertAll(h => $"{h.Method} *{h.PathSuffix}")));
+    }
+
+    /// <inheritdoc />
+    public Task<StripeStreamedResponse> MakeStreamingRequestAsync(StripeRequest request, CancellationToken cancellationToken = default)
+    {
+        // Streaming endpoints are not exercised by the Stripe adapter under test;
+        // any caller hitting this path indicates a missing test-side stub setup.
+        throw new NotSupportedException(
+            "StubStripeHttpClient does not support streaming requests in unit tests.");
+    }
+
+    private sealed record Handler(
+        HttpMethod Method,
+        string PathSuffix,
+        string JsonBody,
+        HttpStatusCode StatusCode,
+        bool OneShot);
+
+    /// <summary>Captured request issued by the SDK against this stub.</summary>
+    public sealed record RequestRecord(HttpMethod Method, Uri Uri, string? Content);
+}

--- a/tests/Unit/Compendium.Adapters.Stripe.Tests/Webhooks/StripeWebhookHandlerExtraTests.cs
+++ b/tests/Unit/Compendium.Adapters.Stripe.Tests/Webhooks/StripeWebhookHandlerExtraTests.cs
@@ -1,0 +1,297 @@
+// -----------------------------------------------------------------------
+// <copyright file="StripeWebhookHandlerExtraTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Compendium.Abstractions.Billing;
+using Compendium.Adapters.Stripe.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Compendium.Adapters.Stripe.Tests.Webhooks;
+
+/// <summary>
+/// Additional webhook coverage exercising every branch of the resource-metadata
+/// extractor: subscription, customer (already covered in the baseline test),
+/// checkout_session, invoice, generic <c>IHasId+IHasObject</c>, and the empty
+/// metadata path.
+/// </summary>
+public sealed class StripeWebhookHandlerExtraTests
+{
+    private const string SigningSecret = "whsec_test_secret_extra";
+
+    [Fact]
+    public async Task ProcessWebhookAsync_SubscriptionEvent_ExtractsSubscriptionResource()
+    {
+        // Arrange
+        var payload = WrapEvent(
+            "evt_sub_1",
+            "customer.subscription.created",
+            objectJson: """
+                {
+                  "id": "sub_xyz",
+                  "object": "subscription",
+                  "metadata": { "tenant_id": "t-sub", "campaign": "spring" }
+                }
+                """);
+        var handler = CreateHandler(SigningSecret);
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(payload, SignPayload(SigningSecret, payload));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ResourceType.Should().Be("subscription");
+        result.Value.ResourceId.Should().Be("sub_xyz");
+        result.Value.TenantId.Should().Be("t-sub");
+        result.Value.ExtractedData.Should().ContainKey("metadata_campaign");
+        result.Value.ExtractedData!["metadata_campaign"].Should().Be("spring");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_CheckoutSessionEvent_ExtractsCheckoutSessionResource()
+    {
+        // Arrange
+        var payload = WrapEvent(
+            "evt_cs_1",
+            "checkout.session.completed",
+            objectJson: """
+                {
+                  "id": "cs_qq",
+                  "object": "checkout.session",
+                  "metadata": { "tenant_id": "t-cs" }
+                }
+                """);
+        var handler = CreateHandler(SigningSecret);
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(payload, SignPayload(SigningSecret, payload));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ResourceType.Should().Be("checkout_session");
+        result.Value.ResourceId.Should().Be("cs_qq");
+        result.Value.TenantId.Should().Be("t-cs");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_InvoiceEvent_ExtractsInvoiceResource()
+    {
+        // Arrange
+        var payload = WrapEvent(
+            "evt_inv_1",
+            "invoice.paid",
+            objectJson: """
+                {
+                  "id": "in_abc",
+                  "object": "invoice",
+                  "metadata": { "tenant_id": "t-inv" }
+                }
+                """);
+        var handler = CreateHandler(SigningSecret);
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(payload, SignPayload(SigningSecret, payload));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ResourceType.Should().Be("invoice");
+        result.Value.ResourceId.Should().Be("in_abc");
+        result.Value.TenantId.Should().Be("t-inv");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_PaymentIntentEvent_FallsBackToIHasIdHasObjectExtractor()
+    {
+        // Arrange — payment_intent isn't one of the explicitly handled types, but
+        // the SDK still deserialises into a class that implements IHasId+IHasObject,
+        // so the resource type is taken from the "object" field.
+        var payload = WrapEvent(
+            "evt_pi_1",
+            "payment_intent.succeeded",
+            objectJson: """
+                {
+                  "id": "pi_abc",
+                  "object": "payment_intent"
+                }
+                """);
+        var handler = CreateHandler(SigningSecret);
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(payload, SignPayload(SigningSecret, payload));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ResourceType.Should().Be("payment_intent");
+        result.Value.ResourceId.Should().Be("pi_abc");
+        result.Value.TenantId.Should().BeNull();
+        result.Value.ExtractedData.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_NoMetadataOnCustomer_ReturnsNullExtractedData()
+    {
+        // Arrange — customer event without metadata at all.
+        var payload = WrapEvent(
+            "evt_cus_no_meta",
+            "customer.created",
+            objectJson: """
+                {
+                  "id": "cus_no_meta",
+                  "object": "customer"
+                }
+                """);
+        var handler = CreateHandler(SigningSecret);
+
+        // Act
+        var result = await handler.ProcessWebhookAsync(payload, SignPayload(SigningSecret, payload));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ResourceType.Should().Be("customer");
+        result.Value.ExtractedData.Should().BeNull();
+        result.Value.TenantId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_DevModeMissingSignatureSkipsValidationButStillExtractsResource()
+    {
+        // Arrange — dev mode (no signing secret), customer event.
+        var handler = CreateHandler(string.Empty);
+        var payload = WrapEvent(
+            "evt_dev",
+            "customer.created",
+            objectJson: """
+                {
+                  "id": "cus_dev",
+                  "object": "customer",
+                  "metadata": { "tenant_id": "t-dev" }
+                }
+                """);
+
+        // Act — passing a bogus signature should be ignored in dev mode.
+        var result = await handler.ProcessWebhookAsync(payload, "ignored_in_dev");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ResourceType.Should().Be("customer");
+        result.Value.ResourceId.Should().Be("cus_dev");
+        result.Value.TenantId.Should().Be("t-dev");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_NullPayload_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var handler = CreateHandler(SigningSecret);
+
+        // Act
+        var act = () => handler.ProcessWebhookAsync(null!, "t=0,v1=00");
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_NullSignature_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var handler = CreateHandler(SigningSecret);
+
+        // Act
+        var act = () => handler.ProcessWebhookAsync("{}", null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Ctor_NullOptions_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var handlerType = HandlerType();
+
+        // Act
+        var act = () => Activator.CreateInstance(
+            handlerType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new object?[] { null, NullLoggerInstance(handlerType) },
+            culture: null);
+
+        // Assert
+        act.Should().Throw<TargetInvocationException>()
+           .WithInnerException<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var handlerType = HandlerType();
+        var options = Options.Create(new StripeOptions { WebhookSigningSecret = "x" });
+
+        // Act
+        var act = () => Activator.CreateInstance(
+            handlerType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new object?[] { options, null },
+            culture: null);
+
+        // Assert
+        act.Should().Throw<TargetInvocationException>()
+           .WithInnerException<ArgumentNullException>();
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static IPaymentWebhookHandler CreateHandler(string signingSecret)
+    {
+        var handlerType = HandlerType();
+        var options = Options.Create(new StripeOptions { WebhookSigningSecret = signingSecret });
+        var logger = NullLoggerInstance(handlerType);
+
+        var instance = Activator.CreateInstance(
+            handlerType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new object[] { options, logger },
+            culture: null)!;
+
+        return (IPaymentWebhookHandler)instance;
+    }
+
+    private static Type HandlerType() => typeof(StripeOptions).Assembly
+        .GetType("Compendium.Adapters.Stripe.Webhooks.StripeWebhookHandler", throwOnError: true)!;
+
+    private static object NullLoggerInstance(Type handlerType) =>
+        Activator.CreateInstance(typeof(NullLogger<>).MakeGenericType(handlerType))!;
+
+    private static string WrapEvent(string eventId, string eventType, string objectJson) => $$"""
+        {
+          "id": "{{eventId}}",
+          "object": "event",
+          "api_version": "2024-06-20",
+          "type": "{{eventType}}",
+          "data": { "object": {{objectJson}} }
+        }
+        """;
+
+    private static string SignPayload(string secret, string payload, DateTimeOffset? timestamp = null)
+    {
+        var ts = (timestamp ?? DateTimeOffset.UtcNow).ToUnixTimeSeconds();
+        var signedPayload = $"{ts}.{payload}";
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var sig = Convert.ToHexString(hmac.ComputeHash(Encoding.UTF8.GetBytes(signedPayload))).ToLowerInvariant();
+        return $"t={ts},v1={sig}";
+    }
+}


### PR DESCRIPTION
## Summary
Tops up `Compendium.Adapters.Stripe` from 26.1% → 99.7% line coverage. Part of the testing campaign (VK POM-481).

## Coverage report — Compendium.Adapters.Stripe
- Tests added: 86 (4 new test files)
- Existing tests preserved: 32
- Test files added:
  - `tests/Unit/Compendium.Adapters.Stripe.Tests/Services/StripeBillingServiceTests.cs` (27 tests)
  - `tests/Unit/Compendium.Adapters.Stripe.Tests/Services/StripeSubscriptionServiceTests.cs` (33 tests)
  - `tests/Unit/Compendium.Adapters.Stripe.Tests/Services/StripeMapperBehaviorTests.cs` (16 tests)
  - `tests/Unit/Compendium.Adapters.Stripe.Tests/Webhooks/StripeWebhookHandlerExtraTests.cs` (10 tests)
  - `tests/Unit/Compendium.Adapters.Stripe.Tests/TestSupport/StubStripeHttpClient.cs` (`IHttpClient` stub for the Stripe.net SDK)
  - `tests/Unit/Compendium.Adapters.Stripe.Tests/TestSupport/StripeGlobalStateCollection.cs` (xUnit collection serialising tests that mutate `StripeConfiguration.StripeClient`)
- Line coverage: **26.1% → 99.7%**
- Branch coverage: **— → 90.7%**
- Bugs surfaced: 0
- Types excluded as integration-only: none

## Approach
Production code is untouched. Stripe.net's services (`CustomerService`, `SubscriptionService`, `SessionService`, `BillingPortal.SessionService`) read from the global `StripeConfiguration.StripeClient`. Tests install a `StripeClient` whose `IHttpClient` is a tiny in-process stub (`StubStripeHttpClient`) that:
- matches requests by HTTP method + URL path suffix,
- returns canned `StripeResponse` objects (success bodies for happy paths, Stripe-shaped error JSON for failure paths),
- records every request so we can assert form-encoded request bodies (e.g. `metadata[tenant_id]=t-1`, `pause_collection[behavior]=mark_uncollectible`).

Tests that mutate the global `StripeConfiguration.StripeClient` are placed in a single xUnit `[Collection]` so they don't race in parallel. `Dispose()` restores the previous client to keep test order independent.

The webhook handler's HMAC-SHA256 signing branch reuses the existing helper from `StripeWebhookHandlerTests.cs` and adds resource-extraction coverage for `subscription`, `checkout.session`, `invoice`, and the `IHasId+IHasObject` fallback (e.g. `payment_intent`).

The internal `StripeMapper` surface (`ToBillingCustomer`, `ToSubscription`, `ToCheckoutSession`, `ToUtcOffset` overloads) is reached via reflection — same pattern the existing `StripeMapperTests.cs` already uses.

## Test plan
- [x] `dotnet build Compendium.sln -c Release` green
- [x] `dotnet test tests/Unit/Compendium.Adapters.Stripe.Tests -c Release` green (118 tests = 32 baseline + 86 new)
- [x] Two consecutive runs produce identical results (no flake)
- [x] No production code modified
- [x] No version bumps in `Directory.Packages.props`
- [x] No `Moq`, no `Assert.*`, no `Thread.Sleep` introduced
- [ ] CI green