### PR TITLE
test(load): add baseline NBomber scenarios

### DIFF
--- a/docs/testing/load-tests.md
+++ b/docs/testing/load-tests.md
@@ -1,0 +1,113 @@
+# Load tests
+
+The `Compendium.LoadTests` project (under `tests/LoadTests/Compendium.LoadTests`)
+hosts a small collection of [NBomber 6](https://nbomber.com) scenarios that
+exercise the in-memory implementations of the framework's hot-path
+abstractions. Their purpose is **informational baselining** — they measure
+the cost of the framework's own code paths on a developer machine, with no
+external dependencies (no PostgreSQL, no Redis, no network).
+
+These scenarios are **not gated in CI**. They are intended to be run
+manually before merging a change that could plausibly affect throughput
+(touching `IEventStore`, `IProjectionManager`, `IIdempotencyStore`, or any
+adapter on the request path), and to be cited in the PR description for
+review.
+
+## Running a scenario
+
+```bash
+dotnet run --project tests/LoadTests/Compendium.LoadTests -c Release -- \
+    --scenario <name> [--duration 30s] [--artifacts artifacts/load] [--no-warmup]
+```
+
+Flags:
+
+- `--scenario <name>` (required) — one of `eventstore`, `projection`,
+  `idempotency`, `tenant`.
+- `--duration <value>` — total run length. Accepts `30s`, `2m`, `500ms`, or
+  a bare integer interpreted as seconds. Default: `15s`.
+- `--artifacts <dir>` — output directory. Default: `artifacts/load`.
+- `--no-warmup` — skip the 2-second warm-up phase that NBomber would
+  otherwise prepend to the run.
+
+Each run produces:
+
+| File                                                | Producer        |
+|-----------------------------------------------------|-----------------|
+| `<artifacts>/<scenario>-report.html`                | NBomber         |
+| `<artifacts>/<scenario>-report.{csv,md,txt}`        | NBomber         |
+| `<artifacts>/<scenario>.json`                       | This project    |
+
+The JSON summary is what to commit/share for run-over-run comparisons; the
+HTML report is the human-readable view.
+
+## Scenarios
+
+### `eventstore` — `IEventStore.AppendEventsAsync` throughput
+
+Repeatedly appends a 10-event batch to a fresh aggregate against the
+in-memory `InMemoryEventStore`. 32 NBomber copies run in parallel, so this
+exercises the writer-lock contention.
+
+- **Metric**: append operations per second (NBomber `Ok.Request.RPS`).
+- **Derived**: events per second &asymp; `Ok.Request.RPS &times; 10`.
+- **Measured dev-box baseline (Apple M-series, .NET 9, Release, 10&#8202;s
+  run)**: &asymp; **60&#8202;000 ops/s** &rarr; **&asymp; 600&#8202;000 events/s**
+  sustained, mean latency 1&#160;ms, p99 &asymp; 15&#160;ms.
+
+### `projection` — projection catch-up rate
+
+Pre-populates a single aggregate with 5&#8202;000 events, then on each
+NBomber iteration resets a `ProjectionBase`-derived projection and runs
+`ProjectionManager.RebuildProjectionAsync` from version 0 to N. Run with a
+single copy because each iteration is intentionally heavy (full replay).
+
+- **Metric**: rebuild iterations per second + per-iteration latency
+  (NBomber latency percentiles).
+- **Derived**: events processed per second &asymp; `5_000 / mean_latency_seconds`.
+- **Measured dev-box baseline**: &asymp; **290 rebuilds/s** &rarr;
+  **&asymp; 1.5&#8202;M events/s** for the `CountingProjection` (which does
+  only a counter update), mean iteration 3&#160;ms, p99 &asymp; 5&#160;ms.
+  Real projections will be lower — this measures the manager + replay
+  overhead, not the projection body.
+
+### `idempotency` — `IIdempotencyStore` reads/writes under concurrency
+
+64 NBomber copies hammering an in-memory `IIdempotencyStore` with an 80/20
+read/write split, against 10&#8202;000 pre-populated keys.
+
+- **Metric**: lookup operations per second + per-call latency percentiles.
+- **Measured dev-box baseline**: &asymp; **1.3&#8202;M ops/s**, mean latency
+  &asymp; 30&#160;&micro;s, p95 &asymp; 10&#160;&micro;s, p99 &asymp; 2.5&#160;ms
+  (the store is a `ConcurrentDictionary`; the long-tail comes from GC pauses).
+- **What this tells you**: the abstraction itself adds negligible cost; if
+  a real Redis-backed run is dramatically slower, the bottleneck is in the
+  network / serialisation, not in the framework's idempotency contract.
+
+### `tenant` — `CompositeTenantResolver` chain throughput
+
+64 NBomber copies driving a `CompositeTenantResolver` ( header &rarr; host )
+backed by an `InMemoryTenantStore` of 200 tenants. The traffic mix is
+deliberate: 60&#160;% header hits (fast path), 20&#160;% host hits (chain
+walks past the header resolver), 20&#160;% misses (chain walks the full
+list before returning `null`).
+
+- **Metric**: resolutions per second, with mean and p99 latency.
+- **Measured dev-box baseline**: &asymp; **2.9&#8202;M resolutions/s**, mean
+  latency &asymp; 50&#160;&micro;s, p95 &asymp; 80&#160;&micro;s.
+- **What this tells you**: walking a two-resolver chain on every request
+  adds tens of nanoseconds per call against the in-memory store; it is not
+  a scaling concern.
+
+## CI policy
+
+These scenarios are **excluded** from `dotnet test` invocations because
+they are an executable, not a test project (`<IsTestProject>false</IsTestProject>`
+in the csproj). The CI pipeline should still build the project (it is in
+`Compendium.sln`); use a test filter that targets `tests/Unit/` and
+`tests/Integration/` directly when running tests in CI.
+
+If a scenario is added that requires a backing service (PostgreSQL, Redis),
+keep it self-contained — start the dependency in `Build(...)` (e.g. via
+Testcontainers) and document it here so reviewers know what running it
+implies.

--- a/tests/LoadTests/Compendium.LoadTests/Compendium.LoadTests.csproj
+++ b/tests/LoadTests/Compendium.LoadTests/Compendium.LoadTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,19 +6,20 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>false</IsTestProject>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NBomber" />
     <PackageReference Include="NBomber.Http" />
-    <PackageReference Include="Testcontainers.PostgreSql" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../../src/Abstractions/Compendium.Abstractions/Compendium.Abstractions.csproj" />
     <ProjectReference Include="../../../src/Core/Compendium.Core/Compendium.Core.csproj" />
+    <ProjectReference Include="../../../src/Application/Compendium.Application/Compendium.Application.csproj" />
     <ProjectReference Include="../../../src/Infrastructure/Compendium.Infrastructure/Compendium.Infrastructure.csproj" />
-    <ProjectReference Include="../../../src/Adapters/Compendium.Adapters.PostgreSQL/Compendium.Adapters.PostgreSQL.csproj" />
+    <ProjectReference Include="../../../src/Multitenancy/Compendium.Multitenancy/Compendium.Multitenancy.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/LoadTests/Compendium.LoadTests/Program.cs
+++ b/tests/LoadTests/Compendium.LoadTests/Program.cs
@@ -1,278 +1,79 @@
-using Compendium.Adapters.PostgreSQL.Configuration;
-using Compendium.Adapters.PostgreSQL.EventStore;
-using Compendium.Core.Domain.Events;
-using Compendium.Core.EventSourcing;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
+// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.LoadTests.Scenarios;
+using Compendium.LoadTests.Support;
+using NBomber.Contracts;
 using NBomber.CSharp;
-using Testcontainers.PostgreSql;
 
-Console.WriteLine("🚀 Compendium Load Testing Suite (COMP-014)");
-Console.WriteLine("===========================================\n");
-
-// Configuration: Use external DB or TestContainers
-var externalConnectionString = Environment.GetEnvironmentVariable("EVENTSTORE_CONNECTION_STRING");
-var useExternalDb = !string.IsNullOrWhiteSpace(externalConnectionString);
-
-PostgreSqlContainer? container = null;
-string connectionString;
-
-if (useExternalDb)
+var options = ArgsParser.Parse(args);
+if (options is null)
 {
-    Console.WriteLine("📊 Using external PostgreSQL database");
-    connectionString = externalConnectionString!;
-}
-else
-{
-    Console.WriteLine("🐳 Starting PostgreSQL container with TestContainers...");
-    container = new PostgreSqlBuilder()
-        .WithImage("postgres:16-alpine")
-        .WithDatabase("loadtest")
-        .WithUsername("testuser")
-        .WithPassword("testpass")
-        .Build();
-
-    await container.StartAsync();
-    connectionString = container.GetConnectionString();
-    Console.WriteLine($"✅ Container started: {connectionString}\n");
+    PrintUsage();
+    return 64;
 }
 
