### PR TITLE
feat(abstractions/search): define ISearchIndex port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -129,6 +129,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Vec
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.VectorStore.Tests", "tests\Unit\Compendium.Abstractions.VectorStore.Tests\Compendium.Abstractions.VectorStore.Tests.csproj", "{61932BC1-0068-4F8A-927F-C45E536598E0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Search", "src\Abstractions\Compendium.Abstractions.Search\Compendium.Abstractions.Search.csproj", "{F8AF93A7-4628-42A8-AF92-FC38C2D3B414}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Search.Tests", "tests\Unit\Compendium.Abstractions.Search.Tests\Compendium.Abstractions.Search.Tests.csproj", "{7D018598-0092-4490-9D81-0E8FF1FA202D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -330,6 +334,14 @@ Global
 		{61932BC1-0068-4F8A-927F-C45E536598E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{61932BC1-0068-4F8A-927F-C45E536598E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{61932BC1-0068-4F8A-927F-C45E536598E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8AF93A7-4628-42A8-AF92-FC38C2D3B414}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8AF93A7-4628-42A8-AF92-FC38C2D3B414}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8AF93A7-4628-42A8-AF92-FC38C2D3B414}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8AF93A7-4628-42A8-AF92-FC38C2D3B414}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D018598-0092-4490-9D81-0E8FF1FA202D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D018598-0092-4490-9D81-0E8FF1FA202D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D018598-0092-4490-9D81-0E8FF1FA202D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D018598-0092-4490-9D81-0E8FF1FA202D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -392,5 +404,7 @@ Global
 		{071D6168-7960-4B44-83A0-6A73312EE034} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{A2970BBA-F52C-4203-B529-D8B92738F93E} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
 		{61932BC1-0068-4F8A-927F-C45E536598E0} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{F8AF93A7-4628-42A8-AF92-FC38C2D3B414} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
+		{7D018598-0092-4490-9D81-0E8FF1FA202D} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Search/Compendium.Abstractions.Search.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Search/Compendium.Abstractions.Search.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Search</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Search</RootNamespace>
+    <PackageId>Compendium.Abstractions.Search</PackageId>
+    <Description>Search abstractions for Compendium Framework: ISearchIndex port and supporting models. Provider-agnostic interface for search engines (Meilisearch, Typesense, Elasticsearch, OpenSearch).</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Search.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Search/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Search/GlobalUsings.cs
@@ -1,0 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;
+global using System.Text.Json.Serialization;

--- a/src/Abstractions/Compendium.Abstractions.Search/ISearchIndex.cs
+++ b/src/Abstractions/Compendium.Abstractions.Search/ISearchIndex.cs
@@ -1,0 +1,72 @@
+// -----------------------------------------------------------------------
+// <copyright file="ISearchIndex.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Search.Models;
+
+namespace Compendium.Abstractions.Search;
+
+/// <summary>
+/// Provides search-engine-agnostic indexing and querying operations.
+/// Adapter targets include Meilisearch, Typesense, Elasticsearch, and OpenSearch.
+/// </summary>
+public interface ISearchIndex
+{
+    /// <summary>
+    /// Ensures the named index exists with the supplied settings.
+    /// Implementations should be idempotent: calling twice with the same arguments must succeed.
+    /// </summary>
+    /// <param name="index">The index name.</param>
+    /// <param name="settings">The desired index settings.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A success result, or a failure describing why the index could not be created or updated.</returns>
+    Task<Result> EnsureIndexAsync(
+        string index,
+        IndexSettings settings,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Indexes (creates or updates) a document in the named index.
+    /// </summary>
+    /// <typeparam name="T">The document type.</typeparam>
+    /// <param name="index">The index name.</param>
+    /// <param name="id">The unique document identifier.</param>
+    /// <param name="document">The document to index.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A success result, or a failure describing the indexing error.</returns>
+    Task<Result> IndexAsync<T>(
+        string index,
+        string id,
+        T document,
+        CancellationToken cancellationToken = default)
+        where T : class;
+
+    /// <summary>
+    /// Deletes a document from the named index.
+    /// </summary>
+    /// <param name="index">The index name.</param>
+    /// <param name="id">The unique document identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A success result, or a failure describing the deletion error.</returns>
+    Task<Result> DeleteAsync(
+        string index,
+        string id,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes a search query against the named index.
+    /// </summary>
+    /// <typeparam name="T">The deserialized document type.</typeparam>
+    /// <param name="index">The index name.</param>
+    /// <param name="query">The query to execute.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the search response, or a failure describing the search error.</returns>
+    Task<Result<SearchResult<T>>> SearchAsync<T>(
+        string index,
+        SearchQuery query,
+        CancellationToken cancellationToken = default)
+        where T : class;
+}

--- a/src/Abstractions/Compendium.Abstractions.Search/Models/IndexSettings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Search/Models/IndexSettings.cs
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------
+// <copyright file="IndexSettings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search.Models;
+
+/// <summary>
+/// Represents the configuration of a search index.
+/// </summary>
+public sealed record IndexSettings
+{
+    /// <summary>
+    /// Gets the attributes considered when matching the query text.
+    /// </summary>
+    public IReadOnlyList<string> SearchableAttributes { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets the attributes that may appear in <see cref="SearchQuery.Filters"/>.
+    /// </summary>
+    public IReadOnlyList<string> FilterableAttributes { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets the attributes that may be used in <see cref="SearchSort"/>.
+    /// </summary>
+    public IReadOnlyList<string> SortableAttributes { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets the optional attribute used for distinct/deduplication.
+    /// </summary>
+    public string? DistinctAttribute { get; init; }
+
+    /// <summary>
+    /// Gets the ordered list of ranking rules applied by the engine.
+    /// </summary>
+    public IReadOnlyList<string> RankingRules { get; init; } = Array.Empty<string>();
+}

--- a/src/Abstractions/Compendium.Abstractions.Search/Models/SearchHit.cs
+++ b/src/Abstractions/Compendium.Abstractions.Search/Models/SearchHit.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchHit.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search.Models;
+
+/// <summary>
+/// Represents a single document returned by a search query.
+/// </summary>
+/// <typeparam name="T">The deserialized document type.</typeparam>
+public sealed record SearchHit<T>
+{
+    /// <summary>
+    /// Gets the matched document.
+    /// </summary>
+    public required T Document { get; init; }
+
+    /// <summary>
+    /// Gets the relevance score assigned by the search engine. Higher is more relevant.
+    /// </summary>
+    public double Score { get; init; }
+
+    /// <summary>
+    /// Gets the highlight fragments per attribute (attribute name → highlighted snippets).
+    /// Empty when highlighting is disabled.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> Highlights { get; init; } =
+        new Dictionary<string, IReadOnlyList<string>>();
+}

--- a/src/Abstractions/Compendium.Abstractions.Search/Models/SearchQuery.cs
+++ b/src/Abstractions/Compendium.Abstractions.Search/Models/SearchQuery.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchQuery.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search.Models;
+
+/// <summary>
+/// Represents a provider-agnostic search query.
+/// </summary>
+public sealed record SearchQuery
+{
+    /// <summary>
+    /// Gets the free-text query string. May be empty for filter-only queries.
+    /// </summary>
+    public required string Text { get; init; }
+
+    /// <summary>
+    /// Gets the structured filters applied to the query (attribute → value).
+    /// </summary>
+    public IReadOnlyDictionary<string, object> Filters { get; init; } =
+        new Dictionary<string, object>();
+
+    /// <summary>
+    /// Gets the attributes to compute facet counts for.
+    /// </summary>
+    public IReadOnlyList<string> Facets { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets the optional sort instruction. When null, the engine's default ranking is used.
+    /// </summary>
+    public SearchSort? Sort { get; init; }
+
+    /// <summary>
+    /// Gets the maximum number of hits to return. Defaults to 20.
+    /// </summary>
+    public int Limit { get; init; } = 20;
+
+    /// <summary>
+    /// Gets the number of hits to skip (for pagination). Defaults to 0.
+    /// </summary>
+    public int Offset { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether highlight fragments should be returned. Defaults to <see langword="false"/>.
+    /// </summary>
+    public bool Highlight { get; init; }
+
+    /// <summary>
+    /// Gets the optional tenant identifier for multi-tenant indexes.
+    /// </summary>
+    public string? TenantId { get; init; }
+}

--- a/src/Abstractions/Compendium.Abstractions.Search/Models/SearchResult.cs
+++ b/src/Abstractions/Compendium.Abstractions.Search/Models/SearchResult.cs
@@ -1,0 +1,36 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchResult.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search.Models;
+
+/// <summary>
+/// Represents the result of a search query.
+/// </summary>
+/// <typeparam name="T">The deserialized document type.</typeparam>
+public sealed record SearchResult<T>
+{
+    /// <summary>
+    /// Gets the hits returned for the current page.
+    /// </summary>
+    public IReadOnlyList<SearchHit<T>> Hits { get; init; } = Array.Empty<SearchHit<T>>();
+
+    /// <summary>
+    /// Gets the total number of documents matching the query (across all pages).
+    /// </summary>
+    public long Total { get; init; }
+
+    /// <summary>
+    /// Gets the facet counts (attribute → value → count) when facets were requested.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyDictionary<string, long>> FacetCounts { get; init; } =
+        new Dictionary<string, IReadOnlyDictionary<string, long>>();
+
+    /// <summary>
+    /// Gets the time the search engine spent processing the query.
+    /// </summary>
+    public TimeSpan Took { get; init; }
+}

--- a/src/Abstractions/Compendium.Abstractions.Search/Models/SearchSort.cs
+++ b/src/Abstractions/Compendium.Abstractions.Search/Models/SearchSort.cs
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchSort.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search.Models;
+
+/// <summary>
+/// Specifies the direction of a sort operation.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum SortDirection
+{
+    /// <summary>
+    /// Ascending sort order (smallest first).
+    /// </summary>
+    Asc,
+
+    /// <summary>
+    /// Descending sort order (largest first).
+    /// </summary>
+    Desc,
+}
+
+/// <summary>
+/// Represents a sort instruction for a search query.
+/// </summary>
+public sealed record SearchSort
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SearchSort"/> class.
+    /// </summary>
+    /// <param name="field">The name of the field to sort on.</param>
+    /// <param name="direction">The direction of the sort. Defaults to <see cref="SortDirection.Asc"/>.</param>
+    public SearchSort(string field, SortDirection direction = SortDirection.Asc)
+    {
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            throw new ArgumentException("Sort field must be non-empty.", nameof(field));
+        }
+
+        this.Field = field;
+        this.Direction = direction;
+    }
+
+    /// <summary>
+    /// Gets the name of the field to sort on.
+    /// </summary>
+    public string Field { get; init; }
+
+    /// <summary>
+    /// Gets the direction of the sort.
+    /// </summary>
+    public SortDirection Direction { get; init; }
+
+    /// <summary>
+    /// Creates an ascending sort on the given field.
+    /// </summary>
+    /// <param name="field">The field to sort on.</param>
+    /// <returns>A new <see cref="SearchSort"/> sorting ascending.</returns>
+    public static SearchSort Ascending(string field) => new(field, SortDirection.Asc);
+
+    /// <summary>
+    /// Creates a descending sort on the given field.
+    /// </summary>
+    /// <param name="field">The field to sort on.</param>
+    /// <returns>A new <see cref="SearchSort"/> sorting descending.</returns>
+    public static SearchSort Descending(string field) => new(field, SortDirection.Desc);
+}

--- a/src/Abstractions/Compendium.Abstractions.Search/SearchErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Search/SearchErrors.cs
@@ -1,0 +1,67 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search;
+
+/// <summary>
+/// Provides standardized error definitions for search operations.
+/// </summary>
+public static class SearchErrors
+{
+    /// <summary>
+    /// Gets the error code prefix for search errors.
+    /// </summary>
+    public const string Prefix = "Search";
+
+    /// <summary>
+    /// The requested index does not exist.
+    /// </summary>
+    /// <param name="index">The name of the missing index.</param>
+    /// <returns>A not-found error.</returns>
+    public static Error IndexNotFound(string index) =>
+        Error.NotFound($"{Prefix}.IndexNotFound", $"Search index '{index}' was not found.");
+
+    /// <summary>
+    /// The query is malformed or otherwise invalid for the engine.
+    /// </summary>
+    /// <param name="reason">A human-readable reason describing why the query is invalid.</param>
+    /// <returns>A validation error.</returns>
+    public static Error InvalidQuery(string reason) =>
+        Error.Validation($"{Prefix}.InvalidQuery", $"Invalid search query: {reason}.");
+
+    /// <summary>
+    /// A filter referenced an attribute that is not declared as filterable on the index.
+    /// </summary>
+    /// <param name="attribute">The attribute that was used as a filter.</param>
+    /// <returns>A validation error.</returns>
+    public static Error AttributeNotFilterable(string attribute) =>
+        Error.Validation(
+            $"{Prefix}.AttributeNotFilterable",
+            $"Attribute '{attribute}' is not configured as filterable on this index.");
+
+    /// <summary>
+    /// A sort referenced an attribute that is not declared as sortable on the index.
+    /// </summary>
+    /// <param name="attribute">The attribute that was used to sort.</param>
+    /// <returns>A validation error.</returns>
+    public static Error AttributeNotSortable(string attribute) =>
+        Error.Validation(
+            $"{Prefix}.AttributeNotSortable",
+            $"Attribute '{attribute}' is not configured as sortable on this index.");
+
+    /// <summary>
+    /// The request was rejected because the engine is rate-limiting the caller.
+    /// </summary>
+    /// <param name="retryAfter">Optional duration after which the caller may retry.</param>
+    /// <returns>A too-many-requests error.</returns>
+    public static Error Throttled(TimeSpan? retryAfter = null) =>
+        Error.TooManyRequests(
+            $"{Prefix}.Throttled",
+            retryAfter.HasValue
+                ? $"Search engine throttled the request. Retry after {retryAfter.Value.TotalSeconds} seconds."
+                : "Search engine throttled the request. Please try again later.");
+}

--- a/tests/Unit/Compendium.Abstractions.Search.Tests/Compendium.Abstractions.Search.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Search.Tests/Compendium.Abstractions.Search.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Search.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Search.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Search\Compendium.Abstractions.Search.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Search.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Search.Tests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using Xunit;
+global using FluentAssertions;
+global using NSubstitute;
+global using Compendium.Abstractions.Search;
+global using Compendium.Abstractions.Search.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Search.Tests/Models/IndexSettingsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Search.Tests/Models/IndexSettingsTests.cs
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="IndexSettingsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search.Tests.Models;
+
+public class IndexSettingsTests
+{
+    [Fact]
+    public void Defaults_AreEmptyCollections()
+    {
+        // Act
+        var settings = new IndexSettings();
+
+        // Assert
+        settings.SearchableAttributes.Should().BeEmpty();
+        settings.FilterableAttributes.Should().BeEmpty();
+        settings.SortableAttributes.Should().BeEmpty();
+        settings.DistinctAttribute.Should().BeNull();
+        settings.RankingRules.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AllProperties_AssignableViaInit()
+    {
+        // Arrange
+        var searchable = new[] { "title", "description" };
+        var filterable = new[] { "category", "in_stock" };
+        var sortable = new[] { "price", "created_at" };
+        var ranking = new[] { "words", "typo", "proximity" };
+
+        // Act
+        var settings = new IndexSettings
+        {
+            SearchableAttributes = searchable,
+            FilterableAttributes = filterable,
+            SortableAttributes = sortable,
+            DistinctAttribute = "sku",
+            RankingRules = ranking,
+        };
+
+        // Assert
+        settings.SearchableAttributes.Should().BeEquivalentTo(searchable);
+        settings.FilterableAttributes.Should().BeEquivalentTo(filterable);
+        settings.SortableAttributes.Should().BeEquivalentTo(sortable);
+        settings.DistinctAttribute.Should().Be("sku");
+        settings.RankingRules.Should().BeEquivalentTo(ranking);
+    }
+
+    [Fact]
+    public void Records_WithSameContent_AreEqual()
+    {
+        // Arrange
+        var a = new IndexSettings { DistinctAttribute = "id" };
+        var b = new IndexSettings { DistinctAttribute = "id" };
+
+        // Assert
+        a.Should().Be(b);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Search.Tests/Models/SearchHitTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Search.Tests/Models/SearchHitTests.cs
@@ -1,0 +1,65 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchHitTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search.Tests.Models;
+
+public class SearchHitTests
+{
+    private sealed record Document(string Id, string Title);
+
+    [Fact]
+    public void Defaults_AssignedWhenOnlyDocumentSet()
+    {
+        // Arrange
+        var doc = new Document("1", "Hello");
+
+        // Act
+        var hit = new SearchHit<Document> { Document = doc };
+
+        // Assert
+        hit.Document.Should().Be(doc);
+        hit.Score.Should().Be(0d);
+        hit.Highlights.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AllProperties_AssignableViaInit()
+    {
+        // Arrange
+        var doc = new Document("42", "Title");
+        var highlights = new Dictionary<string, IReadOnlyList<string>>
+        {
+            ["title"] = new[] { "<em>Title</em>" },
+        };
+
+        // Act
+        var hit = new SearchHit<Document>
+        {
+            Document = doc,
+            Score = 0.95,
+            Highlights = highlights,
+        };
+
+        // Assert
+        hit.Document.Should().Be(doc);
+        hit.Score.Should().Be(0.95);
+        hit.Highlights.Should().ContainKey("title");
+        hit.Highlights["title"].Should().ContainSingle().Which.Should().Be("<em>Title</em>");
+    }
+
+    [Fact]
+    public void Records_WithSameContent_AreStructurallyEquivalent()
+    {
+        // Arrange
+        var doc = new Document("1", "x");
+        var a = new SearchHit<Document> { Document = doc, Score = 1.0 };
+        var b = new SearchHit<Document> { Document = doc, Score = 1.0 };
+
+        // Assert
+        a.Should().BeEquivalentTo(b);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Search.Tests/Models/SearchQueryTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Search.Tests/Models/SearchQueryTests.cs
@@ -1,0 +1,88 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchQueryTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search.Tests.Models;
+
+public class SearchQueryTests
+{
+    [Fact]
+    public void Defaults_AreApplied_WhenOnlyTextProvided()
+    {
+        // Act
+        var query = new SearchQuery { Text = "laptop" };
+
+        // Assert
+        query.Text.Should().Be("laptop");
+        query.Filters.Should().BeEmpty();
+        query.Facets.Should().BeEmpty();
+        query.Sort.Should().BeNull();
+        query.Limit.Should().Be(20);
+        query.Offset.Should().Be(0);
+        query.Highlight.Should().BeFalse();
+        query.TenantId.Should().BeNull();
+    }
+
+    [Fact]
+    public void AllProperties_AreAssignable_ViaInit()
+    {
+        // Arrange
+        var filters = new Dictionary<string, object> { ["category"] = "books", ["in_stock"] = true };
+        var facets = new[] { "category", "brand" };
+        var sort = SearchSort.Descending("price");
+
+        // Act
+        var query = new SearchQuery
+        {
+            Text = "harry potter",
+            Filters = filters,
+            Facets = facets,
+            Sort = sort,
+            Limit = 50,
+            Offset = 100,
+            Highlight = true,
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        query.Text.Should().Be("harry potter");
+        query.Filters.Should().BeEquivalentTo(filters);
+        query.Facets.Should().BeEquivalentTo(facets);
+        query.Sort.Should().Be(sort);
+        query.Limit.Should().Be(50);
+        query.Offset.Should().Be(100);
+        query.Highlight.Should().BeTrue();
+        query.TenantId.Should().Be("tenant-1");
+    }
+
+    [Fact]
+    public void Records_WithSameContent_AreStructurallyEquivalent()
+    {
+        // Arrange
+        var a = new SearchQuery { Text = "x", Limit = 5 };
+        var b = new SearchQuery { Text = "x", Limit = 5 };
+
+        // Assert
+        a.Should().BeEquivalentTo(b);
+    }
+
+    [Fact]
+    public void With_Expression_ProducesNewInstanceWithMutatedField()
+    {
+        // Arrange
+        var original = new SearchQuery { Text = "x" };
+
+        // Act
+        var clone = original with { Text = "y", Limit = 100 };
+
+        // Assert
+        clone.Should().NotBe(original);
+        clone.Text.Should().Be("y");
+        clone.Limit.Should().Be(100);
+        original.Text.Should().Be("x");
+        original.Limit.Should().Be(20);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Search.Tests/Models/SearchResultTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Search.Tests/Models/SearchResultTests.cs
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchResultTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search.Tests.Models;
+
+public class SearchResultTests
+{
+    private sealed record Document(string Id);
+
+    [Fact]
+    public void Defaults_ProduceEmptyResult()
+    {
+        // Act
+        var result = new SearchResult<Document>();
+
+        // Assert
+        result.Hits.Should().BeEmpty();
+        result.Total.Should().Be(0);
+        result.FacetCounts.Should().BeEmpty();
+        result.Took.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void AllProperties_AssignableViaInit()
+    {
+        // Arrange
+        var hits = new[]
+        {
+            new SearchHit<Document> { Document = new Document("1"), Score = 1.0 },
+            new SearchHit<Document> { Document = new Document("2"), Score = 0.5 },
+        };
+        var facets = new Dictionary<string, IReadOnlyDictionary<string, long>>
+        {
+            ["category"] = new Dictionary<string, long> { ["books"] = 12, ["games"] = 3 },
+        };
+
+        // Act
+        var result = new SearchResult<Document>
+        {
+            Hits = hits,
+            Total = 42,
+            FacetCounts = facets,
+            Took = TimeSpan.FromMilliseconds(15),
+        };
+
+        // Assert
+        result.Hits.Should().HaveCount(2);
+        result.Total.Should().Be(42);
+        result.FacetCounts.Should().ContainKey("category");
+        result.FacetCounts["category"]["books"].Should().Be(12);
+        result.Took.Should().Be(TimeSpan.FromMilliseconds(15));
+    }
+
+    [Fact]
+    public void Records_WithSameContent_AreStructurallyEquivalent()
+    {
+        // Arrange
+        var a = new SearchResult<Document> { Total = 7 };
+        var b = new SearchResult<Document> { Total = 7 };
+
+        // Assert
+        a.Should().BeEquivalentTo(b);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Search.Tests/Models/SearchSortTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Search.Tests/Models/SearchSortTests.cs
@@ -1,0 +1,98 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchSortTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search.Tests.Models;
+
+public class SearchSortTests
+{
+    [Fact]
+    public void Constructor_WithFieldOnly_DefaultsToAscending()
+    {
+        // Act
+        var sort = new SearchSort("price");
+
+        // Assert
+        sort.Field.Should().Be("price");
+        sort.Direction.Should().Be(SortDirection.Asc);
+    }
+
+    [Fact]
+    public void Constructor_WithExplicitDirection_AssignsBothFields()
+    {
+        // Act
+        var sort = new SearchSort("created_at", SortDirection.Desc);
+
+        // Assert
+        sort.Field.Should().Be("created_at");
+        sort.Direction.Should().Be(SortDirection.Desc);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Constructor_WithBlankField_Throws(string? field)
+    {
+        // Act
+        var act = () => new SearchSort(field!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithParameterName("field");
+    }
+
+    [Fact]
+    public void Ascending_Factory_BuildsAscendingSort()
+    {
+        // Act
+        var sort = SearchSort.Ascending("name");
+
+        // Assert
+        sort.Field.Should().Be("name");
+        sort.Direction.Should().Be(SortDirection.Asc);
+    }
+
+    [Fact]
+    public void Descending_Factory_BuildsDescendingSort()
+    {
+        // Act
+        var sort = SearchSort.Descending("name");
+
+        // Assert
+        sort.Field.Should().Be("name");
+        sort.Direction.Should().Be(SortDirection.Desc);
+    }
+
+    [Fact]
+    public void Records_WithSameValues_AreEqual()
+    {
+        // Arrange
+        var a = new SearchSort("price", SortDirection.Desc);
+        var b = new SearchSort("price", SortDirection.Desc);
+
+        // Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Records_WithDifferentDirection_AreNotEqual()
+    {
+        // Arrange
+        var asc = new SearchSort("price");
+        var desc = new SearchSort("price", SortDirection.Desc);
+
+        // Assert
+        asc.Should().NotBe(desc);
+    }
+
+    [Fact]
+    public void SortDirection_HasExpectedMembers()
+    {
+        // Assert
+        Enum.GetNames<SortDirection>().Should().BeEquivalentTo("Asc", "Desc");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Search.Tests/SearchErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Search.Tests/SearchErrorsTests.cs
@@ -1,0 +1,93 @@
+// -----------------------------------------------------------------------
+// <copyright file="SearchErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Search.Tests;
+
+public class SearchErrorsTests
+{
+    [Fact]
+    public void Prefix_IsSearch()
+    {
+        // Assert
+        SearchErrors.Prefix.Should().Be("Search");
+    }
+
+    [Fact]
+    public void IndexNotFound_ReturnsNotFoundErrorWithIndexName()
+    {
+        // Act
+        var error = SearchErrors.IndexNotFound("products");
+
+        // Assert
+        error.Code.Should().Be("Search.IndexNotFound");
+        error.Message.Should().Contain("products");
+        error.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public void InvalidQuery_ReturnsValidationErrorWithReason()
+    {
+        // Act
+        var error = SearchErrors.InvalidQuery("missing closing brace");
+
+        // Assert
+        error.Code.Should().Be("Search.InvalidQuery");
+        error.Message.Should().Contain("missing closing brace");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
+
+    [Fact]
+    public void AttributeNotFilterable_ReturnsValidationErrorWithAttribute()
+    {
+        // Act
+        var error = SearchErrors.AttributeNotFilterable("price");
+
+        // Assert
+        error.Code.Should().Be("Search.AttributeNotFilterable");
+        error.Message.Should().Contain("price");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
+
+    [Fact]
+    public void AttributeNotSortable_ReturnsValidationErrorWithAttribute()
+    {
+        // Act
+        var error = SearchErrors.AttributeNotSortable("created_at");
+
+        // Assert
+        error.Code.Should().Be("Search.AttributeNotSortable");
+        error.Message.Should().Contain("created_at");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
+
+    [Fact]
+    public void Throttled_WithoutRetryAfter_ReturnsTooManyRequestsWithGenericMessage()
+    {
+        // Act
+        var error = SearchErrors.Throttled();
+
+        // Assert
+        error.Code.Should().Be("Search.Throttled");
+        error.Message.Should().Contain("throttled");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+    }
+
+    [Fact]
+    public void Throttled_WithRetryAfter_IncludesRetrySeconds()
+    {
+        // Arrange
+        var retryAfter = TimeSpan.FromSeconds(45);
+
+        // Act
+        var error = SearchErrors.Throttled(retryAfter);
+
+        // Assert
+        error.Code.Should().Be("Search.Throttled");
+        error.Message.Should().Contain("45");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+    }
+}


### PR DESCRIPTION
## Summary
Defines ISearchIndex port in new Compendium.Abstractions.Search assembly. Unblocks compendium-adapter-meilisearch / typesense / elasticsearch per ADR-0006.

## Surface
- ISearchIndex (EnsureIndex / Index<T> / Delete / Search<T>)
- SearchQuery, SearchResult<T>, SearchHit<T>, IndexSettings, SearchSort records
- SortDirection enum, SearchErrors factories

## Coverage >= 90 % line.

## Test plan
- [x] dotnet build green
- [x] dotnet test green
- [x] Coverage >= 90 %
- [ ] CI green