### PR TITLE
feat(abstractions/analytics): define IProductAnalytics port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -133,6 +133,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Sea
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Search.Tests", "tests\Unit\Compendium.Abstractions.Search.Tests\Compendium.Abstractions.Search.Tests.csproj", "{7D018598-0092-4490-9D81-0E8FF1FA202D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Abstractions", "Abstractions", "{25C6CE4F-1EE7-4448-AC41-F3C3584AF7BA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Analytics", "src\Abstractions\Compendium.Abstractions.Analytics\Compendium.Abstractions.Analytics.csproj", "{C68ED9B6-9F78-4BDE-82BA-D197AFD27190}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Unit", "Unit", "{17245130-8317-4D67-B86D-BFA713DE2C1C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Analytics.Tests", "tests\Unit\Compendium.Abstractions.Analytics.Tests\Compendium.Abstractions.Analytics.Tests.csproj", "{AA96B706-D6F9-4858-850B-5D71F7CFCFD3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -342,6 +350,14 @@ Global
 		{7D018598-0092-4490-9D81-0E8FF1FA202D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7D018598-0092-4490-9D81-0E8FF1FA202D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7D018598-0092-4490-9D81-0E8FF1FA202D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C68ED9B6-9F78-4BDE-82BA-D197AFD27190}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C68ED9B6-9F78-4BDE-82BA-D197AFD27190}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C68ED9B6-9F78-4BDE-82BA-D197AFD27190}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C68ED9B6-9F78-4BDE-82BA-D197AFD27190}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA96B706-D6F9-4858-850B-5D71F7CFCFD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA96B706-D6F9-4858-850B-5D71F7CFCFD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA96B706-D6F9-4858-850B-5D71F7CFCFD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA96B706-D6F9-4858-850B-5D71F7CFCFD3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -406,5 +422,7 @@ Global
 		{61932BC1-0068-4F8A-927F-C45E536598E0} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{F8AF93A7-4628-42A8-AF92-FC38C2D3B414} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
 		{7D018598-0092-4490-9D81-0E8FF1FA202D} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{C68ED9B6-9F78-4BDE-82BA-D197AFD27190} = {25C6CE4F-1EE7-4448-AC41-F3C3584AF7BA}
+		{AA96B706-D6F9-4858-850B-5D71F7CFCFD3} = {17245130-8317-4D67-B86D-BFA713DE2C1C}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Analytics/AnalyticsErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Analytics/AnalyticsErrors.cs
@@ -1,0 +1,46 @@
+// -----------------------------------------------------------------------
+// <copyright file="AnalyticsErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Analytics;
+
+/// <summary>
+/// Provides standardized error definitions for product analytics operations.
+/// </summary>
+public static class AnalyticsErrors
+{
+    /// <summary>
+    /// Gets the error code prefix for analytics errors.
+    /// </summary>
+    public const string Prefix = "Analytics";
+
+    /// <summary>
+    /// The provided event payload failed validation.
+    /// </summary>
+    /// <param name="reason">A short explanation of why the event was rejected.</param>
+    public static Error InvalidEvent(string reason) =>
+        Error.Validation($"{Prefix}.InvalidEvent", $"Invalid analytics event: {reason}.");
+
+    /// <summary>
+    /// The analytics provider is unreachable or returned a transport-level failure.
+    /// </summary>
+    /// <param name="provider">The identifier of the analytics provider.</param>
+    public static Error ProviderUnreachable(string provider) =>
+        Error.Failure(
+            $"{Prefix}.ProviderUnreachable",
+            $"Analytics provider '{provider}' is unreachable.");
+
+    /// <summary>
+    /// The analytics provider returned a rate-limit response.
+    /// </summary>
+    /// <param name="retryAfter">Optional duration to wait before retrying.</param>
+    public static Error RateLimited(TimeSpan? retryAfter = null) =>
+        Error.Failure(
+            $"{Prefix}.RateLimited",
+            retryAfter.HasValue
+                ? $"Analytics provider rate limit exceeded. Retry after {retryAfter.Value.TotalSeconds} seconds."
+                : "Analytics provider rate limit exceeded. Please try again later.");
+}

--- a/src/Abstractions/Compendium.Abstractions.Analytics/Compendium.Abstractions.Analytics.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Analytics/Compendium.Abstractions.Analytics.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Analytics</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Analytics</RootNamespace>
+    <PackageId>Compendium.Abstractions.Analytics</PackageId>
+    <Description>Product analytics abstractions for Compendium Framework: IProductAnalytics. Provider-agnostic interfaces for tracking events, identifying users, grouping, and aliasing across analytics backends (PostHog, Mixpanel, Amplitude).</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Analytics.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Analytics/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Analytics/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.Analytics/IProductAnalytics.cs
+++ b/src/Abstractions/Compendium.Abstractions.Analytics/IProductAnalytics.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// <copyright file="IProductAnalytics.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Analytics.Models;
+
+namespace Compendium.Abstractions.Analytics;
+
+/// <summary>
+/// Provides product analytics operations such as event tracking, user identification,
+/// group association, and identity aliasing. This interface is provider-agnostic and
+/// can be implemented by analytics backends such as PostHog, Mixpanel, or Amplitude.
+/// </summary>
+public interface IProductAnalytics
+{
+    /// <summary>
+    /// Records an analytics event.
+    /// </summary>
+    /// <param name="evt">The event to track.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result indicating success or an error with details.</returns>
+    Task<Result> TrackAsync(AnalyticsEvent evt, CancellationToken ct);
+
+    /// <summary>
+    /// Associates a set of properties with a user identified by <paramref name="distinctId"/>.
+    /// </summary>
+    /// <param name="distinctId">The stable identifier for the user.</param>
+    /// <param name="properties">The properties to associate with the user.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result indicating success or an error with details.</returns>
+    Task<Result> IdentifyAsync(
+        string distinctId,
+        IReadOnlyDictionary<string, object> properties,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Associates a set of properties with a group (e.g. organization, account, project).
+    /// </summary>
+    /// <param name="groupType">The type of group (e.g. "organization", "account").</param>
+    /// <param name="groupKey">The unique key identifying the group within its type.</param>
+    /// <param name="properties">The properties to associate with the group.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result indicating success or an error with details.</returns>
+    Task<Result> GroupAsync(
+        string groupType,
+        string groupKey,
+        IReadOnlyDictionary<string, object> properties,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Merges a previously-used identity (typically anonymous) into a known distinct identity.
+    /// </summary>
+    /// <param name="previousId">The previously-used identifier (often anonymous).</param>
+    /// <param name="distinctId">The canonical distinct identifier to merge into.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result indicating success or an error with details.</returns>
+    Task<Result> AliasAsync(string previousId, string distinctId, CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Analytics/Models/AnalyticsEvent.cs
+++ b/src/Abstractions/Compendium.Abstractions.Analytics/Models/AnalyticsEvent.cs
@@ -1,0 +1,23 @@
+// -----------------------------------------------------------------------
+// <copyright file="AnalyticsEvent.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Analytics.Models;
+
+/// <summary>
+/// Represents a product analytics event captured for a specific user and tenant.
+/// </summary>
+/// <param name="Name">The event name (e.g. "order_placed", "user_signed_up").</param>
+/// <param name="DistinctId">The stable identifier for the user or entity triggering the event.</param>
+/// <param name="TenantId">The tenant identifier this event belongs to, enabling multi-tenant isolation.</param>
+/// <param name="Timestamp">The instant the event occurred.</param>
+/// <param name="Properties">Additional structured properties describing the event.</param>
+public sealed record AnalyticsEvent(
+    string Name,
+    string DistinctId,
+    string TenantId,
+    DateTimeOffset Timestamp,
+    IReadOnlyDictionary<string, object> Properties);

--- a/tests/Unit/Compendium.Abstractions.Analytics.Tests/AnalyticsErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Analytics.Tests/AnalyticsErrorsTests.cs
@@ -1,0 +1,72 @@
+// -----------------------------------------------------------------------
+// <copyright file="AnalyticsErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Analytics.Tests;
+
+public class AnalyticsErrorsTests
+{
+    [Fact]
+    public void Prefix_ShouldBeAnalytics()
+    {
+        // Act
+        var prefix = AnalyticsErrors.Prefix;
+
+        // Assert
+        prefix.Should().Be("Analytics");
+    }
+
+    [Fact]
+    public void InvalidEvent_ShouldReturnValidationError()
+    {
+        // Act
+        var error = AnalyticsErrors.InvalidEvent("name is empty");
+
+        // Assert
+        error.Code.Should().Be("Analytics.InvalidEvent");
+        error.Message.Should().Contain("name is empty");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
+
+    [Fact]
+    public void ProviderUnreachable_ShouldReturnFailureError()
+    {
+        // Act
+        var error = AnalyticsErrors.ProviderUnreachable("posthog");
+
+        // Assert
+        error.Code.Should().Be("Analytics.ProviderUnreachable");
+        error.Message.Should().Contain("posthog");
+        error.Type.Should().Be(ErrorType.Failure);
+    }
+
+    [Fact]
+    public void RateLimited_WithoutRetryAfter_ShouldReturnGenericMessage()
+    {
+        // Act
+        var error = AnalyticsErrors.RateLimited();
+
+        // Assert
+        error.Code.Should().Be("Analytics.RateLimited");
+        error.Message.Should().Contain("rate limit");
+        error.Type.Should().Be(ErrorType.Failure);
+    }
+
+    [Fact]
+    public void RateLimited_WithRetryAfter_ShouldIncludeRetryTime()
+    {
+        // Arrange
+        var retryAfter = TimeSpan.FromSeconds(45);
+
+        // Act
+        var error = AnalyticsErrors.RateLimited(retryAfter);
+
+        // Assert
+        error.Code.Should().Be("Analytics.RateLimited");
+        error.Message.Should().Contain("45");
+        error.Type.Should().Be(ErrorType.Failure);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Analytics.Tests/Compendium.Abstractions.Analytics.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Analytics.Tests/Compendium.Abstractions.Analytics.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Analytics.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Analytics.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Analytics\Compendium.Abstractions.Analytics.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Analytics.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Analytics.Tests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using Xunit;
+global using FluentAssertions;
+global using NSubstitute;
+global using Compendium.Abstractions.Analytics;
+global using Compendium.Abstractions.Analytics.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Analytics.Tests/Models/AnalyticsEventTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Analytics.Tests/Models/AnalyticsEventTests.cs
@@ -1,0 +1,101 @@
+// -----------------------------------------------------------------------
+// <copyright file="AnalyticsEventTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Analytics.Tests.Models;
+
+public class AnalyticsEventTests
+{
+    [Fact]
+    public void AnalyticsEvent_Constructor_ShouldSetAllProperties()
+    {
+        // Arrange
+        var timestamp = new DateTimeOffset(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+        var properties = new Dictionary<string, object>
+        {
+            ["plan"] = "pro",
+            ["seats"] = 5,
+        };
+
+        // Act
+        var evt = new AnalyticsEvent(
+            Name: "subscription_upgraded",
+            DistinctId: "user-42",
+            TenantId: "tenant-acme",
+            Timestamp: timestamp,
+            Properties: properties);
+
+        // Assert
+        evt.Name.Should().Be("subscription_upgraded");
+        evt.DistinctId.Should().Be("user-42");
+        evt.TenantId.Should().Be("tenant-acme");
+        evt.Timestamp.Should().Be(timestamp);
+        evt.Properties.Should().BeSameAs(properties);
+    }
+
+    [Fact]
+    public void AnalyticsEvent_Equality_ShouldHoldForSameValues()
+    {
+        // Arrange
+        var timestamp = DateTimeOffset.UnixEpoch;
+        var properties = new Dictionary<string, object> { ["k"] = "v" };
+        var a = new AnalyticsEvent("evt", "did", "tid", timestamp, properties);
+        var b = new AnalyticsEvent("evt", "did", "tid", timestamp, properties);
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void AnalyticsEvent_Equality_ShouldDifferWhenNameChanges()
+    {
+        // Arrange
+        var timestamp = DateTimeOffset.UnixEpoch;
+        var properties = new Dictionary<string, object> { ["k"] = "v" };
+        var a = new AnalyticsEvent("evt-a", "did", "tid", timestamp, properties);
+        var b = new AnalyticsEvent("evt-b", "did", "tid", timestamp, properties);
+
+        // Act / Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void AnalyticsEvent_With_ShouldProduceModifiedCopy()
+    {
+        // Arrange
+        var timestamp = DateTimeOffset.UnixEpoch;
+        var properties = new Dictionary<string, object> { ["k"] = "v" };
+        var original = new AnalyticsEvent("evt", "did", "tid", timestamp, properties);
+
+        // Act
+        var modified = original with { TenantId = "other-tenant" };
+
+        // Assert
+        modified.TenantId.Should().Be("other-tenant");
+        original.TenantId.Should().Be("tid");
+        modified.Should().NotBe(original);
+    }
+
+    [Fact]
+    public void AnalyticsEvent_Properties_ShouldSupportEmptyDictionary()
+    {
+        // Arrange
+        IReadOnlyDictionary<string, object> properties =
+            new Dictionary<string, object>();
+
+        // Act
+        var evt = new AnalyticsEvent(
+            "evt",
+            "did",
+            "tid",
+            DateTimeOffset.UnixEpoch,
+            properties);
+
+        // Assert
+        evt.Properties.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
Defines IProductAnalytics port in new Compendium.Abstractions.Analytics assembly. Unblocks compendium-adapter-posthog / mixpanel / amplitude per ADR-0006.

## Surface
- IProductAnalytics (Track / Identify / Group / Alias)
- AnalyticsEvent record (tenant-aware)
- AnalyticsErrors factories

## Coverage >= 90 % line.

## Test plan
- [x] dotnet build green
- [x] dotnet test green
- [x] Coverage >= 90 %
- [ ] CI green