-// Initialize EventStore with OPTIMIZED configuration (Task 10.3)
-var options = Options.Create(new PostgreSqlOptions
+ScenarioProps scenario;
+try
 {
-    ConnectionString = connectionString,
-
-    // Application-level settings (10x improvement from baseline)
-    MaxPoolSize = 200,           // ✅ Increased from 20 (10x)
-    CommandTimeout = 60,          // ✅ Increased from 30s (2x)
-
-    // Npgsql connection pooling parameters (NEW)
-    MinimumPoolSize = 50,         // ✅ Pre-warm 50 connections (was 0)
-    MaximumPoolSize = 200,        // ✅ Allow 200 connections (was 100 default)
-    ConnectionIdleLifetime = 900, // ✅ 15 minutes (was 300s)
-    ConnectionLifetime = 3600,    // ✅ Recycle hourly (was never)
-    ConnectionTimeout = 30,       // ✅ 30s wait for connection
-    Keepalive = 30,               // ✅ TCP keepalive every 30s
-    EnablePooling = true,
-
-    TableName = "event_store_loadtest",
-    AutoCreateSchema = true,
-    BatchSize = 1000
-});
-
-// Create event type registry and deserializer
-var eventTypeRegistry = new EventTypeRegistry();
-eventTypeRegistry.RegisterEventType(typeof(TestDomainEvent));
-var eventDeserializer = new SecureEventDeserializer(eventTypeRegistry);
-
-var eventStore = new PostgreSqlEventStore(
-    options,
-    eventDeserializer,
-    NullLogger<PostgreSqlEventStore>.Instance
-);
-
-// Initialize schema
-await eventStore.InitializeSchemaAsync();
-
-// Pre-populate some aggregates for read tests
-Console.WriteLine("🔧 Pre-populating test data...");
-var testAggregateIds = new List<string>();
-for (int i = 0; i < 100; i++)
-{
-    var aggregateId = $"test-aggregate-{i}";
-    testAggregateIds.Add(aggregateId);
-
-    var events = GenerateTestEvents(50);
-    await eventStore.AppendEventsAsync(aggregateId, events, -1);
+    scenario = options.Scenario switch
+    {
+        EventStoreAppendScenario.Name => EventStoreAppendScenario.Build(options),
+        ProjectionCatchUpScenario.Name => ProjectionCatchUpScenario.Build(options),
+        IdempotencyLookupScenario.Name => IdempotencyLookupScenario.Build(options),
+        TenantResolutionScenario.Name => TenantResolutionScenario.Build(options),
+        _ => null!,
+    };
 }
-Console.WriteLine($"✅ Pre-populated {testAggregateIds.Count} aggregates\n");
-
-// COMP-014: Scenario 1 - Append Events (10K events/min sustained)
-// Target: 10,000 events/min = 166.67 events/sec = 16.67 appends/sec (10 events each)
-var appendEventsScenario = Scenario.Create("comp014_append_events_sustained", async context =>
+catch (Exception ex)
 {
-    var aggregateId = $"load-test-{Guid.NewGuid()}";
-    var events = GenerateTestEvents(10);
+    Console.Error.WriteLine($"Failed to build scenario '{options.Scenario}': {ex.Message}");
+    return 70;
+}
 
-    var result = await eventStore.AppendEventsAsync(aggregateId, events, -1);
-
-    return result.IsSuccess
-        ? Response.Ok(statusCode: "200", sizeBytes: events.Count * 100)
-        : Response.Fail(statusCode: "500", message: result.Error.Message);
-})
-.WithLoadSimulations(
-    Simulation.RampingInject(rate: 5, interval: TimeSpan.FromSeconds(1), during: TimeSpan.FromSeconds(30)),
-    Simulation.Inject(rate: 17, interval: TimeSpan.FromSeconds(1), during: TimeSpan.FromMinutes(5))
-);
-
-// COMP-014: Scenario 2 - Read Aggregates (Sustained Read Load)
-var readEventsScenario = Scenario.Create("comp014_read_aggregates", async context =>
+if (scenario is null)
 {
-    var aggregateId = testAggregateIds[Random.Shared.Next(testAggregateIds.Count)];
+    Console.Error.WriteLine($"Unknown scenario '{options.Scenario}'.");
+    PrintUsage();
+    return 64;
+}
 
-    var result = await eventStore.GetEventsAsync(aggregateId);
+Directory.CreateDirectory(options.ArtifactsFolder);
 
-    return result.IsSuccess
-        ? Response.Ok(statusCode: "200", sizeBytes: result.Value.Count * 100)
-        : Response.Fail(statusCode: "404", message: "Aggregate not found");
-})
-.WithLoadSimulations(
-    Simulation.RampingConstant(copies: 50, during: TimeSpan.FromSeconds(30)),
-    Simulation.KeepConstant(copies: 200, during: TimeSpan.FromMinutes(5))
-);
-
-// COMP-014: Scenario 3 - Mixed Workload (70% Read, 30% Write)
-var mixedOpsScenario = Scenario.Create("comp014_mixed_workload_70_30", async context =>
-{
-    var isRead = Random.Shared.NextDouble() < 0.7;
-
-    if (isRead)
-    {
-        var aggregateId = testAggregateIds[Random.Shared.Next(testAggregateIds.Count)];
-        var result = await eventStore.GetEventsAsync(aggregateId);
-
-        return result.IsSuccess
-            ? Response.Ok(statusCode: "200", sizeBytes: result.Value.Count * 100)
-            : Response.Fail(statusCode: "404");
-    }
-    else
-    {
-        var aggregateId = $"mixed-{Guid.NewGuid()}";
-        var events = GenerateTestEvents(10);
-        var result = await eventStore.AppendEventsAsync(aggregateId, events, -1);
-
-        return result.IsSuccess
-            ? Response.Ok(statusCode: "201", sizeBytes: events.Count * 100)
-            : Response.Fail(statusCode: "500");
-    }
-})
-.WithLoadSimulations(
-    Simulation.RampingConstant(copies: 100, during: TimeSpan.FromSeconds(30)),
-    Simulation.KeepConstant(copies: 300, during: TimeSpan.FromMinutes(5))
-);
-
-// Scenario 4: Burst Load (Stress Test)
-var burstLoadScenario = Scenario.Create("burst_load_stress_test", async context =>
-{
-    var aggregateId = $"burst-{Guid.NewGuid()}";
-    var events = GenerateTestEvents(20);
-
-    var result = await eventStore.AppendEventsAsync(aggregateId, events, -1);
-
-    return result.IsSuccess
-        ? Response.Ok(statusCode: "200", sizeBytes: events.Count * 100)
-        : Response.Fail(statusCode: "500", message: result.Error.Message);
-})
-.WithLoadSimulations(
-    Simulation.Inject(rate: 200, interval: TimeSpan.FromSeconds(1), during: TimeSpan.FromSeconds(30))
-);
-
-// COMP-014: Scenario 4 - 1000 Concurrent Users (Main Acceptance Test)
-var concurrentUsersScenario = Scenario.Create("comp014_1000_concurrent_users", async context =>
-{
-    // Mix of operations to simulate realistic workload: 50% read, 30% write, 20% check
-    var operation = Random.Shared.Next(10);
-
-    if (operation < 5) // 50% - Read existing aggregate
-    {
-        var readId = testAggregateIds[Random.Shared.Next(testAggregateIds.Count)];
-        var readResult = await eventStore.GetEventsAsync(readId);
-        return readResult.IsSuccess
-            ? Response.Ok(statusCode: "200", sizeBytes: readResult.Value.Count * 100)
-            : Response.Fail(statusCode: "404");
-    }
-    else if (operation < 8) // 30% - Append new events
-    {
-        var appendId = $"concurrent-{Guid.NewGuid()}";
-        var appendEvents = GenerateTestEvents(10);
-        var appendResult = await eventStore.AppendEventsAsync(appendId, appendEvents, -1);
-        return appendResult.IsSuccess
-            ? Response.Ok(statusCode: "201", sizeBytes: appendEvents.Count * 100)
-            : Response.Fail(statusCode: "500");
-    }
-    else // 20% - Check existence
-    {
-        var existsId = testAggregateIds[Random.Shared.Next(testAggregateIds.Count)];
-        var exists = await eventStore.ExistsAsync(existsId);
-        return exists.IsSuccess
-            ? Response.Ok(statusCode: "200", sizeBytes: 10)
-            : Response.Fail(statusCode: "404");
-    }
-})
-.WithLoadSimulations(
-    Simulation.RampingConstant(copies: 200, during: TimeSpan.FromSeconds(30)),
-    Simulation.RampingConstant(copies: 500, during: TimeSpan.FromSeconds(30)),
-    Simulation.RampingConstant(copies: 1000, during: TimeSpan.FromSeconds(60)),
-    Simulation.KeepConstant(copies: 1000, during: TimeSpan.FromMinutes(5))
-);
-
-// Run COMP-014 load tests
-Console.WriteLine("🏃 Running COMP-014 load tests...\n");
-Console.WriteLine("Target: 10,000 events/min sustained for 5 minutes");
-Console.WriteLine("Target: 1,000 concurrent users");
-Console.WriteLine("Expected: HTML report with latency/throughput metrics\n");
+Console.WriteLine($"Compendium load tests — scenario={options.Scenario} duration={options.Duration}");
+Console.WriteLine($"Artifacts will be written to {Path.GetFullPath(options.ArtifactsFolder)}");
 
 var stats = NBomberRunner
