### PR TITLE
feat(abstractions/vectorstore): define IVectorStore port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -117,6 +117,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Ide
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Billing.Tests", "tests\Unit\Compendium.Abstractions.Billing.Tests\Compendium.Abstractions.Billing.Tests.csproj", "{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17}"
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Email.Tests", "tests\Unit\Compendium.Abstractions.Email.Tests\Compendium.Abstractions.Email.Tests.csproj", "{BAD4540D-5310-4623-9441-0328DD43879B}"
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Tests", "tests\Unit\Compendium.Abstractions.Tests\Compendium.Abstractions.Tests.csproj", "{071D6168-7960-4B44-83A0-6A73312EE034}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.VectorStore", "src\Abstractions\Compendium.Abstractions.VectorStore\Compendium.Abstractions.VectorStore.csproj", "{A2970BBA-F52C-4203-B529-D8B92738F93E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.VectorStore.Tests", "tests\Unit\Compendium.Abstractions.VectorStore.Tests\Compendium.Abstractions.VectorStore.Tests.csproj", "{61932BC1-0068-4F8A-927F-C45E536598E0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -311,6 +313,14 @@ Global
 		{071D6168-7960-4B44-83A0-6A73312EE034}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{071D6168-7960-4B44-83A0-6A73312EE034}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{071D6168-7960-4B44-83A0-6A73312EE034}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2970BBA-F52C-4203-B529-D8B92738F93E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2970BBA-F52C-4203-B529-D8B92738F93E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2970BBA-F52C-4203-B529-D8B92738F93E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2970BBA-F52C-4203-B529-D8B92738F93E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61932BC1-0068-4F8A-927F-C45E536598E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61932BC1-0068-4F8A-927F-C45E536598E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61932BC1-0068-4F8A-927F-C45E536598E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61932BC1-0068-4F8A-927F-C45E536598E0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -371,5 +381,7 @@ Global
 		{A3257DCF-9F77-4CEE-8FE5-7E8C569F0B17} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{BAD4540D-5310-4623-9441-0328DD43879B} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{071D6168-7960-4B44-83A0-6A73312EE034} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{A2970BBA-F52C-4203-B529-D8B92738F93E} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
+		{61932BC1-0068-4F8A-927F-C45E536598E0} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.VectorStore/Compendium.Abstractions.VectorStore.csproj
+++ b/src/Abstractions/Compendium.Abstractions.VectorStore/Compendium.Abstractions.VectorStore.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.VectorStore</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.VectorStore</RootNamespace>
+    <PackageId>Compendium.Abstractions.VectorStore</PackageId>
+    <Description>Vector store abstractions for Compendium Framework: IVectorStore port for embedding storage, similarity search and tenant-aware filtering. Provider-agnostic interfaces for pgvector, Qdrant, Weaviate, Pinecone and other vector databases.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.VectorStore.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.VectorStore/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.VectorStore/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.VectorStore/IVectorStore.cs
+++ b/src/Abstractions/Compendium.Abstractions.VectorStore/IVectorStore.cs
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------
+// <copyright file="IVectorStore.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.VectorStore.Models;
+
+namespace Compendium.Abstractions.VectorStore;
+
+/// <summary>
+/// Provides storage and similarity search over dense embedding vectors.
+/// This port is provider-agnostic and can be implemented by adapters such as
+/// pgvector, Qdrant, Weaviate, or Pinecone.
+/// </summary>
+public interface IVectorStore
+{
+    /// <summary>
+    /// Ensures the named collection exists with the supplied dimension and distance metric.
+    /// Implementations must be idempotent.
+    /// </summary>
+    /// <param name="collection">The collection (a.k.a. index/namespace) name.</param>
+    /// <param name="dimension">The required embedding dimension.</param>
+    /// <param name="metric">The distance metric to use for similarity search.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result indicating success or an error with details.</returns>
+    Task<Result> EnsureCollectionAsync(
+        string collection,
+        int dimension,
+        DistanceMetric metric,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts or updates the supplied records in the named collection.
+    /// </summary>
+    /// <param name="collection">The collection name.</param>
+    /// <param name="records">The records to upsert.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result indicating success or an error with details.</returns>
+    Task<Result> UpsertAsync(
+        string collection,
+        IReadOnlyList<VectorRecord> records,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes records with the supplied identifiers from the named collection.
+    /// </summary>
+    /// <param name="collection">The collection name.</param>
+    /// <param name="ids">The identifiers of records to delete.</param>
+    /// <param name="tenantId">Optional tenant scope; when supplied, only records owned by the tenant are deleted.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result indicating success or an error with details.</returns>
+    Task<Result> DeleteAsync(
+        string collection,
+        IReadOnlyList<string> ids,
+        string? tenantId = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Searches the named collection for the records whose embeddings are most similar to <paramref name="query"/>.
+    /// </summary>
+    /// <param name="collection">The collection name.</param>
+    /// <param name="query">The query embedding.</param>
+    /// <param name="topK">The maximum number of matches to return.</param>
+    /// <param name="filter">Optional metadata filter to restrict the candidate set.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the matches ordered by similarity score, or an error.</returns>
+    Task<Result<IReadOnlyList<VectorMatch>>> SearchAsync(
+        string collection,
+        ReadOnlyMemory<float> query,
+        int topK,
+        VectorFilter? filter = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/Compendium.Abstractions.VectorStore/Models/DistanceMetric.cs
+++ b/src/Abstractions/Compendium.Abstractions.VectorStore/Models/DistanceMetric.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------
+// <copyright file="DistanceMetric.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.VectorStore.Models;
+
+/// <summary>
+/// Defines the distance metric used to compare vectors during similarity search.
+/// </summary>
+public enum DistanceMetric
+{
+    /// <summary>
+    /// Cosine similarity (angular distance). Range typically [-1, 1] or [0, 2] depending on backend.
+    /// </summary>
+    Cosine = 0,
+
+    /// <summary>
+    /// Euclidean (L2) distance. Lower means closer.
+    /// </summary>
+    L2 = 1,
+
+    /// <summary>
+    /// Inner (dot) product. Higher means closer.
+    /// </summary>
+    InnerProduct = 2,
+}

--- a/src/Abstractions/Compendium.Abstractions.VectorStore/Models/VectorFilter.cs
+++ b/src/Abstractions/Compendium.Abstractions.VectorStore/Models/VectorFilter.cs
@@ -1,0 +1,204 @@
+// -----------------------------------------------------------------------
+// <copyright file="VectorFilter.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.VectorStore.Models;
+
+/// <summary>
+/// Identifies the kind of operation represented by a <see cref="VectorFilter"/> node.
+/// </summary>
+public enum VectorFilterKind
+{
+    /// <summary>Equality on a metadata field.</summary>
+    Eq = 0,
+
+    /// <summary>Inequality on a metadata field.</summary>
+    Ne = 1,
+
+    /// <summary>Membership of a metadata field value in a finite set.</summary>
+    In = 2,
+
+    /// <summary>Inclusive/exclusive range comparison on a metadata field.</summary>
+    Range = 3,
+
+    /// <summary>Logical conjunction over child filters.</summary>
+    And = 4,
+
+    /// <summary>Logical disjunction over child filters.</summary>
+    Or = 5,
+}
+
+/// <summary>
+/// Represents a tenant-aware metadata filter applied to a vector search.
+/// Instances are immutable and built through the static factories.
+/// </summary>
+public sealed class VectorFilter
+{
+    private VectorFilter(
+        VectorFilterKind kind,
+        string? field,
+        object? value,
+        IReadOnlyList<object>? values,
+        object? rangeMin,
+        object? rangeMax,
+        bool rangeMinInclusive,
+        bool rangeMaxInclusive,
+        IReadOnlyList<VectorFilter>? children,
+        string? tenantId)
+    {
+        Kind = kind;
+        Field = field;
+        Value = value;
+        Values = values;
+        RangeMin = rangeMin;
+        RangeMax = rangeMax;
+        RangeMinInclusive = rangeMinInclusive;
+        RangeMaxInclusive = rangeMaxInclusive;
+        Children = children;
+        TenantId = tenantId;
+    }
+
+    /// <summary>Gets the kind of filter node.</summary>
+    public VectorFilterKind Kind { get; }
+
+    /// <summary>Gets the metadata field this filter targets, when applicable.</summary>
+    public string? Field { get; }
+
+    /// <summary>Gets the value compared by the filter, when applicable (<see cref="VectorFilterKind.Eq"/> / <see cref="VectorFilterKind.Ne"/>).</summary>
+    public object? Value { get; }
+
+    /// <summary>Gets the values compared by the filter, when applicable (<see cref="VectorFilterKind.In"/>).</summary>
+    public IReadOnlyList<object>? Values { get; }
+
+    /// <summary>Gets the inclusive/exclusive lower bound of a range filter, when applicable.</summary>
+    public object? RangeMin { get; }
+
+    /// <summary>Gets the inclusive/exclusive upper bound of a range filter, when applicable.</summary>
+    public object? RangeMax { get; }
+
+    /// <summary>Gets a value indicating whether the lower bound is inclusive.</summary>
+    public bool RangeMinInclusive { get; }
+
+    /// <summary>Gets a value indicating whether the upper bound is inclusive.</summary>
+    public bool RangeMaxInclusive { get; }
+
+    /// <summary>Gets the children of an <see cref="VectorFilterKind.And"/> / <see cref="VectorFilterKind.Or"/> node.</summary>
+    public IReadOnlyList<VectorFilter>? Children { get; }
+
+    /// <summary>Gets the tenant scope attached to this filter, if any.</summary>
+    public string? TenantId { get; }
+
+    /// <summary>
+    /// Builds an equality filter on a metadata field.
+    /// </summary>
+    public static VectorFilter Eq(string field, object value)
+    {
+        EnsureField(field);
+        ArgumentNullException.ThrowIfNull(value);
+        return new VectorFilter(VectorFilterKind.Eq, field, value, null, null, null, true, true, null, null);
+    }
+
+    /// <summary>
+    /// Builds a non-equality filter on a metadata field.
+    /// </summary>
+    public static VectorFilter Ne(string field, object value)
+    {
+        EnsureField(field);
+        ArgumentNullException.ThrowIfNull(value);
+        return new VectorFilter(VectorFilterKind.Ne, field, value, null, null, null, true, true, null, null);
+    }
+
+    /// <summary>
+    /// Builds a membership filter on a metadata field over a finite set of values.
+    /// </summary>
+    public static VectorFilter In(string field, IEnumerable<object> values)
+    {
+        EnsureField(field);
+        ArgumentNullException.ThrowIfNull(values);
+        var list = values.ToList();
+        if (list.Count == 0)
+        {
+            throw new ArgumentException("In() requires at least one value.", nameof(values));
+        }
+
+        return new VectorFilter(VectorFilterKind.In, field, null, list, null, null, true, true, null, null);
+    }
+
+    /// <summary>
+    /// Builds a range filter on a metadata field. At least one of <paramref name="min"/> or <paramref name="max"/> must be supplied.
+    /// </summary>
+    public static VectorFilter Range(
+        string field,
+        object? min,
+        object? max,
+        bool minInclusive = true,
+        bool maxInclusive = true)
+    {
+        EnsureField(field);
+        if (min is null && max is null)
+        {
+            throw new ArgumentException("Range() requires at least one bound.", nameof(min));
+        }
+
+        return new VectorFilter(VectorFilterKind.Range, field, null, null, min, max, minInclusive, maxInclusive, null, null);
+    }
+
+    /// <summary>
+    /// Combines filters with a logical AND.
+    /// </summary>
+    public static VectorFilter And(params VectorFilter[] filters)
+    {
+        return Combine(VectorFilterKind.And, filters);
+    }
+
+    /// <summary>
+    /// Combines filters with a logical OR.
+    /// </summary>
+    public static VectorFilter Or(params VectorFilter[] filters)
+    {
+        return Combine(VectorFilterKind.Or, filters);
+    }
+
+    /// <summary>
+    /// Returns a new filter scoped to the supplied tenant. The original filter is not modified.
+    /// </summary>
+    public VectorFilter ForTenant(string tenantId)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new ArgumentException("Tenant id must be a non-empty string.", nameof(tenantId));
+        }
+
+        return new VectorFilter(Kind, Field, Value, Values, RangeMin, RangeMax, RangeMinInclusive, RangeMaxInclusive, Children, tenantId);
+    }
+
+    private static VectorFilter Combine(VectorFilterKind kind, VectorFilter[] filters)
+    {
+        ArgumentNullException.ThrowIfNull(filters);
+        if (filters.Length == 0)
+        {
+            throw new ArgumentException("At least one child filter is required.", nameof(filters));
+        }
+
+        foreach (var f in filters)
+        {
+            if (f is null)
+            {
+                throw new ArgumentException("Child filter cannot be null.", nameof(filters));
+            }
+        }
+
+        return new VectorFilter(kind, null, null, null, null, null, true, true, filters, null);
+    }
+
+    private static void EnsureField(string field)
+    {
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            throw new ArgumentException("Field name must be a non-empty string.", nameof(field));
+        }
+    }
+}

--- a/src/Abstractions/Compendium.Abstractions.VectorStore/Models/VectorMatch.cs
+++ b/src/Abstractions/Compendium.Abstractions.VectorStore/Models/VectorMatch.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+// <copyright file="VectorMatch.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.VectorStore.Models;
+
+/// <summary>
+/// Represents a single match returned by a similarity search.
+/// </summary>
+/// <param name="Id">The identifier of the matched record.</param>
+/// <param name="Score">The similarity score; semantics depend on the configured <see cref="DistanceMetric"/>.</param>
+/// <param name="Metadata">Metadata associated with the matched record.</param>
+/// <param name="TenantId">Optional tenant identifier of the matched record.</param>
+public sealed record VectorMatch(
+    string Id,
+    float Score,
+    IReadOnlyDictionary<string, object> Metadata,
+    string? TenantId = null);

--- a/src/Abstractions/Compendium.Abstractions.VectorStore/Models/VectorRecord.cs
+++ b/src/Abstractions/Compendium.Abstractions.VectorStore/Models/VectorRecord.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+// <copyright file="VectorRecord.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.VectorStore.Models;
+
+/// <summary>
+/// Represents a vector record to be stored in or retrieved from a vector store.
+/// </summary>
+/// <param name="Id">The stable identifier of the record within its collection.</param>
+/// <param name="Embedding">The dense embedding vector.</param>
+/// <param name="Metadata">Arbitrary metadata indexed alongside the vector and usable in filters.</param>
+/// <param name="TenantId">Optional tenant identifier used to enforce per-tenant isolation.</param>
+public sealed record VectorRecord(
+    string Id,
+    ReadOnlyMemory<float> Embedding,
+    IReadOnlyDictionary<string, object> Metadata,
+    string? TenantId = null);

--- a/src/Abstractions/Compendium.Abstractions.VectorStore/VectorStoreErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.VectorStore/VectorStoreErrors.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------
+// <copyright file="VectorStoreErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.VectorStore;
+
+/// <summary>
+/// Provides standardized error definitions for vector store operations.
+/// </summary>
+public static class VectorStoreErrors
+{
+    /// <summary>
+    /// Gets the error code prefix for vector store errors.
+    /// </summary>
+    public const string Prefix = "VectorStore";
+
+    /// <summary>
+    /// The requested collection does not exist.
+    /// </summary>
+    public static Error CollectionNotFound(string collection) =>
+        Error.NotFound($"{Prefix}.CollectionNotFound", $"Collection '{collection}' was not found.");
+
+    /// <summary>
+    /// The supplied embedding dimension does not match the collection configuration.
+    /// </summary>
+    public static Error DimensionMismatch(int expected, int actual) =>
+        Error.Validation(
+            $"{Prefix}.DimensionMismatch",
+            $"Embedding dimension mismatch: expected {expected}, got {actual}.");
+
+    /// <summary>
+    /// No record with the supplied identifier exists in the collection.
+    /// </summary>
+    public static Error IdNotFound(string id) =>
+        Error.NotFound($"{Prefix}.IdNotFound", $"Record with id '{id}' was not found.");
+
+    /// <summary>
+    /// The supplied filter could not be translated or is malformed.
+    /// </summary>
+    public static Error InvalidFilter(string reason) =>
+        Error.Validation($"{Prefix}.InvalidFilter", $"Invalid filter: {reason}.");
+
+    /// <summary>
+    /// The vector store rejected the request due to throttling/rate limits.
+    /// </summary>
+    public static Error Throttled(TimeSpan? retryAfter = null) =>
+        Error.TooManyRequests(
+            $"{Prefix}.Throttled",
+            retryAfter.HasValue
+                ? $"Vector store throttled the request. Retry after {retryAfter.Value.TotalSeconds} seconds."
+                : "Vector store throttled the request. Please try again later.");
+}

--- a/tests/Unit/Compendium.Abstractions.VectorStore.Tests/Compendium.Abstractions.VectorStore.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.VectorStore.Tests/Compendium.Abstractions.VectorStore.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.VectorStore.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.VectorStore.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.VectorStore\Compendium.Abstractions.VectorStore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.VectorStore.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.VectorStore.Tests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using Xunit;
+global using FluentAssertions;
+global using NSubstitute;
+global using Compendium.Abstractions.VectorStore;
+global using Compendium.Abstractions.VectorStore.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.VectorStore.Tests/Models/DistanceMetricTests.cs
+++ b/tests/Unit/Compendium.Abstractions.VectorStore.Tests/Models/DistanceMetricTests.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------
+// <copyright file="DistanceMetricTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.VectorStore.Tests.Models;
+
+public class DistanceMetricTests
+{
+    [Theory]
+    [InlineData(DistanceMetric.Cosine, 0)]
+    [InlineData(DistanceMetric.L2, 1)]
+    [InlineData(DistanceMetric.InnerProduct, 2)]
+    public void DistanceMetric_HasStableNumericValues(DistanceMetric metric, int expected)
+    {
+        // Act / Assert
+        ((int)metric).Should().Be(expected);
+    }
+
+    [Fact]
+    public void DistanceMetric_HasExactlyThreeMembers()
+    {
+        // Act
+        var values = Enum.GetValues<DistanceMetric>();
+
+        // Assert
+        values.Should().HaveCount(3);
+        values.Should().BeEquivalentTo(new[] { DistanceMetric.Cosine, DistanceMetric.L2, DistanceMetric.InnerProduct });
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.VectorStore.Tests/Models/VectorFilterTests.cs
+++ b/tests/Unit/Compendium.Abstractions.VectorStore.Tests/Models/VectorFilterTests.cs
@@ -1,0 +1,309 @@
+// -----------------------------------------------------------------------
+// <copyright file="VectorFilterTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.VectorStore.Tests.Models;
+
+public class VectorFilterTests
+{
+    [Fact]
+    public void Eq_BuildsEqualityNode()
+    {
+        // Act
+        var filter = VectorFilter.Eq("category", "books");
+
+        // Assert
+        filter.Kind.Should().Be(VectorFilterKind.Eq);
+        filter.Field.Should().Be("category");
+        filter.Value.Should().Be("books");
+        filter.Values.Should().BeNull();
+        filter.Children.Should().BeNull();
+        filter.TenantId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Ne_BuildsInequalityNode()
+    {
+        // Act
+        var filter = VectorFilter.Ne("status", "deleted");
+
+        // Assert
+        filter.Kind.Should().Be(VectorFilterKind.Ne);
+        filter.Field.Should().Be("status");
+        filter.Value.Should().Be("deleted");
+    }
+
+    [Fact]
+    public void In_BuildsMembershipNode()
+    {
+        // Arrange
+        var values = new object[] { "a", "b", "c" };
+
+        // Act
+        var filter = VectorFilter.In("tag", values);
+
+        // Assert
+        filter.Kind.Should().Be(VectorFilterKind.In);
+        filter.Field.Should().Be("tag");
+        filter.Values.Should().NotBeNull();
+        filter.Values!.Should().Equal("a", "b", "c");
+    }
+
+    [Fact]
+    public void Range_WithBothBounds_PreservesInclusivity()
+    {
+        // Act
+        var filter = VectorFilter.Range("price", 10, 100, minInclusive: false, maxInclusive: true);
+
+        // Assert
+        filter.Kind.Should().Be(VectorFilterKind.Range);
+        filter.Field.Should().Be("price");
+        filter.RangeMin.Should().Be(10);
+        filter.RangeMax.Should().Be(100);
+        filter.RangeMinInclusive.Should().BeFalse();
+        filter.RangeMaxInclusive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Range_WithOnlyMin_IsAccepted()
+    {
+        // Act
+        var filter = VectorFilter.Range("price", 5, null);
+
+        // Assert
+        filter.RangeMin.Should().Be(5);
+        filter.RangeMax.Should().BeNull();
+    }
+
+    [Fact]
+    public void Range_WithOnlyMax_IsAccepted()
+    {
+        // Act
+        var filter = VectorFilter.Range("price", null, 50);
+
+        // Assert
+        filter.RangeMin.Should().BeNull();
+        filter.RangeMax.Should().Be(50);
+    }
+
+    [Fact]
+    public void And_BuildsConjunction()
+    {
+        // Arrange
+        var a = VectorFilter.Eq("a", 1);
+        var b = VectorFilter.Eq("b", 2);
+
+        // Act
+        var combined = VectorFilter.And(a, b);
+
+        // Assert
+        combined.Kind.Should().Be(VectorFilterKind.And);
+        combined.Children.Should().NotBeNull();
+        combined.Children!.Should().HaveCount(2);
+        combined.Children![0].Should().BeSameAs(a);
+        combined.Children![1].Should().BeSameAs(b);
+        combined.Field.Should().BeNull();
+        combined.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public void Or_BuildsDisjunction()
+    {
+        // Arrange
+        var a = VectorFilter.Eq("a", 1);
+
+        // Act
+        var combined = VectorFilter.Or(a);
+
+        // Assert
+        combined.Kind.Should().Be(VectorFilterKind.Or);
+        combined.Children!.Should().ContainSingle().Which.Should().BeSameAs(a);
+    }
+
+    [Fact]
+    public void ForTenant_ReturnsScopedClone_WithoutMutatingOriginal()
+    {
+        // Arrange
+        var original = VectorFilter.Eq("kind", "doc");
+
+        // Act
+        var scoped = original.ForTenant("tenant-7");
+
+        // Assert
+        scoped.Should().NotBeSameAs(original);
+        scoped.TenantId.Should().Be("tenant-7");
+        scoped.Kind.Should().Be(VectorFilterKind.Eq);
+        scoped.Field.Should().Be("kind");
+        scoped.Value.Should().Be("doc");
+        original.TenantId.Should().BeNull();
+    }
+
+    [Fact]
+    public void ForTenant_PreservesCompoundShape()
+    {
+        // Arrange
+        var compound = VectorFilter.And(VectorFilter.Eq("a", 1), VectorFilter.Ne("b", 2));
+
+        // Act
+        var scoped = compound.ForTenant("t-99");
+
+        // Assert
+        scoped.Kind.Should().Be(VectorFilterKind.And);
+        scoped.Children.Should().BeSameAs(compound.Children);
+        scoped.TenantId.Should().Be("t-99");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Eq_WithBlankField_Throws(string? field)
+    {
+        // Act
+        var act = () => VectorFilter.Eq(field!, "x");
+
+        // Assert
+        act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("field");
+    }
+
+    [Fact]
+    public void Eq_WithNullValue_Throws()
+    {
+        // Act
+        var act = () => VectorFilter.Eq("k", null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("value");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Ne_WithBlankField_Throws(string? field)
+    {
+        // Act
+        var act = () => VectorFilter.Ne(field!, "x");
+
+        // Assert
+        act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("field");
+    }
+
+    [Fact]
+    public void Ne_WithNullValue_Throws()
+    {
+        // Act
+        var act = () => VectorFilter.Ne("k", null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("value");
+    }
+
+    [Fact]
+    public void In_WithBlankField_Throws()
+    {
+        // Act
+        var act = () => VectorFilter.In(" ", new object[] { 1 });
+
+        // Assert
+        act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("field");
+    }
+
+    [Fact]
+    public void In_WithNullValues_Throws()
+    {
+        // Act
+        var act = () => VectorFilter.In("k", null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("values");
+    }
+
+    [Fact]
+    public void In_WithEmptyValues_Throws()
+    {
+        // Act
+        var act = () => VectorFilter.In("k", Array.Empty<object>());
+
+        // Assert
+        act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("values");
+    }
+
+    [Fact]
+    public void Range_WithBlankField_Throws()
+    {
+        // Act
+        var act = () => VectorFilter.Range("", 0, 10);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("field");
+    }
+
+    [Fact]
+    public void Range_WithNoBounds_Throws()
+    {
+        // Act
+        var act = () => VectorFilter.Range("price", null, null);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void And_WithNoArgs_Throws()
+    {
+        // Act
+        var act = () => VectorFilter.And();
+
+        // Assert
+        act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("filters");
+    }
+
+    [Fact]
+    public void Or_WithNoArgs_Throws()
+    {
+        // Act
+        var act = () => VectorFilter.Or();
+
+        // Assert
+        act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("filters");
+    }
+
+    [Fact]
+    public void And_WithNullFiltersArray_Throws()
+    {
+        // Act
+        var act = () => VectorFilter.And((VectorFilter[])null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("filters");
+    }
+
+    [Fact]
+    public void Or_WithNullChild_Throws()
+    {
+        // Act
+        var act = () => VectorFilter.Or(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("filters");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void ForTenant_WithBlankTenantId_Throws(string? tenantId)
+    {
+        // Arrange
+        var filter = VectorFilter.Eq("a", 1);
+
+        // Act
+        var act = () => filter.ForTenant(tenantId!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("tenantId");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.VectorStore.Tests/Models/VectorMatchTests.cs
+++ b/tests/Unit/Compendium.Abstractions.VectorStore.Tests/Models/VectorMatchTests.cs
@@ -1,0 +1,66 @@
+// -----------------------------------------------------------------------
+// <copyright file="VectorMatchTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.VectorStore.Tests.Models;
+
+public class VectorMatchTests
+{
+    [Fact]
+    public void VectorMatch_Construct_AssignsAllProperties()
+    {
+        // Arrange
+        var metadata = new Dictionary<string, object> { ["source"] = "wiki" };
+
+        // Act
+        var match = new VectorMatch("doc-9", 0.87f, metadata, "tenant-x");
+
+        // Assert
+        match.Id.Should().Be("doc-9");
+        match.Score.Should().Be(0.87f);
+        match.Metadata.Should().BeSameAs(metadata);
+        match.TenantId.Should().Be("tenant-x");
+    }
+
+    [Fact]
+    public void VectorMatch_TenantId_DefaultsToNull()
+    {
+        // Arrange / Act
+        var match = new VectorMatch("doc-1", 0f, new Dictionary<string, object>());
+
+        // Assert
+        match.TenantId.Should().BeNull();
+    }
+
+    [Fact]
+    public void VectorMatch_RecordEquality_HoldsForSameComponents()
+    {
+        // Arrange
+        var metadata = new Dictionary<string, object> { ["k"] = "v" };
+
+        // Act
+        var first = new VectorMatch("id", 0.5f, metadata, "t");
+        var second = new VectorMatch("id", 0.5f, metadata, "t");
+
+        // Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void VectorMatch_RecordEquality_DiffersOnScore()
+    {
+        // Arrange
+        var metadata = new Dictionary<string, object>();
+
+        // Act
+        var first = new VectorMatch("id", 0.5f, metadata);
+        var second = new VectorMatch("id", 0.6f, metadata);
+
+        // Assert
+        first.Should().NotBe(second);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.VectorStore.Tests/Models/VectorRecordTests.cs
+++ b/tests/Unit/Compendium.Abstractions.VectorStore.Tests/Models/VectorRecordTests.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="VectorRecordTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.VectorStore.Tests.Models;
+
+public class VectorRecordTests
+{
+    [Fact]
+    public void VectorRecord_Construct_AssignsAllProperties()
+    {
+        // Arrange
+        var embedding = new ReadOnlyMemory<float>(new[] { 0.1f, 0.2f, 0.3f });
+        var metadata = new Dictionary<string, object> { ["k"] = "v" };
+
+        // Act
+        var record = new VectorRecord("doc-1", embedding, metadata, "tenant-1");
+
+        // Assert
+        record.Id.Should().Be("doc-1");
+        record.Embedding.ToArray().Should().Equal(0.1f, 0.2f, 0.3f);
+        record.Metadata.Should().BeSameAs(metadata);
+        record.TenantId.Should().Be("tenant-1");
+    }
+
+    [Fact]
+    public void VectorRecord_TenantId_DefaultsToNull()
+    {
+        // Arrange
+        var metadata = new Dictionary<string, object>();
+
+        // Act
+        var record = new VectorRecord("doc-1", ReadOnlyMemory<float>.Empty, metadata);
+
+        // Assert
+        record.TenantId.Should().BeNull();
+    }
+
+    [Fact]
+    public void VectorRecord_RecordEquality_HoldsForSameComponents()
+    {
+        // Arrange
+        var embedding = new ReadOnlyMemory<float>(new[] { 1f });
+        var metadata = new Dictionary<string, object> { ["a"] = 1 };
+
+        // Act
+        var first = new VectorRecord("id", embedding, metadata, "t");
+        var second = new VectorRecord("id", embedding, metadata, "t");
+
+        // Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void VectorRecord_RecordEquality_DiffersOnId()
+    {
+        // Arrange
+        var embedding = ReadOnlyMemory<float>.Empty;
+        var metadata = new Dictionary<string, object>();
+
+        // Act
+        var first = new VectorRecord("id-a", embedding, metadata);
+        var second = new VectorRecord("id-b", embedding, metadata);
+
+        // Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void VectorRecord_With_OverridesTenantId()
+    {
+        // Arrange
+        var record = new VectorRecord("id", ReadOnlyMemory<float>.Empty, new Dictionary<string, object>(), "t-1");
+
+        // Act
+        var rotated = record with { TenantId = "t-2" };
+
+        // Assert
+        rotated.TenantId.Should().Be("t-2");
+        record.TenantId.Should().Be("t-1");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.VectorStore.Tests/VectorStoreErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.VectorStore.Tests/VectorStoreErrorsTests.cs
@@ -1,0 +1,90 @@
+// -----------------------------------------------------------------------
+// <copyright file="VectorStoreErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.VectorStore.Tests;
+
+public class VectorStoreErrorsTests
+{
+    [Fact]
+    public void Prefix_IsVectorStore()
+    {
+        // Assert
+        VectorStoreErrors.Prefix.Should().Be("VectorStore");
+    }
+
+    [Fact]
+    public void CollectionNotFound_ReturnsNotFoundError()
+    {
+        // Act
+        var error = VectorStoreErrors.CollectionNotFound("docs");
+
+        // Assert
+        error.Code.Should().Be("VectorStore.CollectionNotFound");
+        error.Message.Should().Contain("docs");
+        error.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public void DimensionMismatch_ReturnsValidationError()
+    {
+        // Act
+        var error = VectorStoreErrors.DimensionMismatch(1536, 768);
+
+        // Assert
+        error.Code.Should().Be("VectorStore.DimensionMismatch");
+        error.Message.Should().Contain("1536");
+        error.Message.Should().Contain("768");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
+
+    [Fact]
+    public void IdNotFound_ReturnsNotFoundError()
+    {
+        // Act
+        var error = VectorStoreErrors.IdNotFound("doc-42");
+
+        // Assert
+        error.Code.Should().Be("VectorStore.IdNotFound");
+        error.Message.Should().Contain("doc-42");
+        error.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public void InvalidFilter_ReturnsValidationError()
+    {
+        // Act
+        var error = VectorStoreErrors.InvalidFilter("unknown operator");
+
+        // Assert
+        error.Code.Should().Be("VectorStore.InvalidFilter");
+        error.Message.Should().Contain("unknown operator");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
+
+    [Fact]
+    public void Throttled_WithoutRetryAfter_ReturnsTooManyRequestsErrorWithGenericMessage()
+    {
+        // Act
+        var error = VectorStoreErrors.Throttled();
+
+        // Assert
+        error.Code.Should().Be("VectorStore.Throttled");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().Contain("throttled");
+    }
+
+    [Fact]
+    public void Throttled_WithRetryAfter_IncludesRetrySeconds()
+    {
+        // Act
+        var error = VectorStoreErrors.Throttled(TimeSpan.FromSeconds(45));
+
+        // Assert
+        error.Code.Should().Be("VectorStore.Throttled");
+        error.Message.Should().Contain("45");
+    }
+}


### PR DESCRIPTION
## Summary
Defines IVectorStore port in a new Compendium.Abstractions.VectorStore assembly. Unblocks compendium-adapter-pgvector / qdrant / weaviate / pinecone per ADR-0006.

## Surface
- IVectorStore (EnsureCollection / Upsert / Delete / Search)
- VectorRecord, VectorMatch records
- VectorFilter builder, DistanceMetric enum
- VectorStoreErrors

## Coverage \u2265 90 % line.

## Test plan
- [x] dotnet build green
- [x] dotnet test green
- [x] Coverage \u2265 90 %
- [ ] CI green