### PR TITLE
docs(adr): ADR-0006 multi-repo adapter split + adapter template scaffold

### DIFF
--- a/docs/adr/0006-multi-repo-adapter-split.md
+++ b/docs/adr/0006-multi-repo-adapter-split.md
@@ -1,0 +1,117 @@
+# 0006. Split heavy adapters into per-adapter repositories
+
+* Status: Proposed
+* Date: 2026-05-10
+* Deciders: @sassy-solutions/maintainers
+
+## Context
+
+Compendium ships seven "heavy" adapters today, all living in the framework monorepo :
+
+| Adapter | LOC | External SDK | Release driver |
+|---|---|---|---|
+| `Compendium.Adapters.PostgreSQL` | 3 692 | Npgsql | own pace |
+| `Compendium.Adapters.Zitadel` | 3 752 | (HTTP) | Zitadel API churn |
+| `Compendium.Adapters.LemonSqueezy` | 2 826 | (HTTP) | LS API churn |
+| `Compendium.Adapters.Listmonk` | 1 546 | (HTTP) | Listmonk API churn |
+| `Compendium.Adapters.Stripe` | 1 052 | Stripe.NET | Stripe.NET releases (~weekly) |
+| `Compendium.Adapters.OpenRouter` | 935 | (HTTP) | OpenRouter API churn |
+| `Compendium.Adapters.Redis` | 816 | StackExchange.Redis | own pace |
+
+Plus two thin glue adapters that have no external SDK and tightly track the framework :
+
+| Adapter | LOC | What |
+|---|---|---|
+| `Compendium.Adapters.AspNetCore` | 1 121 | middleware, ProblemDetails mappers, DI helpers |
+| `Compendium.Adapters.Shared` | 30 | log-redaction helpers, etc. |
+
+This shape has accumulated three frictions :
+
+1. **Coverage measurement is dragged down by the integration-bound adapters.** After the May 2026 unit-coverage campaign every project sits ≥ 90 % except `Compendium.Adapters.PostgreSQL` (36 % — its DB-bound types are by design covered only by Docker integration tests, not unit). The aggregate global is pulled to 88.4 %, which makes a clean "≥ 90 %" CI gate impossible without per-project rules. See [the testing campaign log](../testing/coverage-campaign-2026-05.md).
+2. **External SDK churn forces framework releases.** A weekly `Stripe.NET` patch bump bubbles up as a Compendium NuGet release ; consumers of the framework who don't care about Stripe still have to absorb it.
+3. **Cross-cutting test boundaries.** Integration tests for `PostgreSQL` (Testcontainers + Postgres images), `Redis`, `Zitadel` (HTTP fixtures) all sit in the framework's `tests/Integration` and slow / complicate the framework CI.
+
+We need a structure that decouples the framework's release cadence from the long tail of vendor-specific code without sacrificing the strict hexagonal layering decided in [ADR 0002](0002-hexagonal-architecture.md).
+
+## Decision
+
+Split the seven heavy adapters into **one repository per adapter**, leaving the thin glue adapters in the framework monorepo.
+
+### Scope of the split
+
+**Extracted (one repo each, named `compendium-adapter-<vendor>`)** :
+
+- `compendium-adapter-postgresql`
+- `compendium-adapter-zitadel`
+- `compendium-adapter-lemonsqueezy`
+- `compendium-adapter-listmonk`
+- `compendium-adapter-stripe`
+- `compendium-adapter-openrouter`
+- `compendium-adapter-redis`
+
+**Stays in `compendium`** :
+
+- `Compendium.Core`, `Compendium.Application`, `Compendium.Abstractions.*`, `Compendium.Infrastructure`, `Compendium.Multitenancy`, `Compendium.Testing`
+- `Compendium.Adapters.AspNetCore` — no external SDK, evolves lock-step with `Compendium.Application`.
+- `Compendium.Adapters.Shared` — 30 LOC of cross-adapter helpers ; promote to a small `Compendium.Adapters.Common` NuGet *only when a second consumer needs it*.
+
+### Per-adapter repository contract
+
+Each extracted adapter repo :
+
+1. Depends on the published `Compendium.Abstractions.*` NuGet (whichever ports it implements).
+2. Ships its own NuGet : `Compendium.Adapters.<Vendor>` and `Compendium.Adapters.<Vendor>.Tests` is internal.
+3. Owns its **own integration tests** (Testcontainers, vendor sandboxes) so the framework CI no longer carries Docker images for `pg` / `redis`.
+4. Sets a **CI line-coverage gate of 90 %** on the unit-testable surface ; types that genuinely require a live external system are covered by integration tests in the same repo.
+5. Follows the **same testing conventions** as the framework (xUnit 2.9, FluentAssertions 6.12, NSubstitute 5.1, AAA explicit comments, Result-pattern assertions, `IAsyncLifetime` fixtures, no Moq / no `Assert.*` / no `Thread.Sleep`). Codified in the `compendium-test-author` skill, which the template ships with.
+6. Tracks the framework via [Renovate](https://docs.renovatebot.com/) ; a Compendium release auto-opens a PR in every adapter repo within 24 h ; the adapter repo's CI must stay green or the PR blocks.
+
+A starter template lives at `templates/adapter-dotnet/` in this repository (see PR opening this ADR). It is the canonical seed for a new adapter repo : copy, rename `<Vendor>`, push to a fresh GitHub repo, set up NuGet publishing.
+
+### Migration order (suggestion, not binding)
+
+1. **Compendium.Adapters.Stripe** first — heaviest external-SDK churn, smallest domain footprint, validates the workflow.
+2. **Compendium.Adapters.PostgreSQL** — biggest coverage win on the framework side ; once extracted, the framework's global line coverage rises from 88.4 % to ~95 %, making a strict 90 % gate possible.
+3. **Compendium.Adapters.Redis** — small, integration-bound, similar shape to PG.
+4. The remaining four (`Zitadel`, `LemonSqueezy`, `Listmonk`, `OpenRouter`) follow once the workflow is proven.
+
+Each migration is its own PR pair (one in `compendium` removing the project, one in the new repo bringing it in with full history via `git filter-repo`).
+
+## Consequences
+
+### Positive
+
+- **Independent release cadence per adapter.** A Stripe.NET bump no longer triggers a framework release.
+- **Coverage gate becomes clean.** Once PostgreSQL leaves, framework global goes from 88.4 % → ~95 %, and a strict per-project ≥ 90 % gate is achievable without exemptions.
+- **Smaller, vendor-focused PRs.** Reviewers don't need to context-switch between framework internals and `Stripe.WebhookSignature` minutiae.
+- **CI cost.** Framework CI no longer pulls Postgres / Redis images — faster pipelines, less GitHub Actions minutes.
+- **Discoverability.** Each adapter repo has its own README, examples, support contract.
+- **Open-source contribution surface.** Easier for outside contributors to focus on one vendor.
+
+### Negative / Trade-offs
+
+- **Cross-cutting changes to abstractions multiply in cost.** A modification to `IEventStore` or `IDomainEvent` in `Compendium.Abstractions` becomes N PRs (one per adapter repo) instead of one. Mitigated by :
+  - **Strict semver discipline** on `Compendium.Abstractions.*` — breaking changes trigger major-version bumps and are batched.
+  - **Renovate auto-PR** to every adapter repo on every Compendium release ; review burden distributed but mechanical.
+  - A "release train" pattern : Compendium ships, adapters auto-PR within 24 h, central dashboard tracks who's behind.
+- **Local-dev experience worsens** for someone modifying both framework and adapter at once. Mitigated by a `dotnet add reference` "linked-mode" documented in the template README — point the adapter project at a local `Compendium.Abstractions.csproj` instead of the NuGet during local hacking.
+- **Repo proliferation.** Eight repos to maintain instead of one. Each gets its own Dependabot, Renovate, branch protection, secrets, NuGet publishing token. Mitigated by the template baking all of this in.
+- **Documentation is now distributed.** A user looking at "what does Compendium support?" has to crawl multiple READMEs. Mitigated by an adapter index page on the framework's `docs/adapters/`.
+- **Migration cost.** Each extraction is at least a half-day of work : history transplant, NuGet pipeline, branch protection, Dependabot, Renovate, badges, README, sample. We pay this once per adapter and never again.
+
+## Alternatives considered
+
+- **Status quo : keep the monorepo.** Rejected — the three frictions above (coverage gate impossible, framework releases coupled to vendor SDK churn, slow CI) are a permanent tax that compounds with every adapter we add.
+- **Multi-package repository (one repo, many NuGets, separate release lines).** Rejected — possible with paths-filter on Actions and per-project versioning, but it doesn't address the CI-time cost of Docker images, doesn't simplify ownership / contribution, and still ties every release to the same git history. Worth it only if we expected ≤ 2 adapters.
+- **Plugin-style runtime discovery** (adapters loaded at runtime via assembly probing). Rejected — adds a layer of indirection nobody asked for, breaks AOT publishing, and doesn't solve the source-organisation question.
+- **Submodules** (one repo, adapters pulled as git submodules). Rejected — submodules are notoriously painful for contributors, don't help CI parallelism, and confuse most modern tooling (Renovate, GitHub Search, code navigation in IDEs).
+
+## How to use the template
+
+See [`templates/adapter-dotnet/README.md`](../../templates/adapter-dotnet/README.md). Roughly :
+
+1. `cp -r templates/adapter-dotnet ../compendium-adapter-<vendor>`
+2. Find-and-replace `Sample` / `<Vendor>` placeholders.
+3. `git init`, push to `sassy-solutions/compendium-adapter-<vendor>`.
+4. Configure NuGet publishing secrets, branch protection.
+5. Open a follow-up PR in `compendium` removing `src/Adapters/Compendium.Adapters.<Vendor>` and pointing consumers at the new NuGet.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,7 @@ ADRs document the structural choices of Compendium. Format: [MADR](https://adr.g
 | 0003 | [Zero-dependency Core](0003-zero-dep-core.md) | Accepted | 2026-Q2 |
 | 0004 | [Multi-tenancy strategy](0004-multi-tenancy-strategy.md) | Accepted | 2026-Q2 |
 | 0005 | [Event sourcing over state-stored](0005-event-sourcing-vs-state.md) | Accepted | 2026-Q2 |
+| 0006 | [Split heavy adapters into per-adapter repositories](0006-multi-repo-adapter-split.md) | Proposed | 2026-Q2 |
 
 ## Process
 - Propose new ADR via PR with status `Proposed`

--- a/docs/adr/toc.yml
+++ b/docs/adr/toc.yml
@@ -10,5 +10,7 @@
   href: 0004-multi-tenancy-strategy.md
 - name: 0005 — Event sourcing
   href: 0005-event-sourcing-vs-state.md
+- name: 0006 — Multi-repo adapter split
+  href: 0006-multi-repo-adapter-split.md
 - name: Template
   href: 0000-template.md

--- a/templates/adapter-dotnet/.claude/commands/tests.md
+++ b/templates/adapter-dotnet/.claude/commands/tests.md
@@ -1,0 +1,49 @@
+---
+description: Write tests for the current branch's changes (or for a named project) using the Compendium test conventions.
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, Agent
+argument-hint: [--project <Name>] [--coverage] [--integration]
+---
+
+# /tests
+
+Launches a test-author agent that loads the **`compendium-test-author`** skill (`compendium/.claude/skills/compendium-test-author/SKILL.md`) and writes tests for the current branch — or for a named project.
+
+## Behaviour
+
+Inputs `$ARGUMENTS` (parse loosely):
+- `--project <Name>` → restrict scope to `src/.../{Name}/` and `tests/Unit/{Name}.Tests/`. Skip git diff.
+- `--coverage` → also run `/coverage` (or invoke ReportGenerator) at the end and append the report to the agent's final message.
+- `--integration` → additionally write/update tests under `tests/Integration/Compendium.IntegrationTests/` for the same scope.
+
+Default (no flags) = scope to the diff between `HEAD` and `$(git merge-base HEAD main)`.
+
+## What the agent does
+
+1. Resolve scope (project name or `git diff` set of `src/**/*.cs`).
+2. Load the `compendium-test-author` skill and follow its **Process** section literally.
+3. For each type in scope, add tests covering happy path + every branch + every `Result.Failure` + edge cases + (if multi-tenant) tenant-isolation + (if async with `CancellationToken`) cancellation.
+4. Run `dotnet test tests/Unit/{Project}.Tests -c Release` until green.
+5. If `--coverage` : run coverlet + ReportGenerator, attach summary.
+6. If `--integration` : also generate integration tests using `IAsyncLifetime` + existing fixtures (`PostgreSqlFixture`, `RedisFixture`, `RequiresDockerFactAttribute`).
+7. **Never** modify production code. If a real bug surfaces, emit `BUG_FOUND: ...` and stop.
+8. End with the coverage report block defined in the skill.
+
+## Constraints
+
+- Conventions are **non-negotiable** — see the skill's "Hard constraints" section.
+- Any branch created here is named `feat/tests-{project-slug}` (or `feat/tests-{branch-name}` if scoped to a diff).
+- Commit message format: `test({project}): add unit tests covering {area}`.
+- No package version bumps. No new top-level dependency. No `--no-verify`.
+
+## Examples
+
+```
+/tests
+/tests --project Compendium.Application
+/tests --project Compendium.Adapters.Redis --coverage
+/tests --integration
+```
+
+## Implementation note
+
+This command is meant to be invoked as a slash command. The harness expands `$ARGUMENTS`, then the model spawns a subagent (general-purpose) with the skill loaded and the resolved scope.

--- a/templates/adapter-dotnet/.claude/skills/compendium-test-author/SKILL.md
+++ b/templates/adapter-dotnet/.claude/skills/compendium-test-author/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: compendium-test-author
+description: Use when adding or repairing tests inside the Compendium event-sourcing framework — anywhere under tests/Unit, tests/Integration, or tests/Architecture. Triggers on "/tests", "écris les tests pour ...", "add unit tests", "test the changes", "amène <project> à 90%". Encodes xUnit 2.9.3 + FluentAssertions 6.12 + NSubstitute 5.1 + AutoFixture + Bogus, IAsyncLifetime fixtures, Result-pattern assertions, and Compendium-specific patterns (CQRS, ES, hexagonal, multi-tenant, idempotency).
+type: skill
+---
+
+# compendium-test-author
+
+You are an expert test author for the **Compendium** event-sourcing framework (.NET 9, hexagonal, CQRS+ES, multi-tenant). When this skill is loaded, follow the rules below **literally** — they are not suggestions, they are how every existing test in this repo is written.
+
+## When to invoke
+
+- A `/tests` command was issued (project-level command in `.claude/commands/tests.md`).
+- The user asks for tests on a specific change, file, project, or coverage gap.
+- A VK issue body references this skill.
+- You are told to "bring `Compendium.Xxx` to ≥ 90 % coverage".
+
+## Stack — versions are locked, never bump them in a test PR
+
+Read from `Directory.Packages.props`:
+
+| Package | Version | Use |
+|---|---|---|
+| `xunit` | 2.9.3 | Test runner |
+| `xunit.runner.visualstudio` | 3.1.5 | VS adapter |
+| `Microsoft.NET.Test.Sdk` | 18.4.0 | Test SDK |
+| `FluentAssertions` | 6.12.1 | **Assertions — always** |
+| `NSubstitute` | 5.1.0 | **Mocks — preferred** |
+| `Moq` | 4.20.72 | Available but **don't use it** in new tests |
+| `AutoFixture` | 4.18.1 | Auto-generated fixtures |
+| `AutoFixture.Xunit2` | 4.18.1 | `[AutoData]` / `[InlineAutoData]` |
+| `Bogus` | 35.6.1 | Domain-realistic fake data |
+| `coverlet.collector` | 6.0.2 | Coverage |
+| `Testcontainers.PostgreSql` | 4.11.0 | Integration only |
+| `Testcontainers.Redis` | 4.11.0 | Integration only |
+| `RichardSzalay.MockHttp` | 7.0.0 | HTTP mocking for adapter tests |
+
+## Conventions — follow exactly
+
+### File header
+
+Every test file starts with the same copyright block as the rest of the repo (see any file under `tests/Unit/`):
+
+```csharp
+// -----------------------------------------------------------------------
+// <copyright file="{TestFile}.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+```
+
+### Naming
+
+- **Class** : `{SubjectUnderTest}Tests` (e.g. `TenantContextAccessorTests`, `AIErrorsTests`).
+- **Method** : `{MethodOrSubject}_{Scenario}_{ExpectedBehavior}` — read like a sentence.
+  - ✅ `TenantContextAccessor_SetTenant_UpdatesTenantContext`
+  - ✅ `Dispatch_WhenHandlerThrows_ReturnsFailureResult`
+  - ❌ `TestSetTenant`, `Test1`, `Should_work`
+
+### AAA — explicit comments
+
+```csharp
+[Fact]
+public void TenantContextAccessor_SetTenant_UpdatesTenantContext()
+{
+    // Arrange
+    var accessor = new TenantContextAccessor();
+    var tenant = new TenantInfo { Id = "tenant-123", Name = "Test Tenant" };
+
+    // Act
+    accessor.SetTenant(tenant);
+
+    // Assert
+    accessor.TenantContext.HasTenant.Should().BeTrue();
+    accessor.TenantContext.CurrentTenant!.Id.Should().Be("tenant-123");
+}
+```
+
+The `// Arrange / // Act / // Assert` comments are **required** (every existing test in the repo has them).
+
+### Mocking — NSubstitute only
+
+```csharp
+private readonly ITenantContextAccessor _accessor = Substitute.For<ITenantContextAccessor>();
+private readonly ILogger<TenantService> _logger = Substitute.For<ILogger<TenantService>>();
+
+// Setup
+_accessor.TenantContext.Returns(new TenantContext("tenant-1", "Acme"));
+
+// Verify
+_logger.Received(1).LogInformation(Arg.Any<string>());
+```
+
+### Async
+
+- Always `async Task` (never `async void`, never `.Result`, never `.GetAwaiter().GetResult()`).
+- Cancellation tokens: when the SUT takes one, pass `CancellationToken.None` unless the test needs to control cancellation; in that case, create a `CancellationTokenSource` in the test setup and pass its token.
+
+### Theory / data-driven
+
+Prefer when 2+ similar cases differ only by inputs:
+
+```csharp
+[Theory]
+[InlineData("", false)]
+[InlineData("   ", false)]
+[InlineData("tenant-1", true)]
+public void TenantInfo_HasValidId_ReturnsExpected(string id, bool expected)
+{
+    // Arrange / Act
+    var actual = TenantInfo.IsValidId(id);
+
+    // Assert
+    actual.Should().Be(expected);
+}
+```
+
+For complex objects, use `[ClassData]` / `[MemberData]` rather than huge `[InlineData]`.
+
+## Compendium-specific patterns
+
+### Result pattern
+
+The codebase uses `Result<T>` / `Result` (no exceptions for control flow). Test it like this:
+
+```csharp
+result.IsSuccess.Should().BeTrue();
+result.Value.Should().Be(expected);
+
+// or for failure
+result.IsFailure.Should().BeTrue();
+result.Error.Code.Should().Be("tenant.not_found");
+result.Error.Message.Should().Contain("tenant-xyz");
+```
+
+**Never** wrap SUT calls in `try/catch` — if the method throws unexpectedly, let xUnit fail.
+
+### Aggregates (event-sourced)
+
+Test by event-replay then state assertion:
+
+```csharp
+// Arrange
+var aggregate = OrderAggregate.Create(orderId, customerId);
+
+// Act
+aggregate.AddLine(new OrderLine(...));
+aggregate.Place();
+
+// Assert state
+aggregate.Status.Should().Be(OrderStatus.Placed);
+// Assert events emitted
+aggregate.UncommittedEvents.Should().HaveCount(3);
+aggregate.UncommittedEvents[0].Should().BeOfType<OrderCreatedEvent>();
+```
+
+### Tenant isolation
+
+Every adapter / projection / store touched by multi-tenancy must have a test proving it does NOT leak across tenants:
+
+```csharp
+[Fact]
+public async Task Find_WhenTenantMismatch_ReturnsNotFound()
+{
+    // Arrange
+    var entity = await _store.SaveAsync(new Entity("a"), tenantId: "t-1", ct);
+
+    // Act
+    var result = await _store.FindAsync(entity.Id, tenantId: "t-2", ct);
+
+    // Assert
+    result.IsSuccess.Should().BeFalse();
+    result.Error.Code.Should().Be("not_found");
+}
+```
+
+### Idempotency
+
+```csharp
+[Fact]
+public async Task Handle_WhenSameIdempotencyKeyTwice_ProducesSameResult()
+{
+    // Arrange
+    var cmd = new CreateOrderCommand(...) { IdempotencyKey = "key-1" };
+
+    // Act
+    var first = await _handler.Handle(cmd, ct);
+    var second = await _handler.Handle(cmd, ct);
+
+    // Assert
+    first.IsSuccess.Should().BeTrue();
+    second.IsSuccess.Should().BeTrue();
+    first.Value.OrderId.Should().Be(second.Value.OrderId);
+    _eventStore.Received(1).AppendAsync(Arg.Any<OrderCreatedEvent>(), ct);
+}
+```
+
+### CQRS pipeline
+
+Commands → events → projections → DTOs. Each stage is unit-testable in isolation; reserve cross-stage tests for `tests/Integration/`.
+
+## Integration test patterns (tests/Integration/)
+
+Reuse existing fixtures — **don't reinvent**.
+
+- **Postgres** : `tests/Integration/Compendium.IntegrationTests/Fixtures/PostgreSqlFixture.cs:21-112` — implements `IAsyncLifetime`, falls back from env conn-string to Testcontainers.
+- **Redis** : `tests/Integration/Compendium.IntegrationTests/Fixtures/RedisFixture.cs:19-132` — same pattern.
+- **Docker skip** : decorate with `[RequiresDockerFact]` instead of `[Fact]` (auto-skips when Docker is absent).
+- **DO NOT** use `ICollectionFixture` — the repo doesn't, fixtures are per-class via `IAsyncLifetime`.
+- Cleanup goes in `DisposeAsync()`.
+
+## Test helpers (already public, reuse them)
+
+- `src/Testing/Compendium.Testing/InMemoryTestStore.cs:23-63` — generic in-memory store, perfect for idempotency tests.
+- `src/Testing/Compendium.Testing/ApplicationTestHelpers.cs:8-18` — `services.AddTestApplication()` configures a minimal CQRS app for unit tests.
+
+## Process to follow on every invocation
+
+1. **Scope**
+   - If invoked with `--project X` → focus only on `src/.../X/` and `tests/Unit/X.Tests/`.
+   - Otherwise : `git diff $(git merge-base HEAD main)..HEAD --name-only -- 'src/**/*.cs'` → list types touched on the current branch.
+2. **Locate or create** the matching test project under `tests/Unit/{Project}.Tests/`. If absent : copy the closest existing `.csproj` (e.g. `Compendium.Multitenancy.Tests.csproj`) as template, adjust references, add to `Compendium.sln`.
+3. **For every public type / method in scope**, write tests covering:
+   - Happy path
+   - Each branch of `if`, `switch`, `?:`, pattern matches
+   - Each `Result.Failure(...)` return point
+   - Boundary cases : null, empty, whitespace, max-length, concurrent access if relevant
+   - Cancellation behaviour for async methods that accept `CancellationToken`
+   - Tenant isolation if the type is tenant-scoped
+4. **Run** : `dotnet test tests/Unit/{Project}.Tests --collect:"XPlat Code Coverage"` — iterate until green.
+5. **Measure** : run ReportGenerator on the cobertura output (or use `/coverage`). If line coverage < 90 %, add tests for the uncovered lines.
+6. **Stop** : do **not** modify production code. If a test reveals a real bug, halt and emit literally:
+   ```
+   BUG_FOUND: <one-line description>
+   FILE: <src/.../File.cs:line>
+   REPRO: <minimum failing assertion or input>
+   ```
+   Then exit. The orchestrator will create a VK bug ticket and route to a fix-only agent.
+
+## Hard constraints (interdictions)
+
+- ❌ **No Moq** — NSubstitute only, even though Moq is referenced.
+- ❌ **No `Assert.*` xUnit calls** — FluentAssertions exclusively.
+- ❌ **No real DB / Redis / network** in `tests/Unit/` — those belong in `tests/Integration/`.
+- ❌ **No `Thread.Sleep`** — use `await Task.Delay(...)` or inject an `ITimeProvider` mock.
+- ❌ **No order-dependent tests** — every test must pass in isolation and in any order.
+- ❌ **No silent file/console mutation** — clean up everything created in `Dispose` / `DisposeAsync`.
+- ❌ **No production-code change** in a test PR (sole exception : a typo in a string literal asserted by the new test).
+- ❌ **No `--no-verify`, no `--force-push`, no commit-amending** of pushed history.
+- ❌ **No version bumps** in `Directory.Packages.props` from a test PR.
+- ❌ **No new top-level dependency** unless approved by the orchestrator (NSubstitute / FluentAssertions / xUnit are already centrally managed).
+
+## Output format when done
+
+End the run with a short report:
+
+```markdown
+## Coverage report — {Project}
+- Tests added: {N}
+- Test files added/modified: {list}
+- Line coverage: {before}% → {after}%
+- Branch coverage: {before}% → {after}%
+- Uncovered hotspots remaining: {list with file:line}
+- Bugs surfaced: {0 or list of BUG_FOUND}
+- Build/test command : `dotnet test tests/Unit/{Project}.Tests`
+```
+
+## Quality gate before marking done
+
+- [ ] `dotnet build Compendium.sln -c Release` is green.
+- [ ] `dotnet test tests/Unit/{Project}.Tests -c Release` is green.
+- [ ] Line coverage of the SUT project ≥ 90 % (or documented exemption).
+- [ ] No flaky test (run twice, same result).
+- [ ] No `Moq`, no `Assert.*`, no `Thread.Sleep` introduced (grep before commit).
+- [ ] Branch is `feat/tests-{project-slug}`, commit is conventional (`test({project}): add unit tests for X`).
+- [ ] PR body includes the coverage report block above.

--- a/templates/adapter-dotnet/.config/dotnet-tools.json
+++ b/templates/adapter-dotnet/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.4.4",
+      "commands": [
+        "reportgenerator"
+      ]
+    }
+  }
+}