-    .RegisterScenarios(
-        appendEventsScenario,
-        readEventsScenario,
-        mixedOpsScenario,
-        burstLoadScenario,
-        concurrentUsersScenario
-    )
-    .WithReportFolder("load-test-results")
-    .WithReportFileName("comp-014-load-test-report")
+    .RegisterScenarios(scenario)
+    .WithReportFolder(options.ArtifactsFolder)
+    .WithReportFileName($"{options.Scenario}-report")
     .Run();
 
-// Cleanup
-if (container != null)
+JsonSummaryWriter.Write(options, stats);
+
+Console.WriteLine($"Done. Summary: {Path.Combine(options.ArtifactsFolder, options.Scenario + ".json")}");
+return 0;
+
+static void PrintUsage()
 {
-    Console.WriteLine("\n🧹 Cleaning up container...");
-    await container.StopAsync();
-    await container.DisposeAsync();
+    Console.WriteLine("""
+Compendium load tests — usage:
+  dotnet run --project tests/LoadTests/Compendium.LoadTests -c Release -- \
+    --scenario <name> [--duration 15s] [--artifacts artifacts/load] [--no-warmup]
+
+Scenarios:
+  eventstore   Sustained IEventStore.AppendEventsAsync throughput (in-memory)
+  projection   Projection catch-up rate from version 0 to N (in-memory)
+  idempotency  IIdempotencyStore exists/set latency under concurrency
+  tenant       Composite TenantResolver chain throughput with hits and misses
+
+Each run writes:
+  <artifacts>/<scenario>-report.{html,csv,md,txt}    (NBomber native reports)
+  <artifacts>/<scenario>.json                        (machine-readable summary)
+""");
 }
 
-Console.WriteLine("\n✅ COMP-014 Load Testing Completed!");
-Console.WriteLine("===========================================");
-Console.WriteLine($"📊 Results saved to: load-test-results/");
-Console.WriteLine($"📈 HTML Report: load-test-results/comp-014-load-test-report.html");
-Console.WriteLine($"📝 Markdown Report: load-test-results/comp-014-load-test-report.md");
-Console.WriteLine($"\nCOMP-014 Acceptance Criteria:");
-Console.WriteLine($"  ✓ 10,000 events/min sustained for 5 minutes");
-Console.WriteLine($"  ✓ 1,000 concurrent users");
-Console.WriteLine($"  ✓ HTML report with latency/throughput");
-Console.WriteLine($"  ✓ Bottlenecks identified in report");
-
-// Helper method to generate test events
-static List<IDomainEvent> GenerateTestEvents(int count, string? aggregateId = null)
-{
-    var events = new List<IDomainEvent>();
-    var targetAggregateId = aggregateId ?? Guid.NewGuid().ToString();
-
-    for (int i = 0; i < count; i++)
-    {
-        events.Add(new TestDomainEvent
-        {
-            EventId = Guid.NewGuid(),
-            AggregateId = targetAggregateId,
-            AggregateType = "LoadTestAggregate",
-            OccurredOn = DateTimeOffset.UtcNow,
-            AggregateVersion = i + 1,
-            PayloadData = $"{{\"index\":{i},\"timestamp\":\"{DateTimeOffset.UtcNow:O}\",\"payload\":\"test-data-{Guid.NewGuid()}\"}}"
-        });
-    }
-
-    return events;
-}
-
-// Simple test event implementation
-public sealed record TestDomainEvent : IDomainEvent
-{
-    public required Guid EventId { get; init; }
-    public required string AggregateId { get; init; }
-    public required string AggregateType { get; init; }
-    public required DateTimeOffset OccurredOn { get; init; }
-    public required long AggregateVersion { get; init; }
-    public int EventVersion { get; init; } = 1;
-    public required string PayloadData { get; init; }
-}

--- a/tests/LoadTests/Compendium.LoadTests/README.md
+++ b/tests/LoadTests/Compendium.LoadTests/README.md
@@ -1,144 +1,25 @@
-# Compendium Load Testing - PostgreSQL Connection Pooling
+# Compendium.LoadTests
 
-NBomber-based load testing for PostgreSQL connection pooling optimization.
+Baseline NBomber load scenarios for the Compendium framework's hot-path
+abstractions. All scenarios run against the in-memory implementations
+(no Postgres, no Redis, no network) so the suite is runnable locally with
+a single `dotnet run`.
 
-## Prerequisites
+See [`docs/testing/load-tests.md`](../../../docs/testing/load-tests.md) for
+the full list of scenarios, the metric each one measures, and the
+expected dev-machine baseline numbers.
 
-- .NET 9.0 SDK
-- Docker (optional, for TestContainers)
-- External PostgreSQL database (optional)
-
-## Running Load Tests
-
-### Option 1: Using External Database (Recommended for Development)
-
-```bash
-# Set environment variable with connection string
-export EVENTSTORE_CONNECTION_STRING="Host=51.159.205.157;Database=season_events_development;Username=season-pascal;Password=T#j#4}{r5X.]}uPx>*DI;Port=17711;Timeout=30;Command Timeout=30"
-
-# Run load tests
-dotnet run --project tests/LoadTests/Compendium.LoadTests -c Release
-```
-
-### Option 2: Using TestContainers (Requires Docker)
+## Quick start
 
 ```bash
-# Ensure Docker is running
-docker ps
-
-# Run load tests (will automatically start PostgreSQL container)
-dotnet run --project tests/LoadTests/Compendium.LoadTests -c Release
+dotnet run --project tests/LoadTests/Compendium.LoadTests -c Release -- \
+    --scenario eventstore --duration 30s
 ```
 
-## Test Scenarios
+Available scenarios: `eventstore`, `projection`, `idempotency`, `tenant`.
 
-### 1. Append Events (Write Load)
-- **Duration**: 90 seconds
-- **Load Pattern**:
-  - 30s @ 50 req/sec injection
-  - 60s @ 100 concurrent connections
-- **Operation**: Append 10 events per request
+Output is written to `artifacts/load/<scenario>.json` plus the standard
+NBomber HTML / CSV / Markdown reports.
 
