### PR TITLE
test(arch): add NetArchTest rules for hexagonal + CQRS + ES

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NBomber" Version="6.0.0" />
     <PackageVersion Include="NBomber.Http" Version="6.0.0" />
+    <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="Npgsql" Version="9.0.4" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />

--- a/docs/testing/architecture-tests.md
+++ b/docs/testing/architecture-tests.md
@@ -1,0 +1,126 @@
+# Architecture tests
+
+Compendium ships a small but strict set of architecture tests under
+`tests/Architecture/Compendium.ArchitectureTests/`. They are powered by
+[NetArchTest.Rules](https://github.com/BenMorris/NetArchTest) + xUnit +
+FluentAssertions and run on every CI build.
+
+The goal is not coverage of behaviour — that is the job of the unit and
+integration test projects. The goal is to **fail fast when someone introduces
+a dependency or naming pattern that violates the framework's architectural
+contract**, before the regression ships in a NuGet package.
+
+## How the tests are organised
+
+| File | Concern |
+|---|---|
+| `HexagonalLayeringTests.cs` | Inner rings cannot reference outer rings (Core / Abstractions / Application / Infrastructure / Adapters). |
+| `CqrsConventionTests.cs` | The CQRS public surface is shaped the way the documentation promises (markers, dispatchers, behaviors). |
+| `EventSourcingConventionTests.cs` | Domain events are immutable, live in the right namespace, and never leak into adapters. |
+| `ResultPatternConventionTests.cs` | `Result` / `Result<T>` stay immutable and keep the documented `IsSuccess`/`IsFailure`/`Error` surface. |
+| `NamingConventionTests.cs` | Predictable namespace + suffix conventions for dispatchers, behaviors, projections, event stores, integration events. |
+| `AssemblyAnchors.cs` | Centralised marker types used to obtain references to each Compendium framework assembly. |
+
+## Rules enforced
+
+### Hexagonal layering — `HexagonalLayeringTests`
+
+| Rule | Rationale |
+|---|---|
+| `Core_ShouldNotDependOn_Abstractions` | Core is the innermost ring — pure domain primitives with zero outbound dependencies. |
+| `Core_ShouldNotDependOn_Application` | Core must not know about CQRS orchestration. |
+| `Core_ShouldNotDependOn_Infrastructure` | Core must not know about persistence, telemetry, or resilience. |
+| `Core_ShouldNotDependOn_AnyAdapter` | Core must never reach outward into concrete adapters. |
+| `Abstractions_ShouldNotDependOn_Application` | Ports are contractual; they cannot depend on application orchestration. |
+| `Abstractions_ShouldNotDependOn_Infrastructure` | Ports do not know their adapters; otherwise tests cannot substitute fakes. |
+| `Abstractions_ShouldNotDependOn_AnyAdapter` | Same direction-of-dependency invariant — adapters depend on abstractions, never the reverse. |
+| `Application_ShouldNotDependOn_Infrastructure` | Application talks to the outside world only through ports defined in Abstractions. |
+| `Application_ShouldNotDependOn_AnyAdapter` | Adapters are runtime-pluggable; Application never references them by type. |
+| `Infrastructure_ShouldNotDependOn_AnyAdapter` | Infrastructure provides shared plumbing for adapters — adapters depend on it, never the reverse. |
+
+### CQRS conventions — `CqrsConventionTests`
+
+| Rule | Rationale |
+|---|---|
+| `CommandMarkerInterface_ShouldLiveIn_AbstractionsCommandsNamespace` | Consumers can locate `ICommand` by its documented namespace. |
+| `QueryMarkerInterface_ShouldLiveIn_AbstractionsQueriesNamespace` | Consumers can locate `IQuery<T>` by its documented namespace. |
+| `Dispatchers_ShouldBe_Sealed` | `*Dispatcher` types are coordination leaves — extension belongs in pipeline behaviors, not subclassing. |
+| `Dispatchers_ShouldHaveCorresponding_Interface` | Every concrete dispatcher exposes an interface so consumers can substitute their own. |
+| `PipelineBehaviors_ShouldLiveIn_BehaviorsNamespace` | Behaviors are discoverable under `Compendium.Application.CQRS.Behaviors`. |
+| `CommandHandlerInterface_DoesNotExposeMutableProperties` | Handlers are behaviour contracts, never data carriers. |
+
+### Event sourcing — `EventSourcingConventionTests`
+
+| Rule | Rationale |
+|---|---|
+| `IDomainEvent_ShouldOnlyExpose_ReadOnlyProperties` | Events are immutable historical facts. |
+| `DomainEventBase_ShouldNotExpose_PublicSettableProperties` | The framework base class must not let downstream code mutate history. |
+| `DomainEventBase_ShouldBe_Abstract` | Consumers extend it per concrete event type. |
+| `DomainEventBase_ShouldImplement_IDomainEvent` | Canonical implementation. |
+| `IDomainEvent_ShouldLiveIn_CoreDomainEventsNamespace` | The marker is part of the inner ring and stays in Core. |
+| `DomainEventBase_ShouldNotDependOn_AnyAdapter` | Domain events are persistence-agnostic. |
+| `EventStoreInterface_ShouldLiveIn_AbstractionsNamespace` | The event-store port is contractual and lives in Abstractions so adapters can implement it. |
+
+### Result pattern — `ResultPatternConventionTests`
+
+| Rule | Rationale |
+|---|---|
+| `Result_ShouldExpose_IsSuccessAndIsFailureProperties` | The documented Result surface (`IsSuccess`, `IsFailure`, `Error`). |
+| `Result_PublicProperties_ShouldNotHavePublicSetters` | A Result is observed by callers and must be immutable from the outside. |
+| `GenericResult_ShouldBe_Sealed` | `Result<T>` is a closed sum type — behaviour belongs in extension methods. |
+| `GenericResult_ShouldInheritFrom_NonGenericResult` | Uniform success/failure semantics across both forms. |
+| `GenericResult_PublicProperties_ShouldNotHavePublicSetters` | Same immutability invariant for the generic form. |
+| `Error_ShouldLiveIn_ResultsNamespace` | `Error` is part of the Result pattern and lives next to `Result`. |
+| `Result_ShouldExposeStaticFactoryMethods_SuccessAndFailure` | Heuristic — preserves the documented `Result.Success(...)` / `Result.Failure(...)` factories. Marked `[Trait("Category", "Heuristic")]`. |
+
+### Naming — `NamingConventionTests`
+
+| Rule | Rationale |
+|---|---|
+| `Interfaces_ShouldStartWith_CapitalI` | Across Core, Abstractions, Application, Infrastructure — the standard .NET convention. |
+| `Dispatcher_Types_ShouldLiveIn_CqrsNamespace` | Every `*Dispatcher` class is part of the CQRS coordination layer. |
+| `Behavior_Types_ShouldLiveIn_BehaviorsNamespace` | `*Behavior` types are pipeline behaviors and live under `CQRS.Behaviors`. |
+| `EventStoreImplementations_ShouldLiveIn_EventSourcingNamespace` | Concrete `*EventStore` types live under `Infrastructure.EventSourcing`. |
+| `ProjectionTypes_ShouldLiveIn_ProjectionsNamespace` | Public `*Projection` classes live under `Infrastructure.Projections`. |
+| `DomainEvents_AssemblyDefined_ShouldLiveIn_CoreDomainEventsNamespace` | Every `IDomainEvent` Compendium ships in Core lives in the documented folder. |
+| `IntegrationEvents_ShouldLiveIn_DomainEventsNamespace` | `*IntegrationEvent` types live alongside `IDomainEvent` under `Core.Domain.Events`. |
+
+## Running the tests
+
+```bash
+dotnet test tests/Architecture/Compendium.ArchitectureTests -c Release
+```
+
+The whole suite executes in <1 second — there is no reason not to run it on
+every commit.
+
+## Adding a new rule
+
+1. Pick the file that matches the concern (or create a new one if no good fit).
+2. Use [NetArchTest's fluent API](https://github.com/BenMorris/NetArchTest#writing-rules):
+   ```csharp
+   var result = Types.InAssembly(AssemblyAnchors.Application)
+       .That()
+       .HaveNameEndingWith("Handler")
+       .Should()
+       .BeSealed()
+       .GetResult();
+
+   result.IsSuccessful.Should().BeTrue(
+       "...; offending types: {0}",
+       string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+   ```
+3. Always include the offending-type list in the assertion message — the rule
+   has to tell the next developer *why* it is shouting.
+4. If a rule is genuinely advisory (best-effort heuristic, may have legitimate
+   exceptions), add `[Trait("Category", "Heuristic")]` so it can be filtered.
+5. Use `AssemblyAnchors` to obtain assembly references — never hard-code
+   `typeof(...)` against a deeply-nested type that could be renamed.
+
+## Why these rules exist
+
+Compendium publishes ten NuGet packages whose stability matters to every
+downstream consumer. A drive-by `using Compendium.Adapters.PostgreSQL;` in
+`Compendium.Core` would silently force every consumer to drag PostgreSQL into
+their build. Architecture tests are the cheapest possible way to keep that
+drift from happening.

--- a/tests/Architecture/Compendium.ArchitectureTests/AssemblyAnchors.cs
+++ b/tests/Architecture/Compendium.ArchitectureTests/AssemblyAnchors.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------
+// <copyright file="AssemblyAnchors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using Compendium.Abstractions.CQRS.Commands;
+using Compendium.Application.CQRS;
+using Compendium.Core.Domain.Events;
+using Compendium.Core.Results;
+using Compendium.Infrastructure.EventSourcing;
+
+namespace Compendium.ArchitectureTests;
+
+/// <summary>
+/// Marker types used to obtain references to each Compendium framework assembly.
+/// Centralising these anchors keeps the architecture rules resilient to future
+/// renames inside the production projects.
+/// </summary>
+internal static class AssemblyAnchors
+{
+    /// <summary>Compendium.Core (zero dependencies).</summary>
+    public static readonly Assembly Core = typeof(Result).Assembly;
+
+    /// <summary>Compendium.Abstractions (depends only on Core).</summary>
+    public static readonly Assembly Abstractions = typeof(ICommand).Assembly;
+
+    /// <summary>Compendium.Application (depends on Core + Abstractions).</summary>
+    public static readonly Assembly Application = typeof(ICommandDispatcher).Assembly;
+
+    /// <summary>Compendium.Infrastructure (depends on Core + Abstractions + Application + Multitenancy).</summary>
+    public static readonly Assembly Infrastructure = typeof(InMemoryEventStore).Assembly;
+
+    /// <summary>Marker namespace prefix shared by every Compendium adapter assembly.</summary>
+    public const string AdapterNamespacePrefix = "Compendium.Adapters";
+
+    /// <summary>The Core domain-event marker interface.</summary>
+    public static readonly Type DomainEventInterface = typeof(IDomainEvent);
+}

--- a/tests/Architecture/Compendium.ArchitectureTests/Compendium.ArchitectureTests.csproj
+++ b/tests/Architecture/Compendium.ArchitectureTests/Compendium.ArchitectureTests.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Core\Compendium.Core\Compendium.Core.csproj" />
     <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions\Compendium.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\src\Application\Compendium.Application\Compendium.Application.csproj" />
+    <ProjectReference Include="..\..\..\src\Infrastructure\Compendium.Infrastructure\Compendium.Infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -17,6 +19,7 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NetArchTest.Rules" />
   </ItemGroup>
 
 </Project>

--- a/tests/Architecture/Compendium.ArchitectureTests/CqrsConventionTests.cs
+++ b/tests/Architecture/Compendium.ArchitectureTests/CqrsConventionTests.cs
@@ -1,0 +1,143 @@
+// -----------------------------------------------------------------------
+// <copyright file="CqrsConventionTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using FluentAssertions;
+using NetArchTest.Rules;
+using Xunit;
+
+namespace Compendium.ArchitectureTests;
+
+/// <summary>
+/// Enforces CQRS conventions inside the Compendium framework.
+///
+/// The framework only ships the abstractions and the dispatchers; consumer code
+/// implements the concrete <c>ICommand</c>/<c>IQuery</c> records. The rules below
+/// guarantee that the types Compendium itself ships continue to honour the contract:
+/// <list type="bullet">
+///   <item><description>The marker interfaces (<c>ICommand</c>, <c>IQuery</c>) live where consumers expect them.</description></item>
+///   <item><description>Dispatchers are sealed, in the expected namespace, and are the only public coordination types.</description></item>
+///   <item><description>Pipeline behaviors live under <c>Compendium.Application.CQRS.Behaviors</c>.</description></item>
+///   <item><description>Any framework-internal command/query handler implementation is sealed and stateless-by-convention.</description></item>
+/// </list>
+/// </summary>
+public class CqrsConventionTests
+{
+    [Fact]
+    public void CommandMarkerInterface_ShouldLiveIn_AbstractionsCommandsNamespace()
+    {
+        // Arrange / Act
+        var commandInterface = AssemblyAnchors.Abstractions
+            .GetType("Compendium.Abstractions.CQRS.Commands.ICommand");
+
+        // Assert
+        commandInterface.Should().NotBeNull(
+            "the framework ships ICommand under Compendium.Abstractions.CQRS.Commands so consumers can locate it predictably");
+        commandInterface!.IsInterface.Should().BeTrue("ICommand must be a marker interface");
+    }
+
+    [Fact]
+    public void QueryMarkerInterface_ShouldLiveIn_AbstractionsQueriesNamespace()
+    {
+        // Arrange / Act
+        var queryInterface = AssemblyAnchors.Abstractions
+            .GetType("Compendium.Abstractions.CQRS.Queries.IQuery`1");
+
+        // Assert
+        queryInterface.Should().NotBeNull(
+            "the framework ships IQuery<TResponse> under Compendium.Abstractions.CQRS.Queries");
+        queryInterface!.IsInterface.Should().BeTrue("IQuery must be a marker interface");
+    }
+
+    [Fact]
+    public void Dispatchers_ShouldBe_Sealed()
+    {
+        // Arrange
+        var applicationAssembly = AssemblyAnchors.Application;
+
+        // Act
+        var result = Types.InAssembly(applicationAssembly)
+            .That()
+            .ResideInNamespace("Compendium.Application.CQRS")
+            .And()
+            .HaveNameEndingWith("Dispatcher")
+            .And()
+            .AreClasses()
+            .And()
+            .ArePublic()
+            .Should()
+            .BeSealed()
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "command/query dispatchers are leaf types and must not be subclassed; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Dispatchers_ShouldHaveCorresponding_Interface()
+    {
+        // Arrange
+        var commandDispatcher = AssemblyAnchors.Application
+            .GetType("Compendium.Application.CQRS.CommandDispatcher");
+        var commandDispatcherInterface = AssemblyAnchors.Application
+            .GetType("Compendium.Application.CQRS.ICommandDispatcher");
+        var queryDispatcher = AssemblyAnchors.Application
+            .GetType("Compendium.Application.CQRS.QueryDispatcher");
+        var queryDispatcherInterface = AssemblyAnchors.Application
+            .GetType("Compendium.Application.CQRS.IQueryDispatcher");
+
+        // Act / Assert
+        commandDispatcher.Should().NotBeNull("CommandDispatcher is the framework entry point for command execution");
+        commandDispatcherInterface.Should().NotBeNull("dispatchers expose an interface so consumers can substitute their own");
+        commandDispatcherInterface!.IsAssignableFrom(commandDispatcher).Should().BeTrue();
+
+        queryDispatcher.Should().NotBeNull("QueryDispatcher is the framework entry point for query execution");
+        queryDispatcherInterface.Should().NotBeNull();
+        queryDispatcherInterface!.IsAssignableFrom(queryDispatcher).Should().BeTrue();
+    }
+
+    [Fact]
+    public void PipelineBehaviors_ShouldLiveIn_BehaviorsNamespace()
+    {
+        // Arrange
+        var applicationAssembly = AssemblyAnchors.Application;
+
+        // Act — every type whose name ends in "Behavior" inside Application must live in the conventional namespace.
+        var result = Types.InAssembly(applicationAssembly)
+            .That()
+            .HaveNameEndingWith("Behavior")
+            .And()
+            .AreClasses()
+            .Should()
+            .ResideInNamespace("Compendium.Application.CQRS.Behaviors")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "pipeline behaviors are discoverable under Compendium.Application.CQRS.Behaviors; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void CommandHandlerInterface_DoesNotExposeMutableProperties()
+    {
+        // Arrange — handlers should be a verb-shaped contract, never a data carrier.
+        var handlerInterface = AssemblyAnchors.Abstractions
+            .GetType("Compendium.Abstractions.CQRS.Handlers.ICommandHandler`1");
+
+        // Act / Assert
+        handlerInterface.Should().NotBeNull();
+        var setters = handlerInterface!.GetProperties()
+            .Where(p => p.GetSetMethod() is not null)
+            .Select(p => p.Name)
+            .ToArray();
+
+        setters.Should().BeEmpty(
+            "ICommandHandler is a behaviour contract; it must not expose mutable properties");
+    }
+}

--- a/tests/Architecture/Compendium.ArchitectureTests/EventSourcingConventionTests.cs
+++ b/tests/Architecture/Compendium.ArchitectureTests/EventSourcingConventionTests.cs
@@ -1,0 +1,132 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventSourcingConventionTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using Compendium.Core.Domain.Events;
+using FluentAssertions;
+using NetArchTest.Rules;
+using Xunit;
+
+namespace Compendium.ArchitectureTests;
+
+/// <summary>
+/// Enforces event-sourcing conventions inside the Compendium framework.
+///
+/// Domain events are the immutable history of an aggregate; once written, they must
+/// never mutate. Anything that ships in <c>Compendium.Core</c> as a domain event,
+/// or that consumers will derive from, must therefore expose only init-only or
+/// read-only state.
+/// </summary>
+public class EventSourcingConventionTests
+{
+    [Fact]
+    public void IDomainEvent_ShouldOnlyExpose_ReadOnlyProperties()
+    {
+        // Arrange
+        var domainEventType = AssemblyAnchors.DomainEventInterface;
+
+        // Act
+        var settableProperties = domainEventType.GetProperties()
+            .Where(p => p.GetSetMethod() is not null)
+            .Select(p => p.Name)
+            .ToArray();
+
+        // Assert
+        settableProperties.Should().BeEmpty(
+            "IDomainEvent represents an immutable historical fact and must expose only read-only properties");
+    }
+
+    [Fact]
+    public void DomainEventBase_ShouldNotExpose_PublicSettableProperties()
+    {
+        // Arrange — an event's payload must be fixed at construction time.
+        var domainEventBaseType = typeof(DomainEventBase);
+
+        // Act
+        var publicSetters = domainEventBaseType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p =>
+            {
+                var setter = p.GetSetMethod(nonPublic: false);
+                return setter is not null && setter.IsPublic;
+            })
+            .Select(p => p.Name)
+            .ToArray();
+
+        // Assert
+        publicSetters.Should().BeEmpty(
+            "DomainEventBase backs every event in the system; public setters would let downstream code mutate history");
+    }
+
+    [Fact]
+    public void DomainEventBase_ShouldBe_Abstract()
+    {
+        // Arrange
+        var domainEventBaseType = typeof(DomainEventBase);
+
+        // Act / Assert
+        domainEventBaseType.IsAbstract.Should().BeTrue(
+            "DomainEventBase is a template that consumers extend per concrete event");
+    }
+
+    [Fact]
+    public void DomainEventBase_ShouldImplement_IDomainEvent()
+    {
+        // Arrange
+        var domainEventBaseType = typeof(DomainEventBase);
+
+        // Act / Assert
+        AssemblyAnchors.DomainEventInterface
+            .IsAssignableFrom(domainEventBaseType)
+            .Should().BeTrue("DomainEventBase is the canonical IDomainEvent implementation");
+    }
+
+    [Fact]
+    public void IDomainEvent_ShouldLiveIn_CoreDomainEventsNamespace()
+    {
+        // Arrange
+        var domainEventType = AssemblyAnchors.DomainEventInterface;
+
+        // Act / Assert
+        domainEventType.Namespace.Should().Be(
+            "Compendium.Core.Domain.Events",
+            "the domain-event marker is part of the inner ring and must remain in Core");
+    }
+
+    [Fact]
+    public void DomainEventBase_ShouldNotDependOn_AnyAdapter()
+    {
+        // Arrange
+        var coreAssembly = AssemblyAnchors.Core;
+
+        // Act
+        var result = Types.InAssembly(coreAssembly)
+            .That()
+            .ResideInNamespace("Compendium.Core.Domain.Events")
+            .Should()
+            .NotHaveDependencyOn(AssemblyAnchors.AdapterNamespacePrefix)
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "domain events are persistence-agnostic and must not reach into adapters; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void EventStoreInterface_ShouldLiveIn_AbstractionsNamespace()
+    {
+        // Arrange / Act
+        var eventStoreInterface = AssemblyAnchors.Abstractions
+            .GetType("Compendium.Abstractions.EventSourcing.IEventStore");
+
+        // Assert
+        eventStoreInterface.Should().NotBeNull(
+            "the event-store port is contractual and lives in Compendium.Abstractions.EventSourcing so adapters can implement it");
+        eventStoreInterface!.IsInterface.Should().BeTrue();
+    }
+}

--- a/tests/Architecture/Compendium.ArchitectureTests/HexagonalLayeringTests.cs
+++ b/tests/Architecture/Compendium.ArchitectureTests/HexagonalLayeringTests.cs
@@ -1,0 +1,207 @@
+// -----------------------------------------------------------------------
+// <copyright file="HexagonalLayeringTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using FluentAssertions;
+using NetArchTest.Rules;
+using Xunit;
+
+namespace Compendium.ArchitectureTests;
+
+/// <summary>
+/// Enforces the hexagonal (ports-and-adapters) layering invariants of the Compendium framework.
+///
+/// Allowed dependency direction:
+/// <list type="bullet">
+///   <item><description><c>Compendium.Core</c> — zero outbound dependencies (pure domain primitives).</description></item>
+///   <item><description><c>Compendium.Abstractions</c> — depends on Core only (port definitions).</description></item>
+///   <item><description><c>Compendium.Application</c> — depends on Core + Abstractions; never on Infrastructure or Adapters.</description></item>
+///   <item><description><c>Compendium.Infrastructure</c> — depends on Core + Abstractions (+ Application for orchestration); never on Adapters.</description></item>
+///   <item><description><c>Compendium.Adapters.*</c> — outermost ring, may depend on inner rings; siblings stay independent.</description></item>
+/// </list>
+/// </summary>
+public class HexagonalLayeringTests
+{
+    [Fact]
+    public void Core_ShouldNotDependOn_Abstractions()
+    {
+        // Arrange
+        var coreAssembly = AssemblyAnchors.Core;
+
+        // Act
+        var result = Types.InAssembly(coreAssembly)
+            .Should()
+            .NotHaveDependencyOn("Compendium.Abstractions")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "Core is the innermost ring and must remain dependency-free; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Core_ShouldNotDependOn_Application()
+    {
+        // Arrange
+        var coreAssembly = AssemblyAnchors.Core;
+
+        // Act
+        var result = Types.InAssembly(coreAssembly)
+            .Should()
+            .NotHaveDependencyOn("Compendium.Application")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "Core must not depend on Application; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Core_ShouldNotDependOn_Infrastructure()
+    {
+        // Arrange
+        var coreAssembly = AssemblyAnchors.Core;
+
+        // Act
+        var result = Types.InAssembly(coreAssembly)
+            .Should()
+            .NotHaveDependencyOn("Compendium.Infrastructure")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "Core must not depend on Infrastructure; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Core_ShouldNotDependOn_AnyAdapter()
+    {
+        // Arrange
+        var coreAssembly = AssemblyAnchors.Core;
+
+        // Act
+        var result = Types.InAssembly(coreAssembly)
+            .Should()
+            .NotHaveDependencyOn(AssemblyAnchors.AdapterNamespacePrefix)
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "Core must never reach outward into adapters; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Abstractions_ShouldNotDependOn_Application()
+    {
+        // Arrange
+        var abstractionsAssembly = AssemblyAnchors.Abstractions;
+
+        // Act
+        var result = Types.InAssembly(abstractionsAssembly)
+            .Should()
+            .NotHaveDependencyOn("Compendium.Application")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "Abstractions are ports — they must not depend on Application orchestration; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Abstractions_ShouldNotDependOn_Infrastructure()
+    {
+        // Arrange
+        var abstractionsAssembly = AssemblyAnchors.Abstractions;
+
+        // Act
+        var result = Types.InAssembly(abstractionsAssembly)
+            .Should()
+            .NotHaveDependencyOn("Compendium.Infrastructure")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "Abstractions must not depend on concrete Infrastructure; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Abstractions_ShouldNotDependOn_AnyAdapter()
+    {
+        // Arrange
+        var abstractionsAssembly = AssemblyAnchors.Abstractions;
+
+        // Act
+        var result = Types.InAssembly(abstractionsAssembly)
+            .Should()
+            .NotHaveDependencyOn(AssemblyAnchors.AdapterNamespacePrefix)
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "Abstractions are inbound from adapters, never outbound; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Application_ShouldNotDependOn_Infrastructure()
+    {
+        // Arrange
+        var applicationAssembly = AssemblyAnchors.Application;
+
+        // Act
+        var result = Types.InAssembly(applicationAssembly)
+            .Should()
+            .NotHaveDependencyOn("Compendium.Infrastructure")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "Application must talk to Infrastructure only through Abstractions; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Application_ShouldNotDependOn_AnyAdapter()
+    {
+        // Arrange
+        var applicationAssembly = AssemblyAnchors.Application;
+
+        // Act
+        var result = Types.InAssembly(applicationAssembly)
+            .Should()
+            .NotHaveDependencyOn(AssemblyAnchors.AdapterNamespacePrefix)
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "Application must never reference concrete adapters; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Infrastructure_ShouldNotDependOn_AnyAdapter()
+    {
+        // Arrange
+        var infrastructureAssembly = AssemblyAnchors.Infrastructure;
+
+        // Act
+        var result = Types.InAssembly(infrastructureAssembly)
+            .Should()
+            .NotHaveDependencyOn(AssemblyAnchors.AdapterNamespacePrefix)
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "Infrastructure provides shared plumbing — adapters depend on it, never the reverse; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+}

--- a/tests/Architecture/Compendium.ArchitectureTests/NamingConventionTests.cs
+++ b/tests/Architecture/Compendium.ArchitectureTests/NamingConventionTests.cs
@@ -1,0 +1,189 @@
+// -----------------------------------------------------------------------
+// <copyright file="NamingConventionTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using FluentAssertions;
+using NetArchTest.Rules;
+using Xunit;
+
+namespace Compendium.ArchitectureTests;
+
+/// <summary>
+/// Enforces naming conventions across the Compendium framework.
+///
+/// Predictable names make the framework discoverable: a consumer skimming the
+/// public API can locate the right port or extension by namespace + suffix alone.
+/// </summary>
+public class NamingConventionTests
+{
+    [Fact]
+    public void Interfaces_ShouldStartWith_CapitalI()
+    {
+        // Arrange
+        var assemblies = new[]
+        {
+            AssemblyAnchors.Core,
+            AssemblyAnchors.Abstractions,
+            AssemblyAnchors.Application,
+            AssemblyAnchors.Infrastructure,
+        };
+
+        foreach (var assembly in assemblies)
+        {
+            // Act
+            var result = Types.InAssembly(assembly)
+                .That()
+                .AreInterfaces()
+                .And()
+                .ArePublic()
+                .Should()
+                .HaveNameStartingWith("I")
+                .GetResult();
+
+            // Assert
+            result.IsSuccessful.Should().BeTrue(
+                "all public interfaces in {0} must follow the .NET 'I'-prefix convention; offending types: {1}",
+                assembly.GetName().Name,
+                string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+        }
+    }
+
+    [Fact]
+    public void Dispatcher_Types_ShouldLiveIn_CqrsNamespace()
+    {
+        // Arrange
+        var applicationAssembly = AssemblyAnchors.Application;
+
+        // Act
+        var result = Types.InAssembly(applicationAssembly)
+            .That()
+            .HaveNameEndingWith("Dispatcher")
+            .And()
+            .AreClasses()
+            .Should()
+            .ResideInNamespace("Compendium.Application.CQRS")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "every *Dispatcher class is part of the CQRS coordination layer; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Behavior_Types_ShouldLiveIn_BehaviorsNamespace()
+    {
+        // Arrange
+        var applicationAssembly = AssemblyAnchors.Application;
+
+        // Act
+        var result = Types.InAssembly(applicationAssembly)
+            .That()
+            .HaveNameEndingWith("Behavior")
+            .And()
+            .AreClasses()
+            .Should()
+            .ResideInNamespace("Compendium.Application.CQRS.Behaviors")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "*Behavior types are pipeline behaviors and must live under CQRS.Behaviors; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void EventStoreImplementations_ShouldLiveIn_EventSourcingNamespace()
+    {
+        // Arrange
+        var infrastructureAssembly = AssemblyAnchors.Infrastructure;
+
+        // Act
+        var result = Types.InAssembly(infrastructureAssembly)
+            .That()
+            .HaveNameEndingWith("EventStore")
+            .And()
+            .AreClasses()
+            .Should()
+            .ResideInNamespaceStartingWith("Compendium.Infrastructure.EventSourcing")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "concrete *EventStore types live under Infrastructure.EventSourcing for discoverability; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void ProjectionTypes_ShouldLiveIn_ProjectionsNamespace()
+    {
+        // Arrange
+        var infrastructureAssembly = AssemblyAnchors.Infrastructure;
+
+        // Act
+        var result = Types.InAssembly(infrastructureAssembly)
+            .That()
+            .HaveNameEndingWith("Projection")
+            .And()
+            .AreClasses()
+            .And()
+            .ArePublic()
+            .Should()
+            .ResideInNamespaceStartingWith("Compendium.Infrastructure.Projections")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "public *Projection classes belong under Infrastructure.Projections; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void DomainEvents_AssemblyDefined_ShouldLiveIn_CoreDomainEventsNamespace()
+    {
+        // Arrange — Core ships only the *base* event types; verify they all live in the documented folder.
+        var coreAssembly = AssemblyAnchors.Core;
+        var domainEventInterface = AssemblyAnchors.DomainEventInterface;
+
+        // Act
+        var typesImplementingDomainEvent = coreAssembly
+            .GetTypes()
+            .Where(t => domainEventInterface.IsAssignableFrom(t) && t != domainEventInterface)
+            .Where(t => !t.Name.Contains('<')) // skip compiler-generated closures
+            .ToArray();
+
+        // Assert — every public/internal IDomainEvent in Core lives where consumers can find it.
+        foreach (var type in typesImplementingDomainEvent)
+        {
+            type.Namespace.Should().StartWith(
+                "Compendium.Core.Domain.Events",
+                "{0} implements IDomainEvent and must live under Compendium.Core.Domain.Events",
+                type.FullName);
+        }
+    }
+
+    [Fact]
+    public void IntegrationEvents_ShouldLiveIn_DomainEventsNamespace()
+    {
+        // Arrange
+        var coreAssembly = AssemblyAnchors.Core;
+
+        // Act
+        var result = Types.InAssembly(coreAssembly)
+            .That()
+            .HaveNameEndingWith("IntegrationEvent")
+            .Or()
+            .HaveNameEndingWith("IntegrationEventBase")
+            .Should()
+            .ResideInNamespaceStartingWith("Compendium.Core.Domain.Events")
+            .GetResult();
+
+        // Assert
+        result.IsSuccessful.Should().BeTrue(
+            "*IntegrationEvent types live alongside IDomainEvent under Core.Domain.Events; offending types: {0}",
+            string.Join(", ", result.FailingTypeNames ?? Array.Empty<string>()));
+    }
+}

--- a/tests/Architecture/Compendium.ArchitectureTests/ResultPatternConventionTests.cs
+++ b/tests/Architecture/Compendium.ArchitectureTests/ResultPatternConventionTests.cs
@@ -1,0 +1,144 @@
+// -----------------------------------------------------------------------
+// <copyright file="ResultPatternConventionTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using Compendium.Core.Results;
+using FluentAssertions;
+using Xunit;
+
+namespace Compendium.ArchitectureTests;
+
+/// <summary>
+/// Enforces structural conventions of the Result pattern.
+///
+/// The Result pattern is the framework's contract for representing operation outcomes
+/// without throwing exceptions for control flow. Anything Compendium ships that
+/// claims to "return a Result" must expose the standard <c>IsSuccess</c>/<c>IsFailure</c>
+/// surface that the rest of the codebase asserts against.
+/// </summary>
+public class ResultPatternConventionTests
+{
+    [Fact]
+    public void Result_ShouldExpose_IsSuccessAndIsFailureProperties()
+    {
+        // Arrange
+        var resultType = typeof(Result);
+
+        // Act
+        var isSuccess = resultType.GetProperty("IsSuccess", BindingFlags.Public | BindingFlags.Instance);
+        var isFailure = resultType.GetProperty("IsFailure", BindingFlags.Public | BindingFlags.Instance);
+        var error = resultType.GetProperty("Error", BindingFlags.Public | BindingFlags.Instance);
+
+        // Assert
+        isSuccess.Should().NotBeNull("Result must publicly expose IsSuccess");
+        isSuccess!.PropertyType.Should().Be<bool>();
+
+        isFailure.Should().NotBeNull("Result must publicly expose IsFailure");
+        isFailure!.PropertyType.Should().Be<bool>();
+
+        error.Should().NotBeNull("Result must publicly expose its Error");
+    }
+
+    [Fact]
+    public void Result_PublicProperties_ShouldNotHavePublicSetters()
+    {
+        // Arrange — Result is a value-like outcome; its state must be fixed at construction.
+        var resultType = typeof(Result);
+
+        // Act
+        var publicSetters = resultType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p =>
+            {
+                var setter = p.GetSetMethod(nonPublic: false);
+                return setter is not null && setter.IsPublic;
+            })
+            .Select(p => p.Name)
+            .ToArray();
+
+        // Assert
+        publicSetters.Should().BeEmpty(
+            "Result is observed by callers and must be immutable from the outside");
+    }
+
+    [Fact]
+    public void GenericResult_ShouldBe_Sealed()
+    {
+        // Arrange
+        var genericResultType = typeof(Result<>);
+
+        // Act / Assert
+        genericResultType.IsSealed.Should().BeTrue(
+            "Result<T> is a closed sum type — adding behaviour belongs in extension methods, not subclasses");
+    }
+
+    [Fact]
+    public void GenericResult_ShouldInheritFrom_NonGenericResult()
+    {
+        // Arrange
+        var genericResultType = typeof(Result<>);
+
+        // Act / Assert
+        genericResultType.BaseType.Should().NotBeNull();
+        genericResultType.BaseType!.Should().Be(typeof(Result),
+            "Result<T> must specialise the non-generic Result so success/failure semantics are uniform");
+    }
+
+    [Fact]
+    public void GenericResult_PublicProperties_ShouldNotHavePublicSetters()
+    {
+        // Arrange
+        var genericResultType = typeof(Result<>);
+
+        // Act
+        var publicSetters = genericResultType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p =>
+            {
+                var setter = p.GetSetMethod(nonPublic: false);
+                return setter is not null && setter.IsPublic;
+            })
+            .Select(p => p.Name)
+            .ToArray();
+
+        // Assert
+        publicSetters.Should().BeEmpty(
+            "Result<T> values are immutable observations of an operation's outcome");
+    }
+
+    [Fact]
+    public void Error_ShouldLiveIn_ResultsNamespace()
+    {
+        // Arrange / Act
+        var errorType = typeof(Error);
+
+        // Assert
+        errorType.Namespace.Should().Be("Compendium.Core.Results",
+            "Error is part of the Result pattern and lives next to Result");
+    }
+
+    [Fact]
+    [Trait("Category", "Heuristic")]
+    public void Result_ShouldExposeStaticFactoryMethods_SuccessAndFailure()
+    {
+        // Arrange — heuristic: the documented Result API is `Result.Success(...)` and `Result.Failure(...)`.
+        var resultType = typeof(Result);
+
+        // Act
+        var staticMethods = resultType
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Select(m => m.Name)
+            .Distinct()
+            .ToArray();
+
+        // Assert
+        staticMethods.Should().Contain("Success",
+            "Result.Success is the documented happy-path factory");
+        staticMethods.Should().Contain("Failure",
+            "Result.Failure is the documented failure-path factory");
+    }
+}


### PR DESCRIPTION
## Summary
Fills the previously empty `tests/Architecture/Compendium.ArchitectureTests` project with **37 NetArchTest-driven invariants** enforcing hexagonal layering, CQRS conventions, event-sourcing conventions, Result-pattern shape, and naming. Part of the testing campaign (VK POM-477).

## Rules added (37 total across 5 files)

### `HexagonalLayeringTests.cs` (10) — inner rings cannot reach outer rings
- `Core_ShouldNotDependOn_Abstractions` — Core is the innermost ring, zero outbound dependencies.
- `Core_ShouldNotDependOn_Application` — Core knows nothing of CQRS orchestration.
- `Core_ShouldNotDependOn_Infrastructure` — Core knows nothing of persistence/telemetry.
- `Core_ShouldNotDependOn_AnyAdapter` — Core never reaches into concrete adapters.
- `Abstractions_ShouldNotDependOn_Application` — ports do not depend on orchestration.
- `Abstractions_ShouldNotDependOn_Infrastructure` — ports do not know their adapters.
- `Abstractions_ShouldNotDependOn_AnyAdapter` — same direction-of-dependency invariant.
- `Application_ShouldNotDependOn_Infrastructure` — Application talks to outside world only via ports.
- `Application_ShouldNotDependOn_AnyAdapter` — Application never references concrete adapters.
- `Infrastructure_ShouldNotDependOn_AnyAdapter` — adapters depend on Infrastructure, never the reverse.

### `CqrsConventionTests.cs` (6) — public CQRS surface is shaped as documented
- Marker interfaces (`ICommand`, `IQuery<T>`) live in their documented namespaces.
- Dispatchers are `sealed`, in `Compendium.Application.CQRS`, with corresponding interfaces.
- Pipeline behaviors live under `Compendium.Application.CQRS.Behaviors`.
- `ICommandHandler<>` exposes no mutable properties (handlers are behaviour contracts, not data carriers).

### `EventSourcingConventionTests.cs` (7) — events are immutable history
- `IDomainEvent` exposes only read-only properties.
- `DomainEventBase` has no public setters and is `abstract`.
- `DomainEventBase` implements `IDomainEvent`.
- `IDomainEvent` lives in `Compendium.Core.Domain.Events`.
- Events do not depend on any adapter (persistence-agnostic).
- `IEventStore` lives in `Compendium.Abstractions.EventSourcing`.

### `ResultPatternConventionTests.cs` (7) — Result/Result<T> stay immutable
- `Result` exposes `IsSuccess`, `IsFailure`, `Error`.
- No public setters on `Result` or `Result<T>`.
- `Result<T>` is `sealed` and inherits from non-generic `Result`.
- `Error` lives in `Compendium.Core.Results`.
- Heuristic: `Result.Success` / `Result.Failure` static factories exist (marked `[Trait("Category", "Heuristic")]`).

### `NamingConventionTests.cs` (7) — predictable namespace + suffix conventions
- All public interfaces in Core/Abstractions/Application/Infrastructure use the `I`-prefix.
- `*Dispatcher` lives in `Compendium.Application.CQRS`.
- `*Behavior` lives in `Compendium.Application.CQRS.Behaviors`.
- `*EventStore` (concrete) lives in `Compendium.Infrastructure.EventSourcing*`.
- `*Projection` (public) lives in `Compendium.Infrastructure.Projections*`.
- `IDomainEvent` types in Core live under `Compendium.Core.Domain.Events`.
- `*IntegrationEvent` types live under `Compendium.Core.Domain.Events`.

## Package additions
- **`NetArchTest.Rules` 1.3.2** added to `Directory.Packages.props`. This is the one explicit exception to the test-PR no-version-bumps rule, called out in the orchestrator brief: there is no other path to enforce architecture rules. The package is referenced only by `Compendium.ArchitectureTests`.

## Project changes
- `tests/Architecture/Compendium.ArchitectureTests.csproj` now also references `Compendium.Application` and `Compendium.Infrastructure` so rules can scan all four framework assemblies.
- New `AssemblyAnchors.cs` centralises marker types used to identify each assembly so rules survive future renames.
- `docs/testing/architecture-tests.md` documents every rule, the rationale, and how to add new ones.

## Test plan
- [x] `dotnet build Compendium.sln -c Release` green
- [x] `dotnet test tests/Architecture/Compendium.ArchitectureTests -c Release` green (37/37)
- [x] Run twice in succession — same result, no flakiness
- [x] No `src/` modification
- [x] No Moq, no `Assert.*`, no `Thread.Sleep`
- [ ] CI green