--- a/templates/adapter-dotnet/.github/workflows/ci.yml
+++ b/templates/adapter-dotnet/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore
+
+      - name: Test (with coverage)
+        run: |
+          dotnet test -c Release --no-build \
+            --filter "FullyQualifiedName!~IntegrationTests" \
+            --logger "trx;LogFileName=test-results.trx" \
+            --results-directory TestResults/ \
+            --collect:"XPlat Code Coverage"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults/
+          retention-days: 14
+
+      - name: Coverage report + 90% gate
+        run: |
+          dotnet tool restore
+          dotnet tool run reportgenerator \
+            -reports:'TestResults/**/coverage.cobertura.xml' \
+            -targetdir:coverage-report \
+            -reporttypes:'TextSummary;MarkdownSummary'
+          cat coverage-report/Summary.txt
+          # Fail if line coverage < 90% on the unit-testable surface.
+          # Override per-class via [ExcludeFromCodeCoverage] when the class
+          # genuinely requires integration tests (e.g. raw DB drivers).
+          line_pct=$(grep -E '^Line coverage' coverage-report/Summary.txt | awk '{print $3}' | tr -d '%')
+          echo "Line coverage: ${line_pct}%"
+          awk -v c="$line_pct" 'BEGIN { exit (c+0 >= 90) ? 0 : 1 }'
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage-report/
+          retention-days: 14