-### 2. Read Events (Read Load)
-- **Duration**: 60 seconds
-- **Load Pattern**: 100 concurrent connections
-- **Operation**: Read all events for random aggregates
-
-### 3. Mixed Operations (70% Read / 30% Write)
-- **Duration**: 60 seconds
-- **Load Pattern**: 100 concurrent connections
-- **Operation**:
-  - 70% reads from existing aggregates
-  - 30% writes (5 events per request)
-
-### 4. Burst Load (Stress Test)
-- **Duration**: 30 seconds
-- **Load Pattern**: 200 req/sec injection
-- **Operation**: Append 20 events per request
-
-### 5. 1000 Concurrent Connections (Main Test)
-- **Duration**: 120 seconds total
-- **Load Pattern**:
-  - 10s ramp: 0 → 100 connections
-  - 20s ramp: 100 → 500 connections
-  - 30s ramp: 500 → 1000 connections
-  - 60s sustain: 1000 connections
-- **Operation Mix**:
-  - 50% reads from existing aggregates
-  - 30% writes (10 events per request)
-  - 20% existence checks
-
-## Current Configuration Under Test
-
-```csharp
-MaxPoolSize = 20           // Application-level semaphore
-CommandTimeout = 30        // seconds
-TableName = "event_store_loadtest"
-AutoCreateSchema = true
-BatchSize = 1000
-```
-
-**Npgsql Connection String** (defaults):
-- Pooling = true
-- Minimum Pool Size = 0
-- Maximum Pool Size = 100
-- Connection Idle Lifetime = 300s
-- Timeout = 15s
-
-## Results
-
-Results are saved to `load-test-results/` folder:
-- `compendium-connection-pooling-report.html` - Interactive HTML report with charts
-- `compendium-connection-pooling-report.txt` - Text summary
-
-## Key Metrics to Monitor
-
-1. **Request Throughput**: Requests/sec achieved
-2. **Response Time**: Mean, median, p95, p99 latencies
-3. **Error Rate**: Failed requests / Total requests
-4. **Connection Pool Utilization**: From application semaphore
-5. **Database Connections**: Monitor PostgreSQL connection count
-
-## Expected Results (Current Config)
-
-With MaxPoolSize=20, expect:
-- ✅ Scenarios 1-3: Should complete successfully
-- ⚠️ Scenario 4 (Burst): May show delays due to connection pool bottleneck
-- ❌ Scenario 5 (1000 concurrent): Will fail or show high latency (20 < 1000)
-
-## Troubleshooting
-
-### Container fails to start
-```bash
-# Check Docker is running
-docker ps
-
-# Check disk space
-df -h
-```
-
-### Connection timeouts
-- Verify external database is accessible
-- Check firewall rules
-- Verify connection string credentials
-
-### Out of memory errors
-- Reduce concurrent connection counts in scenarios
-- Increase Docker memory limits
-- Use external database instead of TestContainers
-
-## Next Steps
-
-After baseline results:
-1. Increase `MaxPoolSize` to 100-200 (Task 10.3)
-2. Add Npgsql pooling parameters to connection string (Task 10.3)
-3. Re-run tests and compare metrics
-4. Optimize PostgreSqlEventStore if needed (Task 10.4)
-5. Add connection pooling metrics (Task 10.5)
-
-## References
-
-- [NBomber Documentation](https://nbomber.com)
-- [Npgsql Connection Pooling](https://www.npgsql.org/doc/connection-string-parameters.html)
-- [PostgreSQL Connection Limits](https://www.postgresql.org/docs/current/runtime-config-connection.html)
-- [Connection Pooling Analysis](../../../docs/performance/npgsql-connection-pooling.md)
+These scenarios are **informational** — they are not part of the CI test
+filter, and they do not gate merges.

--- a/tests/LoadTests/Compendium.LoadTests/Scenarios/EventStoreAppendScenario.cs
+++ b/tests/LoadTests/Compendium.LoadTests/Scenarios/EventStoreAppendScenario.cs
@@ -1,0 +1,67 @@
+// -----------------------------------------------------------------------
+// <copyright file="EventStoreAppendScenario.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.Domain.Events;
+using Compendium.Core.EventSourcing;
+using Compendium.Infrastructure.EventSourcing;
+using Compendium.LoadTests.Support;
+using Microsoft.Extensions.Logging.Abstractions;
+using NBomber.Contracts;
+using NBomber.CSharp;
+
+namespace Compendium.LoadTests.Scenarios;
+
+/// <summary>
+/// Measures sustained <see cref="IEventStore.AppendEventsAsync(string,IEnumerable{IDomainEvent},long,CancellationToken)"/>
+/// throughput against the in-memory implementation. Each iteration appends a
+/// 10-event batch to a fresh aggregate so the contention is on the dictionary
+/// and the writer lock, not on optimistic-concurrency conflicts.
+/// </summary>
+public static class EventStoreAppendScenario
+{
+    /// <summary>
+    /// Stable scenario name used in the CLI and in the JSON output filename.
+    /// </summary>
+    public const string Name = "eventstore";
+
+    private const int EventsPerAppend = 10;
+    private const int CopyCount = 32;
+
+    /// <summary>
+    /// Builds the scenario without registering it; the caller composes load
+    /// simulations and runs it through <see cref="NBomberRunner"/>.
+    /// </summary>
+    public static ScenarioProps Build(ScenarioOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var registry = new EventTypeRegistry();
+        registry.RegisterEventType(typeof(LoadTestEvent));
+        var deserializer = new SecureEventDeserializer(registry);
+        var eventStore = new InMemoryEventStore(deserializer, NullLogger<InMemoryEventStore>.Instance);
+
+        var scenario = Scenario.Create(Name, async _ =>
+        {
+            var aggregateId = $"agg-{Guid.NewGuid():N}";
+            var batch = LoadTestEvent.Batch(aggregateId, EventsPerAppend);
+
+            var result = await eventStore.AppendEventsAsync(aggregateId, batch, expectedVersion: -1);
+
+            return result.IsSuccess
+                ? Response.Ok(sizeBytes: EventsPerAppend * 128)
+                : Response.Fail(message: result.Error.Message);
+        })
+        .WithLoadSimulations(
+            Simulation.KeepConstant(copies: CopyCount, during: options.Duration));
+
+        scenario = options.Warmup
+            ? scenario.WithWarmUpDuration(TimeSpan.FromSeconds(Math.Min(2, Math.Max(1, (int)options.Duration.TotalSeconds / 2))))
+            : scenario.WithoutWarmUp();
+
+        return scenario;
+    }
+}

--- a/tests/LoadTests/Compendium.LoadTests/Scenarios/IdempotencyLookupScenario.cs
+++ b/tests/LoadTests/Compendium.LoadTests/Scenarios/IdempotencyLookupScenario.cs
@@ -1,0 +1,78 @@
+// -----------------------------------------------------------------------
+// <copyright file="IdempotencyLookupScenario.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Application.Idempotency;
+using Compendium.LoadTests.Support;
+using NBomber.Contracts;
+using NBomber.CSharp;
+
+namespace Compendium.LoadTests.Scenarios;
+
+/// <summary>
+/// Stress-tests the <see cref="IIdempotencyStore"/> abstraction with a mix of
+/// reads and writes. Roughly 80&#160;% of iterations are <c>ExistsAsync</c>
+/// (the hot path on every command handler) and 20&#160;% are <c>SetAsync</c>
+/// to simulate the first-time write that follows a cache miss.
+/// </summary>
+public static class IdempotencyLookupScenario
+{
+    /// <summary>
+    /// Stable scenario name used in the CLI and in the JSON output filename.
+    /// </summary>
+    public const string Name = "idempotency";
+
+    private const int CopyCount = 64;
+    private const int PrePopulatedKeys = 10_000;
+
+    /// <summary>
+    /// Builds the scenario without registering it.
+    /// </summary>
+    public static ScenarioProps Build(ScenarioOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var store = new InMemoryIdempotencyStore();
+        var keys = new string[PrePopulatedKeys];
+        for (var i = 0; i < PrePopulatedKeys; i++)
+        {
+            keys[i] = $"idem-{i:D6}";
+            var seed = store.SetAsync(keys[i], true, TimeSpan.FromHours(1)).GetAwaiter().GetResult();
+            if (seed.IsFailure)
+            {
+                throw new InvalidOperationException($"Seeding failed: {seed.Error.Message}");
+            }
+        }
+
+        var scenario = Scenario.Create(Name, async _ =>
+        {
+            var rng = Random.Shared;
+            var key = keys[rng.Next(PrePopulatedKeys)];
+
+            // 80 / 20 split between read and write.
+            if (rng.Next(10) < 8)
+            {
+                var existsResult = await store.ExistsAsync(key);
+                return existsResult.IsSuccess
+                    ? Response.Ok(sizeBytes: 32)
+                    : Response.Fail(message: existsResult.Error.Message);
+            }
+
+            var setResult = await store.SetAsync($"{key}-{Guid.NewGuid():N}", true, TimeSpan.FromMinutes(5));
+            return setResult.IsSuccess
+                ? Response.Ok(sizeBytes: 64)
+                : Response.Fail(message: setResult.Error.Message);
+        })
+        .WithLoadSimulations(
+            Simulation.KeepConstant(copies: CopyCount, during: options.Duration));
+
+        scenario = options.Warmup
+            ? scenario.WithWarmUpDuration(TimeSpan.FromSeconds(Math.Min(2, Math.Max(1, (int)options.Duration.TotalSeconds / 2))))
+            : scenario.WithoutWarmUp();
+
+        return scenario;
+    }
+}

--- a/tests/LoadTests/Compendium.LoadTests/Scenarios/ProjectionCatchUpScenario.cs
+++ b/tests/LoadTests/Compendium.LoadTests/Scenarios/ProjectionCatchUpScenario.cs
@@ -1,0 +1,81 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProjectionCatchUpScenario.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.EventSourcing;
+using Compendium.Infrastructure.EventSourcing;
+using Compendium.LoadTests.Support;
+using Microsoft.Extensions.Logging.Abstractions;
+using NBomber.Contracts;
+using NBomber.CSharp;
+
+namespace Compendium.LoadTests.Scenarios;
+
+/// <summary>
+/// Measures the rate at which <see cref="ProjectionManager"/> can catch a
+/// projection up from version 0 to version <c>N</c>. Each NBomber iteration
+/// rebuilds a freshly-reset projection over a pre-populated aggregate so the
+/// hot path being timed is purely the replay loop.
+/// </summary>
+public static class ProjectionCatchUpScenario
+{
+    /// <summary>
+    /// Stable scenario name used in the CLI and in the JSON output filename.
+    /// </summary>
+    public const string Name = "projection";
+
+    private const int EventCountPerAggregate = 5_000;
+    private const int CopyCount = 1;
+
+    /// <summary>
+    /// Builds the scenario without registering it. A single copy is used
+    /// because each iteration is intentionally heavy (replays N events) and
+    /// throughput is best read as <c>events / iteration_duration</c>.
+    /// </summary>
+    public static ScenarioProps Build(ScenarioOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var registry = new EventTypeRegistry();
+        registry.RegisterEventType(typeof(LoadTestEvent));
+        var deserializer = new SecureEventDeserializer(registry);
+        var eventStore = new InMemoryEventStore(deserializer, NullLogger<InMemoryEventStore>.Instance);
+
+        const string aggregateId = "projection-loadtest-aggregate";
+        var batch = LoadTestEvent.Batch(aggregateId, EventCountPerAggregate);
+        var seedResult = eventStore.AppendEventsAsync(aggregateId, batch, expectedVersion: -1).GetAwaiter().GetResult();
+        if (seedResult.IsFailure)
+        {
+            throw new InvalidOperationException($"Failed to seed projection events: {seedResult.Error.Message}");
+        }
+
+        var projectionManager = new ProjectionManager(eventStore, NullLogger<ProjectionManager>.Instance);
+        var projection = new CountingProjection();
+        projectionManager.RegisterProjection(projection);
+
+        var scenario = Scenario.Create(Name, async _ =>
+        {
+            await projection.ResetAsync();
+
+            var result = await projectionManager.RebuildProjectionAsync(projection.ProjectionId, aggregateId);
+
+            // NBomber already times each iteration end-to-end and surfaces
+            // mean / p50 / p99 latencies; events-per-second is simply
+            // N / mean-latency in the report.
+            return result.IsSuccess
+                ? Response.Ok(sizeBytes: EventCountPerAggregate * 128)
+                : Response.Fail(message: result.Error.Message);
+        })
+        .WithLoadSimulations(
+            Simulation.KeepConstant(copies: CopyCount, during: options.Duration));
+
+        scenario = options.Warmup
+            ? scenario.WithWarmUpDuration(TimeSpan.FromSeconds(Math.Min(2, Math.Max(1, (int)options.Duration.TotalSeconds / 2))))
+            : scenario.WithoutWarmUp();
+
+        return scenario;
+    }
+}

--- a/tests/LoadTests/Compendium.LoadTests/Scenarios/TenantResolutionScenario.cs
+++ b/tests/LoadTests/Compendium.LoadTests/Scenarios/TenantResolutionScenario.cs
@@ -1,0 +1,124 @@
+// -----------------------------------------------------------------------
+// <copyright file="TenantResolutionScenario.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.LoadTests.Support;
+using Compendium.Multitenancy;
+using Compendium.Multitenancy.Stores;
+using Microsoft.Extensions.Logging.Abstractions;
+using NBomber.Contracts;
+using NBomber.CSharp;
+
+namespace Compendium.LoadTests.Scenarios;
+
+/// <summary>
+/// Measures the throughput of a realistic tenant-resolution chain on the
+/// request hot path: a header resolver followed by a host resolver, both
+/// backed by an <see cref="InMemoryTenantStore"/> pre-populated with a
+/// modest number of tenants. The mix purposefully includes cache misses
+/// (unknown ids / hosts) so the cost of failing through the chain is also
+/// captured in the percentile metrics.
+/// </summary>
+public static class TenantResolutionScenario
+{
+    /// <summary>
+    /// Stable scenario name used in the CLI and in the JSON output filename.
+    /// </summary>
+    public const string Name = "tenant";
+
+    private const int CopyCount = 64;
+    private const int TenantCount = 200;
+
+    /// <summary>
+    /// Builds the scenario without registering it.
+    /// </summary>
+    public static ScenarioProps Build(ScenarioOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var store = new InMemoryTenantStore();
+        for (var i = 0; i < TenantCount; i++)
+        {
+            var tenant = new TenantInfo
+            {
+                Id = $"tenant-{i:D4}",
+                Name = $"acme-{i:D4}",
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+            };
+            _ = store.SaveAsync(tenant).GetAwaiter().GetResult();
+            store.AddIdentifierMapping($"tenant-{i:D4}.example.com", tenant.Id);
+        }
+
+        var headerResolver = new HeaderTenantResolver(
+            store,
+            new HeaderTenantResolverOptions { HeaderName = "X-Tenant-ID" },
+            NullLogger<HeaderTenantResolver>.Instance);
+
+        var hostResolver = new HostTenantResolver(
+            store,
+            new HostTenantResolverOptions { UseSubdomain = false },
+            NullLogger<HostTenantResolver>.Instance);
+
+        var composite = new CompositeTenantResolver(
+            new ITenantResolver[] { headerResolver, hostResolver },
+            NullLogger<CompositeTenantResolver>.Instance);
+
+        var scenario = Scenario.Create(Name, async _ =>
+        {
+            var rng = Random.Shared;
+            var roll = rng.Next(10);
+            var ctx = BuildContext(roll, rng);
+
+            var result = await composite.ResolveTenantAsync(ctx);
+            if (result.IsFailure)
+            {
+                return Response.Fail(message: result.Error.Message);
+            }
+
+            // We treat both "tenant resolved" and "no tenant" as Ok — a
+            // production resolver returning null on a public endpoint is not
+            // a failure, only an internal exception or store error is.
+            return Response.Ok(sizeBytes: 64);
+        })
+        .WithLoadSimulations(
+            Simulation.KeepConstant(copies: CopyCount, during: options.Duration));
+
+        scenario = options.Warmup
+            ? scenario.WithWarmUpDuration(TimeSpan.FromSeconds(Math.Min(2, Math.Max(1, (int)options.Duration.TotalSeconds / 2))))
+            : scenario.WithoutWarmUp();
+
+        return scenario;
+    }
+
+    /// <summary>
+    /// Returns a context that exercises a representative mix of resolution paths.
+    /// </summary>
+    private static TenantResolutionContext BuildContext(int roll, Random rng)
+    {
+        // 60% header hits, 20% host hits, 20% misses.
+        if (roll < 6)
+        {
+            return new TenantResolutionContext
+            {
+                Headers = { ["X-Tenant-ID"] = $"tenant-{rng.Next(TenantCount):D4}" },
+            };
+        }
+
+        if (roll < 8)
+        {
+            return new TenantResolutionContext
+            {
+                Host = $"tenant-{rng.Next(TenantCount):D4}.example.com",
+            };
+        }
+
+        return new TenantResolutionContext
+        {
+            Host = $"unknown-{rng.Next(1_000_000):D6}.example.com",
+        };
+    }
+}

--- a/tests/LoadTests/Compendium.LoadTests/Support/CountingProjection.cs
+++ b/tests/LoadTests/Compendium.LoadTests/Support/CountingProjection.cs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------
+// <copyright file="CountingProjection.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.EventSourcing;
+
+namespace Compendium.LoadTests.Support;
+
+/// <summary>
+/// Snapshot record carried by <see cref="CountingProjection"/>.
+/// </summary>
+public sealed record CountingProjectionSnapshot
+{
+    /// <summary>
+    /// Number of events applied since the last reset.
+    /// </summary>
+    public long Processed { get; init; }
+}
+
+/// <summary>
+/// Trivial projection that just increments a counter — used to measure the
+/// per-event overhead of <see cref="IProjectionManager"/> without letting
+/// projection-side work dominate the timing.
+/// </summary>
+public sealed class CountingProjection : ProjectionBase<LoadTestEvent, CountingProjectionSnapshot>
+{
+    /// <inheritdoc />
+    public override string ProjectionId => "loadtests-counting-projection";
+
+    /// <inheritdoc />
+    protected override Task HandleEventAsync(LoadTestEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        var current = State;
+        UpdateState(current with { Processed = current.Processed + 1 });
+        return Task.CompletedTask;
+    }
+}

--- a/tests/LoadTests/Compendium.LoadTests/Support/InMemoryIdempotencyStore.cs
+++ b/tests/LoadTests/Compendium.LoadTests/Support/InMemoryIdempotencyStore.cs
@@ -1,0 +1,92 @@
+// -----------------------------------------------------------------------
+// <copyright file="InMemoryIdempotencyStore.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using Compendium.Application.Idempotency;
+using Compendium.Core.Results;
+
+namespace Compendium.LoadTests.Support;
+
+/// <summary>
+/// Thread-safe in-memory <see cref="IIdempotencyStore"/> used to measure the
+/// raw lookup / write latency of the idempotency abstraction without involving
+/// Redis. Entries expire lazily on access to keep the hot path lock-free.
+/// </summary>
+public sealed class InMemoryIdempotencyStore : IIdempotencyStore
+{
+    private readonly ConcurrentDictionary<string, Entry> _entries = new();
+
+    /// <inheritdoc />
+    public Task<Result<bool>> ExistsAsync(string key, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return Task.FromResult(Result.Success(false));
+        }
+
+        if (_entries.TryGetValue(key, out var entry))
+        {
+            if (entry.IsExpired)
+            {
+                _entries.TryRemove(key, out _);
+                return Task.FromResult(Result.Success(false));
+            }
+
+            return Task.FromResult(Result.Success(true));
+        }
+
+        return Task.FromResult(Result.Success(false));
+    }
+
+    /// <inheritdoc />
+    public Task<Result<TResult?>> GetAsync<TResult>(string key, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return Task.FromResult(Result.Success<TResult?>(default));
+        }
+
+        if (_entries.TryGetValue(key, out var entry))
+        {
+            if (entry.IsExpired)
+            {
+                _entries.TryRemove(key, out _);
+                return Task.FromResult(Result.Success<TResult?>(default));
+            }
+
+            if (entry.Value is TResult typed)
+            {
+                return Task.FromResult(Result.Success<TResult?>(typed));
+            }
+        }
+
+        return Task.FromResult(Result.Success<TResult?>(default));
+    }
+
+    /// <inheritdoc />
+    public Task<Result> SetAsync<TValue>(string key, TValue value, TimeSpan expiration, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return Task.FromResult(Result.Failure(Error.Validation("Idempotency.InvalidKey", "Key cannot be null or empty")));
+        }
+
+        var expiresAt = expiration > TimeSpan.Zero ? DateTimeOffset.UtcNow.Add(expiration) : DateTimeOffset.MaxValue;
+        _entries[key] = new Entry(value, expiresAt);
+        return Task.FromResult(Result.Success());
+    }
+
+    /// <summary>
+    /// Number of live entries currently held in the store.
+    /// </summary>
+    public int Count => _entries.Count;
+
+    private sealed record Entry(object? Value, DateTimeOffset ExpiresAt)
+    {
+        public bool IsExpired => DateTimeOffset.UtcNow >= ExpiresAt;
+    }
+}

