### PR TITLE
feat(abstractions/storage): define IObjectStore port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -108,16 +108,25 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Application.Tests", "tests\Unit\Compendium.Application.Tests\Compendium.Application.Tests.csproj", "{4F876BBF-5817-4488-AD7C-1F4348DDCD15}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.Redis.Tests", "tests\Unit\Compendium.Adapters.Redis.Tests\Compendium.Adapters.Redis.Tests.csproj", "{C63EF05F-7C94-449F-92D1-51E3367395D1}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.AspNetCore.Tests", "tests\Unit\Compendium.Adapters.AspNetCore.Tests\Compendium.Adapters.AspNetCore.Tests.csproj", "{84C5728A-8843-4FFF-B2AB-98AF3838D820}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.Shared.Tests", "tests\Unit\Compendium.Adapters.Shared.Tests\Compendium.Adapters.Shared.Tests.csproj", "{3BFB6A86-8972-4003-9C52-7DFD5D956BAF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Testing.Tests", "tests\Unit\Compendium.Testing.Tests\Compendium.Testing.Tests.csproj", "{E5232EFA-E06C-4975-B5A7-91A241D029CB}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.PostgreSQL.Tests", "tests\Unit\Compendium.Adapters.PostgreSQL.Tests\Compendium.Adapters.PostgreSQL.Tests.csproj", "{3E6C387D-A84B-43A8-AAF5-B7A9494C57CE}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Identity.Tests", "tests\Unit\Compendium.Abstractions.Identity.Tests\Compendium.Abstractions.Identity.Tests.csproj", "{0EDEE2DC-46FE-404B-9615-B6E3F756DF75}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Billing.Tests", "tests\Unit\Compendium.Abstractions.Billing.Tests\Compendium.Abstractions.Billing.Tests.csproj", "{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Email.Tests", "tests\Unit\Compendium.Abstractions.Email.Tests\Compendium.Abstractions.Email.Tests.csproj", "{BAD4540D-5310-4623-9441-0328DD43879B}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Tests", "tests\Unit\Compendium.Abstractions.Tests\Compendium.Abstractions.Tests.csproj", "{071D6168-7960-4B44-83A0-6A73312EE034}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.VectorStore", "src\Abstractions\Compendium.Abstractions.VectorStore\Compendium.Abstractions.VectorStore.csproj", "{A2970BBA-F52C-4203-B529-D8B92738F93E}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.VectorStore.Tests", "tests\Unit\Compendium.Abstractions.VectorStore.Tests\Compendium.Abstractions.VectorStore.Tests.csproj", "{61932BC1-0068-4F8A-927F-C45E536598E0}"
 EndProject
 Global


### PR DESCRIPTION
## Summary
Defines `IObjectStore` port in a new `Compendium.Abstractions.Storage` assembly. Unblocks `compendium-adapter-s3` / `azure-blob` / `gcs` per ADR-0006.

## Surface
- `IObjectStore` (`PutAsync` / `GetAsync` / `DeleteAsync` / `ExistsAsync` / `ListAsync` / `GetPresignedUrlAsync`) — all returning `Result<T>`.
- `ObjectInfo`, `ObjectMetadata`, `ListOptions`, `ListPage` records.
- `ObjectStream` (sealed `IDisposable` + `IAsyncDisposable` wrapping `Stream` + `ObjectInfo`).
- `PresignedAction` enum (`Get`, `Put`).
- `StorageErrors` factories: `NotFound`, `AccessDenied`, `InvalidBucket`, `Throttled`, `ContentTooLarge`, `ConflictExists`.

## Coverage
`Compendium.Abstractions.Storage`: **100 % line / 100 % branch**
`Compendium.Abstractions.Storage.Tests`: **44 tests, all green**

## Test plan
- [x] `dotnet build` green
- [x] `dotnet test` green (44/44)
- [x] Coverage ≥ 90 %
- [ ] CI green