--- a/templates/adapter-dotnet/.gitignore
+++ b/templates/adapter-dotnet/.gitignore
@@ -1,0 +1,27 @@
+# .NET
+bin/
+obj/
+*.user
+*.suo
+.vs/
+*.userosscache
+*.sln.docstates
+TestResults/
+coverage.*
+artifacts/
+
+# Rider / VS / VS Code
+.idea/
+.vscode/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# NuGet
+*.nupkg
+*.snupkg
+.nuget/
+packages/
+
+# Local secrets / dotnet user-secrets are tied to a guid — no need to ignore

--- a/templates/adapter-dotnet/Compendium.Adapters.Sample.sln
+++ b/templates/adapter-dotnet/Compendium.Adapters.Sample.sln
@@ -1,0 +1,32 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D6C5C0A8-4A5A-4A5A-9C4A-1F4A4F4F4F01}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{D6C5C0A8-4A5A-4A5A-9C4A-1F4A4F4F4F02}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.Sample", "src\Compendium.Adapters.Sample\Compendium.Adapters.Sample.csproj", "{A1A1A1A1-0000-0000-0000-000000000001}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.Sample.Tests", "tests\Unit\Compendium.Adapters.Sample.Tests\Compendium.Adapters.Sample.Tests.csproj", "{A1A1A1A1-0000-0000-0000-000000000002}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1A1A1A1-0000-0000-0000-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1A1A1A1-0000-0000-0000-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1A1A1A1-0000-0000-0000-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1A1A1A1-0000-0000-0000-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1A1A1A1-0000-0000-0000-000000000002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1A1A1A1-0000-0000-0000-000000000002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1A1A1A1-0000-0000-0000-000000000002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1A1A1A1-0000-0000-0000-000000000002}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{A1A1A1A1-0000-0000-0000-000000000001} = {D6C5C0A8-4A5A-4A5A-9C4A-1F4A4F4F4F01}
+		{A1A1A1A1-0000-0000-0000-000000000002} = {D6C5C0A8-4A5A-4A5A-9C4A-1F4A4F4F4F02}
+	EndGlobalSection
+EndGlobal