--- a/tests/LoadTests/Compendium.LoadTests/Support/JsonSummaryWriter.cs
+++ b/tests/LoadTests/Compendium.LoadTests/Support/JsonSummaryWriter.cs
@@ -1,0 +1,336 @@
+// -----------------------------------------------------------------------
+// <copyright file="JsonSummaryWriter.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Compendium.LoadTests.Support;
+
+/// <summary>
+/// Writes a per-scenario JSON summary file derived from NBomber's
+/// <c>NodeStats</c> result. We avoid serialising the raw object because
+/// <c>NodeStats.NodeInfo.NodeType</c> is an F# discriminated union which
+/// <see cref="JsonSerializer"/> cannot handle out of the box. Instead we
+/// reflect over a curated set of fields and build a plain CLR object.
+/// </summary>
+public static class JsonSummaryWriter
+{
+    /// <summary>
+    /// Writes <c><![CDATA[<artifacts>/<scenario>.json]]></c> next to NBomber's
+    /// own reports. Failures are logged to stderr and a minimal envelope is
+    /// written instead so callers still get a file at the expected path.
+    /// </summary>
+    public static void Write(ScenarioOptions options, object? nbomberResult)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var path = Path.Combine(options.ArtifactsFolder, $"{options.Scenario}.json");
+        var jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        try
+        {
+            var nodeStats = ExtractNodeStats(nbomberResult);
+
+            // Try to serialise the raw NodeStats first — it carries every
+            // metric NBomber computed. The only known landmine is the
+            // F#-discriminated-union NodeType field, which we silence with
+            // a custom converter.
+            jsonOptions.Converters.Add(new ToStringConverter("NBomber.Contracts.Stats.NodeType"));
+            jsonOptions.Converters.Add(new ToStringConverter("NBomber.Contracts.Cluster"));
+
+            var envelope = new
+            {
+                scenario = options.Scenario,
+                duration = options.Duration.ToString(),
+                warmup = options.Warmup,
+                generatedAtUtc = DateTimeOffset.UtcNow,
+                summary = ExtractScenarioSummaries(nodeStats),
+                raw = nodeStats,
+            };
+
+            File.WriteAllText(path, JsonSerializer.Serialize(envelope, jsonOptions));
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Warning: failed to write JSON summary to {path}: {ex.Message}");
+            File.WriteAllText(path, JsonSerializer.Serialize(new
+            {
+                scenario = options.Scenario,
+                duration = options.Duration.ToString(),
+                error = ex.Message,
+            }, jsonOptions));
+        }
+    }
+
+    /// <summary>
+    /// NBomber 6's <c>NBomberRunner.Run</c> returns either <c>NodeStats</c>
+    /// directly or a <c>Result&lt;NodeStats, IDomainError&gt;</c> wrapper
+    /// depending on the build. Walk both shapes via reflection.
+    /// </summary>
+    private static object? ExtractNodeStats(object? raw)
+    {
+        if (raw is null)
+        {
+            return null;
+        }
+
+        var type = raw.GetType();
+
+        // F# Result.Ok shape — has IsOk + ResultValue.
+        var isOk = type.GetProperty("IsOk", BindingFlags.Public | BindingFlags.Instance);
+        if (isOk?.GetValue(raw) is true)
+        {
+            var value = type.GetProperty("ResultValue", BindingFlags.Public | BindingFlags.Instance);
+            if (value is not null)
+            {
+                return value.GetValue(raw);
+            }
+        }
+
+        // Already a NodeStats — has ScenarioStats.
+        if (type.GetProperty("ScenarioStats") is not null)
+        {
+            return raw;
+        }
+
+        return raw;
+    }
+
+    private static List<object> ExtractScenarioSummaries(object? nodeStats)
+    {
+        var summaries = new List<object>();
+        if (nodeStats is null)
+        {
+            return summaries;
+        }
+
+        var scenarios = nodeStats.GetType().GetProperty("ScenarioStats")?.GetValue(nodeStats) as System.Collections.IEnumerable;
+        if (scenarios is null)
+        {
+            return summaries;
+        }
+
+        foreach (var s in scenarios)
+        {
+            if (s is null)
+            {
+                continue;
+            }
+
+            var stType = s.GetType();
+            var name = stType.GetProperty("ScenarioName")?.GetValue(s)?.ToString();
+            var duration = stType.GetProperty("Duration")?.GetValue(s)?.ToString();
+
+            // NBomber renamed counters between minor versions; collect any
+            // public count-like property so the JSON stays useful regardless.
+            var counts = new Dictionary<string, long>();
+            var rates = new Dictionary<string, double>();
+            foreach (var prop in stType.GetProperties())
+            {
+                var v = prop.GetValue(s);
+                if (v is null)
+                {
+                    continue;
+                }
+
+                if ((prop.PropertyType == typeof(int) || prop.PropertyType == typeof(long)) &&
+                    (prop.Name.EndsWith("Count", StringComparison.Ordinal) ||
+                     prop.Name.EndsWith("Bytes", StringComparison.Ordinal)))
+                {
+                    counts[prop.Name] = ToInt64(v);
+                }
+                else if (prop.PropertyType == typeof(double) || prop.PropertyType == typeof(float))
+                {
+                    rates[prop.Name] = ToDouble(v);
+                }
+            }
+
+            // In NBomber 6 the scenario-level Ok / Fail measurements live
+            // directly on ScenarioStats; StepStats is non-empty only when
+            // the scenario uses Step.Run(...). Extract both shapes so the
+            // JSON works whichever style the scenario uses.
+            var ok = ExtractMetric(stType.GetProperty("Ok")?.GetValue(s));
+            var fail = ExtractMetric(stType.GetProperty("Fail")?.GetValue(s));
+
+            var stepStats = stType.GetProperty("StepStats")?.GetValue(s) as System.Collections.IEnumerable;
+            var steps = new List<object>();
+            if (stepStats is not null)
+            {
+                foreach (var step in stepStats)
+                {
+                    if (step is null)
+                    {
+                        continue;
+                    }
+
+                    var stepType = step.GetType();
+                    var stepName = stepType.GetProperty("StepName")?.GetValue(step)?.ToString();
+                    var stepOk = ExtractMetric(stepType.GetProperty("Ok")?.GetValue(step));
+                    var stepFail = ExtractMetric(stepType.GetProperty("Fail")?.GetValue(step));
+
+                    steps.Add(new
+                    {
+                        stepName,
+                        ok = stepOk,
+                        fail = stepFail,
+                    });
+                }
+            }
+
+            summaries.Add(new
+            {
+                scenario = name,
+                duration,
+                counters = counts,
+                rates,
+                ok,
+                fail,
+                steps,
+            });
+        }
+
+        return summaries;
+    }
+
+    private static object? ExtractMetric(object? metric)
+    {
+        if (metric is null)
+        {
+            return null;
+        }
+
+        var t = metric.GetType();
+        var request = t.GetProperty("Request")?.GetValue(metric);
+        var latency = t.GetProperty("Latency")?.GetValue(metric);
+        var data = t.GetProperty("DataTransfer")?.GetValue(metric);
+
+        return new
+        {
+            request = ExtractRequest(request),
+            latency = ExtractLatency(latency),
+            dataTransfer = ExtractDataTransfer(data),
+        };
+    }
+
+    private static object? ExtractRequest(object? r)
+    {
+        if (r is null)
+        {
+            return null;
+        }
+
+        var t = r.GetType();
+        return new
+        {
+            count = ToInt64(t.GetProperty("Count")?.GetValue(r)),
+            rps = ToDouble(t.GetProperty("RPS")?.GetValue(r)),
+        };
+    }
+
+    private static object? ExtractLatency(object? l)
+    {
+        if (l is null)
+        {
+            return null;
+        }
+
+        var t = l.GetType();
+        return new
+        {
+            minMs = ToDouble(t.GetProperty("MinMs")?.GetValue(l)),
+            meanMs = ToDouble(t.GetProperty("MeanMs")?.GetValue(l)),
+            maxMs = ToDouble(t.GetProperty("MaxMs")?.GetValue(l)),
+            stdDev = ToDouble(t.GetProperty("StdDev")?.GetValue(l)),
+            p50 = ToDouble(t.GetProperty("Percent50")?.GetValue(l)),
+            p75 = ToDouble(t.GetProperty("Percent75")?.GetValue(l)),
+            p95 = ToDouble(t.GetProperty("Percent95")?.GetValue(l)),
+            p99 = ToDouble(t.GetProperty("Percent99")?.GetValue(l)),
+        };
+    }
+
+    private static object? ExtractDataTransfer(object? d)
+    {
+        if (d is null)
+        {
+            return null;
+        }
+
+        var t = d.GetType();
+        return new
+        {
+            minBytes = ToInt64(t.GetProperty("MinBytes")?.GetValue(d)),
+            meanBytes = ToInt64(t.GetProperty("MeanBytes")?.GetValue(d)),
+            maxBytes = ToInt64(t.GetProperty("MaxBytes")?.GetValue(d)),
+            allBytes = ToInt64(t.GetProperty("AllBytes")?.GetValue(d)),
+        };
+    }
+
+    private static long ToInt64(object? value)
+    {
+        return value switch
+        {
+            null => 0L,
+            long l => l,
+            int i => i,
+            double d => (long)d,
+            _ => Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture),
+        };
+    }
+
+    /// <summary>
+    /// Replaces any object whose type name starts with the given prefix with
+    /// its <see cref="object.ToString"/>. Used to neutralise F# discriminated
+    /// unions inside NBomber's <c>NodeStats</c> graph.
+    /// </summary>
+    private sealed class ToStringConverter : JsonConverterFactory
+    {
+        private readonly string _typeNamePrefix;
+
+        public ToStringConverter(string typeNamePrefix)
+        {
+            _typeNamePrefix = typeNamePrefix;
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert.FullName?.StartsWith(_typeNamePrefix, StringComparison.Ordinal) == true;
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            return (JsonConverter)Activator.CreateInstance(typeof(StringConverter<>).MakeGenericType(typeToConvert))!;
+        }
+
+        private sealed class StringConverter<T> : JsonConverter<T>
+        {
+            public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => default;
+
+            public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value?.ToString() ?? string.Empty);
+            }
+        }
+    }
+
+    private static double ToDouble(object? value)
+    {
+        return value switch
+        {
+            null => 0d,
+            double d => d,
+            float f => f,
+            long l => l,
+            int i => i,
+            _ => Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture),
+        };
+    }
+}