--- a/templates/adapter-dotnet/Directory.Build.props
+++ b/templates/adapter-dotnet/Directory.Build.props
@@ -1,0 +1,29 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>13</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- NuGet metadata defaults — override per project as needed -->
+    <Authors>Sassy Solutions</Authors>
+    <Company>Sassy Solutions</Company>
+    <Copyright>Copyright (c) 2026 Sassy Solutions</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/sassy-solutions/compendium-adapter-sample</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/sassy-solutions/compendium-adapter-sample.git</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SourceRoot Include="$(MSBuildThisFileDirectory)/" />
+  </ItemGroup>
+</Project>

--- a/templates/adapter-dotnet/Directory.Packages.props
+++ b/templates/adapter-dotnet/Directory.Packages.props
@@ -1,0 +1,47 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!-- Compendium framework — pin to a published NuGet version. Update via Renovate. -->
+  <ItemGroup>
+    <PackageVersion Include="Compendium.Abstractions" Version="1.0.0-preview.8" />
+    <PackageVersion Include="Compendium.Core" Version="1.0.0-preview.8" />
+  </ItemGroup>
+
+  <!-- Production runtime -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0" />
+  </ItemGroup>
+
+  <!-- Test stack (matches the framework's testing conventions exactly) -->
+  <ItemGroup>
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="AutoFixture" Version="4.18.1" />
+    <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
+    <PackageVersion Include="Bogus" Version="35.6.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+  </ItemGroup>
+
+  <!-- Container fixtures (integration tests only — uncomment when you add them) -->
+  <!--
+  <ItemGroup>
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+  </ItemGroup>
+  -->
+</Project>

--- a/templates/adapter-dotnet/LICENSE
+++ b/templates/adapter-dotnet/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sassy Solutions
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/templates/adapter-dotnet/README.md
+++ b/templates/adapter-dotnet/README.md
@@ -1,0 +1,110 @@
+# `template-compendium-adapter-dotnet`
+
+Starter for a new **Compendium** adapter (.NET 9, single-vendor, lives in its own repository).
+
+Aligns with [ADR 0006](../../docs/adr/0006-multi-repo-adapter-split.md) (split heavy adapters into per-adapter repositories). Encodes the [`compendium-test-author`](.claude/skills/compendium-test-author/SKILL.md) skill so `/tests` and `/coverage` work out of the box.
+
+## What you get
+
+```
+.
+├── src/Compendium.Adapters.Sample/        — the adapter project (rename Sample → <Vendor>)
+│   ├── DependencyInjection/
+│   │   └── ServiceCollectionExtensions.cs
+│   ├── Options/SampleOptions.cs
+│   └── SampleAdapter.cs                   — illustrates the IAdapter (or any port) shape
+├── tests/Unit/Compendium.Adapters.Sample.Tests/
+│   ├── DependencyInjection/ServiceCollectionExtensionsTests.cs
+│   ├── Options/SampleOptionsTests.cs
+│   └── GlobalUsings.cs
+├── .github/workflows/ci.yml               — build + test + 90% coverage gate
+├── .claude/skills/compendium-test-author/SKILL.md
+├── .claude/commands/{tests,coverage}.md
+├── .config/dotnet-tools.json              — pins ReportGenerator
+├── Directory.Build.props
+├── Directory.Packages.props               — central package management
+├── Compendium.Adapters.Sample.sln
+├── global.json                            — pins .NET 9 SDK
+└── LICENSE
+```
+
+## Conventions enforced (copy from Compendium framework)
+
+| Aspect | Choice |
+|---|---|
+| Test framework | xUnit 2.9.3 |
+| Assertions | FluentAssertions 6.12.1 — never `Assert.*` |
+| Mocks | NSubstitute 5.1.0 — never Moq |
+| Coverage | coverlet.collector 6.0.2 + ReportGenerator (local tool) |
+| Result pattern | `Result<T>` from `Compendium.Abstractions` (NuGet) |
+| Async | `async Task` + cancellation tokens — never `Thread.Sleep`, never `.Result` |
+| Test naming | `{SUT}Tests` / `{Method}_{Scenario}_{Expected}` |
+| Test layout | AAA explicit (`// Arrange / // Act / // Assert`) |
+| File header | Sassy Solutions copyright block |
+| HTTP mocking (when applicable) | `RichardSzalay.MockHttp` 7.0.0 |
+| Container fixtures (integration) | `Testcontainers` 4.11.0 + `IAsyncLifetime` + `[RequiresDockerFact]` |
+| CI gate | ≥ 90 % line coverage on the unit-testable surface (DB-bound types may be exempted with documented reason) |
+
+## How to scaffold a new adapter
+
+```bash
+# 1. Pick a vendor name (use PascalCase: Stripe, PostgreSQL, Redis…)
+export VENDOR=Stripe
+
+# 2. Copy the template to a new directory next to your Compendium clone
+cp -r templates/adapter-dotnet ../compendium-adapter-${VENDOR,,}
+cd ../compendium-adapter-${VENDOR,,}
+
+# 3. Find-and-replace placeholders (BSD sed on macOS — adapt for GNU sed)
+find . -type f \( -name '*.cs' -o -name '*.csproj' -o -name '*.sln' -o -name '*.md' -o -name '*.yml' -o -name '*.json' -o -name '*.props' \) -exec sed -i '' -e "s/Sample/${VENDOR}/g" -e "s/sample/${VENDOR,,}/g" {} +
+
+# 4. Rename folders/files
+git mv src/Compendium.Adapters.Sample              src/Compendium.Adapters.${VENDOR}
+git mv src/Compendium.Adapters.${VENDOR}/Compendium.Adapters.Sample.csproj \
+       src/Compendium.Adapters.${VENDOR}/Compendium.Adapters.${VENDOR}.csproj
+git mv src/Compendium.Adapters.${VENDOR}/SampleAdapter.cs                   \
+       src/Compendium.Adapters.${VENDOR}/${VENDOR}Adapter.cs
+git mv src/Compendium.Adapters.${VENDOR}/Options/SampleOptions.cs           \
+       src/Compendium.Adapters.${VENDOR}/Options/${VENDOR}Options.cs
+
+git mv tests/Unit/Compendium.Adapters.Sample.Tests           tests/Unit/Compendium.Adapters.${VENDOR}.Tests
+git mv tests/Unit/Compendium.Adapters.${VENDOR}.Tests/Compendium.Adapters.Sample.Tests.csproj \
+       tests/Unit/Compendium.Adapters.${VENDOR}.Tests/Compendium.Adapters.${VENDOR}.Tests.csproj
+git mv tests/Unit/Compendium.Adapters.${VENDOR}.Tests/Options/SampleOptionsTests.cs \
+       tests/Unit/Compendium.Adapters.${VENDOR}.Tests/Options/${VENDOR}OptionsTests.cs
+
+mv Compendium.Adapters.Sample.sln Compendium.Adapters.${VENDOR}.sln
+
+# 5. Initialise git and verify build
+git init
+git add .
+dotnet build -c Release
+dotnet test  -c Release
+```
+
+## What you still need to do per repo
+
+After scaffolding :
+
+- **Author the actual adapter code.** Replace `SampleAdapter` with the real implementation of whatever port (`IEventStore`, `IIdentityProvider`, `IBillingProvider`, `IEmailSender`, …) you're filling.
+- **NuGet publishing.** Add `NUGET_API_KEY` to repo secrets ; the included `release.yml` (TODO — add when first needed) packs and pushes on `v*` tags.
+- **Branch protection.** Require `build-test` (CI), at least one review, no force-push to `main`.
+- **Renovate or Dependabot.** Renovate config at `renovate.json` — track Compendium NuGets so a framework release auto-PRs the adapter. Dependabot for npm-style scheduled dep bumps.
+- **Integration tests** (optional but recommended for adapters with external systems). Add `tests/Integration/Compendium.Adapters.<Vendor>.IntegrationTests/` with `Testcontainers` if needed. Keep them out of the unit CI job.
+
+## Local-dev mode (when you're modifying both framework and adapter)
+
+Edit `Directory.Packages.props` to add a project reference instead of the NuGet :
+
+```xml
+<ItemGroup Condition="'$(LinkLocalCompendium)' == 'true'">
+  <PackageReference Remove="Compendium.Abstractions" />
+  <ProjectReference Include="../compendium/src/Abstractions/Compendium.Abstractions/Compendium.Abstractions.csproj" />
+</ItemGroup>
+```
+
+Then `dotnet build -p:LinkLocalCompendium=true`.
+
+## License
+
+MIT — same as Compendium itself.

--- a/templates/adapter-dotnet/global.json
+++ b/templates/adapter-dotnet/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/templates/adapter-dotnet/src/Compendium.Adapters.Sample/Compendium.Adapters.Sample.csproj
+++ b/templates/adapter-dotnet/src/Compendium.Adapters.Sample/Compendium.Adapters.Sample.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Adapters.Sample</AssemblyName>
+    <RootNamespace>Compendium.Adapters.Sample</RootNamespace>
+    <Description>Compendium adapter for Sample (placeholder — replace with real vendor description).</Description>
+    <PackageTags>compendium;adapter;sample</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Compendium.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/templates/adapter-dotnet/src/Compendium.Adapters.Sample/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/templates/adapter-dotnet/src/Compendium.Adapters.Sample/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,64 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Adapters.Sample.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Compendium.Adapters.Sample.DependencyInjection;
+
+/// <summary>
+/// DI registration helpers for the Sample adapter.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="SampleAdapter"/> and its options.
+    /// </summary>
+    /// <param name="services">DI container.</param>
+    /// <param name="configuration">Source configuration; section <see cref="SampleOptions.SectionName"/> is bound.</param>
+    /// <returns>The same <paramref name="services"/> for chaining.</returns>
+    public static IServiceCollection AddCompendiumSampleAdapter(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddOptions<SampleOptions>()
+            .Bind(configuration.GetSection(SampleOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddSingleton<SampleAdapter>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="SampleAdapter"/> with an inline configuration callback.
+    /// </summary>
+    /// <param name="services">DI container.</param>
+    /// <param name="configure">Callback to mutate <see cref="SampleOptions"/>.</param>
+    /// <returns>The same <paramref name="services"/> for chaining.</returns>
+    public static IServiceCollection AddCompendiumSampleAdapter(
+        this IServiceCollection services,
+        Action<SampleOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.AddOptions<SampleOptions>()
+            .Configure(configure)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddSingleton<SampleAdapter>();
+
+        return services;
+    }
+}

--- a/templates/adapter-dotnet/src/Compendium.Adapters.Sample/Options/SampleOptions.cs
+++ b/templates/adapter-dotnet/src/Compendium.Adapters.Sample/Options/SampleOptions.cs
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------
+// <copyright file="SampleOptions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Compendium.Adapters.Sample.Options;
+
+/// <summary>
+/// Configuration for <see cref="SampleAdapter"/>.
+/// </summary>
+public sealed class SampleOptions
+{
+    /// <summary>
+    /// Configuration section name used by <c>IConfiguration.GetSection(...)</c>.
+    /// </summary>
+    public const string SectionName = "Compendium:Adapters:Sample";
+
+    /// <summary>
+    /// Vendor base URL. Required.
+    /// </summary>
+    [Required]
+    [Url]
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// API key. Required.
+    /// </summary>
+    [Required]
+    public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Per-request timeout. Default : 30 seconds.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+}

--- a/templates/adapter-dotnet/src/Compendium.Adapters.Sample/SampleAdapter.cs
+++ b/templates/adapter-dotnet/src/Compendium.Adapters.Sample/SampleAdapter.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------
+// <copyright file="SampleAdapter.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Adapters.Sample.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Compendium.Adapters.Sample;
+
+/// <summary>
+/// Sample adapter — replace with the real vendor implementation.
+/// Demonstrates the canonical shape:
+/// <list type="bullet">
+///   <item>typed options bound from configuration</item>
+///   <item>injected logger (no static logging)</item>
+///   <item>methods return <c>Result&lt;T&gt;</c> from Compendium.Abstractions</item>
+/// </list>
+/// </summary>
+public sealed class SampleAdapter
+{
+    private readonly SampleOptions _options;
+    private readonly ILogger<SampleAdapter> _logger;
+
+    /// <summary>
+    /// Creates a new <see cref="SampleAdapter"/>.
+    /// </summary>
+    /// <param name="options">Adapter configuration.</param>
+    /// <param name="logger">Diagnostic logger.</param>
+    public SampleAdapter(IOptions<SampleOptions> options, ILogger<SampleAdapter> logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Echoes a payload back. Replace with the real adapter operation.
+    /// </summary>
+    /// <param name="payload">Input payload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The same payload, prefixed with the configured base URL.</returns>
+    public Task<string> EchoAsync(string payload, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+        _logger.LogDebug("Echoing payload of length {Length}", payload.Length);
+        return Task.FromResult($"{_options.BaseUrl}::{payload}");
+    }
+}

--- a/templates/adapter-dotnet/tests/Unit/Compendium.Adapters.Sample.Tests/Compendium.Adapters.Sample.Tests.csproj
+++ b/templates/adapter-dotnet/tests/Unit/Compendium.Adapters.Sample.Tests/Compendium.Adapters.Sample.Tests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Adapters.Sample.Tests</AssemblyName>
+    <RootNamespace>Compendium.Adapters.Sample.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Compendium.Adapters.Sample\Compendium.Adapters.Sample.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/templates/adapter-dotnet/tests/Unit/Compendium.Adapters.Sample.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/templates/adapter-dotnet/tests/Unit/Compendium.Adapters.Sample.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Adapters.Sample.DependencyInjection;
+using Compendium.Adapters.Sample.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Compendium.Adapters.Sample.Tests.DependencyInjection;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddCompendiumSampleAdapter_WithConfiguration_RegistersAdapterAndOptions()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Compendium:Adapters:Sample:BaseUrl"] = "https://api.example.com",
+                ["Compendium:Adapters:Sample:ApiKey"] = "k1",
+            })
+            .Build();
+
+        // Act
+        var actual = services.AddCompendiumSampleAdapter(configuration);
+        var sp = actual.BuildServiceProvider();
+
+        // Assert
+        actual.Should().BeSameAs(services);
+        sp.GetRequiredService<SampleAdapter>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddCompendiumSampleAdapter_WithCallback_RegistersAdapterAndOptions()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Act
+        services.AddCompendiumSampleAdapter(o =>
+        {
+            o.BaseUrl = "https://api.example.com";
+            o.ApiKey = "k1";
+        });
+        var sp = services.BuildServiceProvider();
+
+        // Assert
+        sp.GetRequiredService<SampleAdapter>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddCompendiumSampleAdapter_NullServices_Throws()
+    {
+        // Arrange
+        IServiceCollection? services = null;
+
+        // Act
+        var act = () => services!.AddCompendiumSampleAdapter(_ => { });
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/templates/adapter-dotnet/tests/Unit/Compendium.Adapters.Sample.Tests/GlobalUsings.cs
+++ b/templates/adapter-dotnet/tests/Unit/Compendium.Adapters.Sample.Tests/GlobalUsings.cs
@@ -1,0 +1,10 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using FluentAssertions;
+global using NSubstitute;
+global using Xunit;

--- a/templates/adapter-dotnet/tests/Unit/Compendium.Adapters.Sample.Tests/Options/SampleOptionsTests.cs
+++ b/templates/adapter-dotnet/tests/Unit/Compendium.Adapters.Sample.Tests/Options/SampleOptionsTests.cs
@@ -1,0 +1,66 @@
+// -----------------------------------------------------------------------
+// <copyright file="SampleOptionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.ComponentModel.DataAnnotations;
+using Compendium.Adapters.Sample.Options;
+
+namespace Compendium.Adapters.Sample.Tests.Options;
+
+/// <summary>
+/// Demonstrates the convention every adapter test follows :
+/// <list type="bullet">
+///   <item>file copyright header</item>
+///   <item>class named <c>{SUT}Tests</c></item>
+///   <item>method named <c>{Method}_{Scenario}_{Expected}</c></item>
+///   <item>explicit <c>// Arrange / // Act / // Assert</c> comments</item>
+///   <item>FluentAssertions only — never <c>Assert.*</c></item>
+/// </list>
+/// </summary>
+public class SampleOptionsTests
+{
+    [Fact]
+    public void SampleOptions_Defaults_AreSensible()
+    {
+        // Arrange / Act
+        var options = new SampleOptions();
+
+        // Assert
+        options.Timeout.Should().Be(TimeSpan.FromSeconds(30));
+        options.BaseUrl.Should().BeEmpty();
+        options.ApiKey.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("", "key", false)]
+    [InlineData("   ", "key", false)]
+    [InlineData("not-a-url", "key", false)]
+    [InlineData("https://api.example.com", "", false)]
+    [InlineData("https://api.example.com", "valid-key", true)]
+    public void SampleOptions_DataAnnotations_ValidateAsExpected(
+        string baseUrl,
+        string apiKey,
+        bool expectedValid)
+    {
+        // Arrange
+        var options = new SampleOptions { BaseUrl = baseUrl, ApiKey = apiKey };
+        var ctx = new ValidationContext(options);
+        var results = new List<ValidationResult>();
+
+        // Act
+        var actual = Validator.TryValidateObject(options, ctx, results, validateAllProperties: true);
+
+        // Assert
+        actual.Should().Be(expectedValid);
+    }
+
+    [Fact]
+    public void SampleOptions_SectionName_IsCanonical()
+    {
+        // Assert
+        SampleOptions.SectionName.Should().Be("Compendium:Adapters:Sample");
+    }
+}


### PR DESCRIPTION
## Summary
Two related deliverables :

1. **[ADR-0006](docs/adr/0006-multi-repo-adapter-split.md)** (status `Proposed`) — formalises the decision to extract the seven heavy adapters (PostgreSQL, Redis, Stripe, Zitadel, LemonSqueezy, Listmonk, OpenRouter) into per-adapter repositories, while keeping the thin glue adapters (`AspNetCore`, `Shared`) in this monorepo.

2. **`templates/adapter-dotnet/`** — a copy-paste seed for new adapter repositories. Includes :
   - `Compendium.Adapters.Sample` production project (sample adapter + Options + DI extensions, 47 LOC)
   - `Compendium.Adapters.Sample.Tests` unit project with 10 sample tests demonstrating the canonical conventions (xUnit + FluentAssertions + NSubstitute, AAA explicit, file copyright header, `{SUT}Tests` / `{Method}_{Scenario}_{Expected}`).
   - `.github/workflows/ci.yml` with build + test + ReportGenerator + a strict ≥ 90 % line coverage gate.
   - `.claude/` pre-loaded with the `compendium-test-author` skill (verbatim copy from this repo) and `/tests` + `/coverage` slash commands so the same workflow drops into every new adapter repo.
   - `Directory.Packages.props` central package management mirroring the framework's pinned versions.

## Why
Today the framework's global line coverage is dragged from ~95 % to **88.4 %** by `Compendium.Adapters.PostgreSQL` alone (its DB-bound types are integration-only by design). Extracting it lets the framework hold a strict ≥ 90 % gate without exemptions, decouples Stripe.NET-style SDK churn from framework releases, and keeps Docker-based integration tests out of the framework CI.

## Verified locally
```
$ cd templates/adapter-dotnet
$ dotnet build -c Release       # 0 warnings, 0 errors
$ dotnet test -c Release         # 10 passed, 0 failed (~42 ms)
```

## Not in scope (will be done as separate PRs once ADR is accepted)
- Migration of any specific adapter — first candidate per the ADR is `Adapters.Stripe`.
- The `release.yml` (NuGet publishing on tag) for the template — minimal stub goes in with the first real extraction.
- Renovate config sample — drops in with the first extraction.
- Removal of extracted adapters from this repo.

## Test plan
- [x] Build green
- [x] Sample tests run green
- [ ] CI green
- [ ] ADR reviewed and moved to `Accepted` (or amended)