--- a/tests/LoadTests/Compendium.LoadTests/Support/LoadTestEvent.cs
+++ b/tests/LoadTests/Compendium.LoadTests/Support/LoadTestEvent.cs
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------
+// <copyright file="LoadTestEvent.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Core.Domain.Events;
+
+namespace Compendium.LoadTests.Support;
+
+/// <summary>
+/// Minimal domain event used as payload across all load-test scenarios.
+/// Kept stable so registry / deserializer setup is identical between scenarios.
+/// </summary>
+public sealed record LoadTestEvent : IDomainEvent
+{
+    /// <inheritdoc />
+    public required Guid EventId { get; init; }
+
+    /// <inheritdoc />
+    public required string AggregateId { get; init; }
+
+    /// <inheritdoc />
+    public required string AggregateType { get; init; }
+
+    /// <inheritdoc />
+    public required DateTimeOffset OccurredOn { get; init; }
+
+    /// <inheritdoc />
+    public required long AggregateVersion { get; init; }
+
+    /// <inheritdoc />
+    public int EventVersion { get; init; } = 1;
+
+    /// <summary>
+    /// Inline payload used to give each event a non-trivial size, similar to
+    /// what a real domain event would carry.
+    /// </summary>
+    public required string Payload { get; init; }
+
+    /// <summary>
+    /// Builds a single deterministic event for a given aggregate / version slot.
+    /// </summary>
+    public static LoadTestEvent Create(string aggregateId, long version)
+    {
+        return new LoadTestEvent
+        {
+            EventId = Guid.NewGuid(),
+            AggregateId = aggregateId,
+            AggregateType = "LoadTestAggregate",
+            OccurredOn = DateTimeOffset.UtcNow,
+            AggregateVersion = version,
+            Payload = $"payload-{version}-{Guid.NewGuid():N}",
+        };
+    }
+
+    /// <summary>
+    /// Builds a contiguous batch of events for an aggregate, starting at version 1.
+    /// </summary>
+    public static List<IDomainEvent> Batch(string aggregateId, int count, long startVersion = 1)
+    {
+        var list = new List<IDomainEvent>(count);
+        for (var i = 0; i < count; i++)
+        {
+            list.Add(Create(aggregateId, startVersion + i));
+        }
+
+        return list;
+    }
+}

--- a/tests/LoadTests/Compendium.LoadTests/Support/ScenarioContext.cs
+++ b/tests/LoadTests/Compendium.LoadTests/Support/ScenarioContext.cs
@@ -1,0 +1,145 @@
+// -----------------------------------------------------------------------
+// <copyright file="ScenarioContext.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.LoadTests.Support;
+
+/// <summary>
+/// Simple value object carrying the user-supplied knobs that every scenario
+/// can react to. Parsed once in <see cref="ArgsParser"/>.
+/// </summary>
+public sealed record ScenarioOptions
+{
+    /// <summary>
+    /// The name of the scenario the user asked to run (lower-case, hyphenated).
+    /// </summary>
+    public required string Scenario { get; init; }
+
+    /// <summary>
+    /// Total duration of the scenario. Defaults to a short value so the suite
+    /// is runnable locally without a long wait. Override with <c>--duration</c>.
+    /// </summary>
+    public TimeSpan Duration { get; init; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Output folder for NBomber reports and the JSON summary file.
+    /// </summary>
+    public string ArtifactsFolder { get; init; } = Path.Combine("artifacts", "load");
+
+    /// <summary>
+    /// When true, the scenario tries to execute a single warm-up iteration
+    /// before NBomber starts collecting stats. Always true unless the caller
+    /// passes <c>--no-warmup</c>.
+    /// </summary>
+    public bool Warmup { get; init; } = true;
+}
+
+/// <summary>
+/// Tiny argv parser tailored to the small set of flags used by the load
+/// tests. Avoids pulling in a full CLI library for a single executable.
+/// </summary>
+public static class ArgsParser
+{
+    /// <summary>
+    /// Parses the argv array passed to <c>Main</c>. Returns <c>null</c> when
+    /// the user asked for help or supplied an unknown shape (the dispatcher
+    /// will print usage and exit gracefully).
+    /// </summary>
+    public static ScenarioOptions? Parse(string[] args)
+    {
+        if (args is null || args.Length == 0)
+        {
+            return null;
+        }
+
+        if (args.Any(a => a is "-h" or "--help"))
+        {
+            return null;
+        }
+
+        string? scenario = null;
+        var duration = TimeSpan.FromSeconds(15);
+        var artifacts = Path.Combine("artifacts", "load");
+        var warmup = true;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--scenario" when i + 1 < args.Length:
+                    scenario = args[++i].Trim().ToLowerInvariant();
+                    break;
+                case "--duration" when i + 1 < args.Length:
+                    if (TryParseDuration(args[++i], out var d))
+                    {
+                        duration = d;
+                    }
+                    break;
+                case "--artifacts" when i + 1 < args.Length:
+                    artifacts = args[++i];
+                    break;
+                case "--no-warmup":
+                    warmup = false;
+                    break;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(scenario))
+        {
+            return null;
+        }
+
+        return new ScenarioOptions
+        {
+            Scenario = scenario,
+            Duration = duration,
+            ArtifactsFolder = artifacts,
+            Warmup = warmup,
+        };
+    }
+
+    /// <summary>
+    /// Parses a duration of the form <c>30s</c>, <c>2m</c>, <c>500ms</c> or a
+    /// plain integer (interpreted as seconds).
+    /// </summary>
+    private static bool TryParseDuration(string raw, out TimeSpan value)
+    {
+        value = TimeSpan.Zero;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        var trimmed = raw.Trim().ToLowerInvariant();
+
+        if (trimmed.EndsWith("ms", StringComparison.Ordinal) &&
+            int.TryParse(trimmed[..^2], out var ms))
+        {
+            value = TimeSpan.FromMilliseconds(ms);
+            return true;
+        }
+
+        if (trimmed.EndsWith('s') && int.TryParse(trimmed[..^1], out var s))
+        {
+            value = TimeSpan.FromSeconds(s);
+            return true;
+        }
+
+        if (trimmed.EndsWith('m') && int.TryParse(trimmed[..^1], out var m))
+        {
+            value = TimeSpan.FromMinutes(m);
+            return true;
+        }
+
+        if (int.TryParse(trimmed, out var seconds))
+        {
+            value = TimeSpan.FromSeconds(seconds);
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Adds four NBomber 6.0 load scenarios to `tests/LoadTests/Compendium.LoadTests`. All run against the in-memory implementations of the framework's hot-path abstractions, so the suite is runnable locally with a single `dotnet run` (no Postgres, no Redis, no network).

These scenarios are **informational only** — they are not gated in CI (`.github/workflows/ci.yml` already excludes `LoadTests` from the unit-test filter) and they do not gate merges. Part of the testing campaign tracked in **VK POM-480**.

## Scenarios

Measured dev-box baselines (Apple M-series, .NET 9, Release, 10&#8202;s run, in-memory only):

| Scenario      | What it measures                                                       | Throughput      | Latency (mean / p99) |
|---------------|------------------------------------------------------------------------|-----------------|----------------------|
| `eventstore`  | `IEventStore.AppendEventsAsync` (10-event batches, in-memory store)    | ~60k ops/s &rarr; ~600k events/s | 1 ms / 15 ms         |
| `projection`  | `ProjectionManager.RebuildProjectionAsync` (5000-event replay)         | ~290 rebuilds/s &rarr; ~1.5M events/s | 3 ms / 5 ms |
| `idempotency` | `IIdempotencyStore.ExistsAsync` + `SetAsync` (80 / 20 mix, 64 copies)  | ~1.3M ops/s     | 30 &micro;s / 2.5 ms |
| `tenant`      | `CompositeTenantResolver` (header &rarr; host chain, hits + misses)    | ~2.9M res/s     | 50 &micro;s / 9 ms   |

## How to run

```bash
dotnet run --project tests/LoadTests/Compendium.LoadTests -c Release -- \
    --scenario <name> [--duration 30s] [--artifacts artifacts/load] [--no-warmup]
```

Each run writes:

- `<artifacts>/<scenario>-report.{html,csv,md,txt}` &mdash; NBomber native reports
- `<artifacts>/<scenario>.json` &mdash; machine-readable summary (this PR's writer)

See [`docs/testing/load-tests.md`](docs/testing/load-tests.md) for the full reference.

## What changed

- Restructured the existing PostgreSQL-coupled placeholder Program into a scenario dispatcher (`--scenario` arg).
- Removed the `Testcontainers.PostgreSql` and `Compendium.Adapters.PostgreSQL` references &mdash; not needed for the in-memory scenarios; kept `NBomber` and `NBomber.Http` (already centrally managed in `Directory.Packages.props`, no version bumps).
- Added `Compendium.Application` and `Compendium.Multitenancy` project references for the idempotency / tenant scenarios.
- Added a `JsonSummaryWriter` that walks NBomber's `NodeStats` via reflection and neutralises the F#-DU `NodeType` field that breaks raw `System.Text.Json` serialisation.
- Added `docs/testing/load-tests.md` describing each scenario, the metric it measures, and the observed dev-box baselines.

## Test plan

- [x] `dotnet build Compendium.sln -c Release` &mdash; green (0 errors, warnings only on pre-existing CS1591 docs).
- [x] All four scenarios smoke-run end-to-end (`--duration 5s --no-warmup` and `--duration 10s` with warm-up); each produces native reports + JSON summary.
- [x] Unit tests still pass (`dotnet test` with the existing CI filter): all assemblies green.
- [x] No production code modified.
- [x] No version bumps in `Directory.Packages.props`.
- [ ] CI green (load tests excluded from CI test filter; build of the solution still includes the project).