### PR TITLE
feat(abstractions/featureflags): define IFeatureFlags port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -141,6 +141,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Unit", "Unit", "{17245130-8
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Analytics.Tests", "tests\Unit\Compendium.Abstractions.Analytics.Tests\Compendium.Abstractions.Analytics.Tests.csproj", "{AA96B706-D6F9-4858-850B-5D71F7CFCFD3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.FeatureFlags", "src\Abstractions\Compendium.Abstractions.FeatureFlags\Compendium.Abstractions.FeatureFlags.csproj", "{D0DE6EBF-7414-4A5C-B65C-D0711D6B383C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.FeatureFlags.Tests", "tests\Unit\Compendium.Abstractions.FeatureFlags.Tests\Compendium.Abstractions.FeatureFlags.Tests.csproj", "{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -358,6 +362,14 @@ Global
 		{AA96B706-D6F9-4858-850B-5D71F7CFCFD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AA96B706-D6F9-4858-850B-5D71F7CFCFD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AA96B706-D6F9-4858-850B-5D71F7CFCFD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0DE6EBF-7414-4A5C-B65C-D0711D6B383C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0DE6EBF-7414-4A5C-B65C-D0711D6B383C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0DE6EBF-7414-4A5C-B65C-D0711D6B383C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0DE6EBF-7414-4A5C-B65C-D0711D6B383C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -424,5 +436,7 @@ Global
 		{7D018598-0092-4490-9D81-0E8FF1FA202D} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{C68ED9B6-9F78-4BDE-82BA-D197AFD27190} = {25C6CE4F-1EE7-4448-AC41-F3C3584AF7BA}
 		{AA96B706-D6F9-4858-850B-5D71F7CFCFD3} = {17245130-8317-4D67-B86D-BFA713DE2C1C}
+		{D0DE6EBF-7414-4A5C-B65C-D0711D6B383C} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
+		{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.FeatureFlags/Compendium.Abstractions.FeatureFlags.csproj
+++ b/src/Abstractions/Compendium.Abstractions.FeatureFlags/Compendium.Abstractions.FeatureFlags.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.FeatureFlags</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.FeatureFlags</RootNamespace>
+    <PackageId>Compendium.Abstractions.FeatureFlags</PackageId>
+    <Description>Feature flag and experimentation abstractions for Compendium Framework: IFeatureFlags port for boolean flags, typed variants and experiment assignments. Provider-agnostic interface for GrowthBook, Flagsmith, LaunchDarkly and other feature flag providers.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.FeatureFlags.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.FeatureFlags/FeatureFlagErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.FeatureFlags/FeatureFlagErrors.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// <copyright file="FeatureFlagErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.FeatureFlags;
+
+/// <summary>
+/// Provides standardized error definitions for feature flag operations.
+/// </summary>
+public static class FeatureFlagErrors
+{
+    /// <summary>
+    /// Gets the error code prefix for feature flag errors.
+    /// </summary>
+    public const string Prefix = "FeatureFlags";
+
+    /// <summary>
+    /// The requested flag key was not registered with the provider.
+    /// </summary>
+    public static Error FlagNotFound(string flagKey) =>
+        Error.NotFound($"{Prefix}.FlagNotFound", $"Feature flag '{flagKey}' was not found.");
+
+    /// <summary>
+    /// The supplied <see cref="Models.FlagContext"/> did not satisfy provider requirements.
+    /// </summary>
+    public static Error InvalidContext(string reason) =>
+        Error.Validation($"{Prefix}.InvalidContext", $"Invalid flag context: {reason}.");
+
+    /// <summary>
+    /// The feature flag provider could not be reached.
+    /// </summary>
+    public static Error ProviderUnreachable(string provider) =>
+        Error.Unavailable(
+            $"{Prefix}.ProviderUnreachable",
+            $"Feature flag provider '{provider}' is unreachable.");
+
+    /// <summary>
+    /// The feature flag provider rejected the request because of rate limiting.
+    /// </summary>
+    public static Error RateLimited(TimeSpan? retryAfter = null) =>
+        Error.TooManyRequests(
+            $"{Prefix}.RateLimited",
+            retryAfter.HasValue
+                ? $"Feature flag provider rate limited the request. Retry after {retryAfter.Value.TotalSeconds} seconds."
+                : "Feature flag provider rate limited the request. Please try again later.");
+}

--- a/src/Abstractions/Compendium.Abstractions.FeatureFlags/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.FeatureFlags/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.FeatureFlags/IFeatureFlags.cs
+++ b/src/Abstractions/Compendium.Abstractions.FeatureFlags/IFeatureFlags.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="IFeatureFlags.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.FeatureFlags.Models;
+
+namespace Compendium.Abstractions.FeatureFlags;
+
+/// <summary>
+/// Provides feature flag and experiment evaluation operations.
+/// This interface is provider-agnostic and can be implemented by various feature flag
+/// providers such as GrowthBook, Flagsmith, LaunchDarkly, ConfigCat or self-hosted backends.
+/// </summary>
+public interface IFeatureFlags
+{
+    /// <summary>
+    /// Evaluates a boolean feature flag for the given context.
+    /// </summary>
+    /// <param name="flagKey">The unique key of the feature flag to evaluate.</param>
+    /// <param name="ctx">The evaluation context (mandatory tenant + optional user / attributes).</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A <see cref="Result{T}"/> containing the boolean evaluation or an error.</returns>
+    Task<Result<bool>> IsOnAsync(string flagKey, FlagContext ctx, CancellationToken ct);
+
+    /// <summary>
+    /// Evaluates a typed variant feature flag for the given context.
+    /// </summary>
+    /// <typeparam name="T">The CLR type of the variant value.</typeparam>
+    /// <param name="flagKey">The unique key of the feature flag to evaluate.</param>
+    /// <param name="defaultValue">The value returned when the provider has no opinion or the flag is missing.</param>
+    /// <param name="ctx">The evaluation context.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A <see cref="Result{T}"/> containing the resolved variant value or an error.</returns>
+    Task<Result<T>> GetVariantAsync<T>(string flagKey, T defaultValue, FlagContext ctx, CancellationToken ct);
+
+    /// <summary>
+    /// Evaluates an experiment and returns the assignment for the given context.
+    /// </summary>
+    /// <param name="experimentKey">The unique key of the experiment.</param>
+    /// <param name="ctx">The evaluation context.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A <see cref="Result{T}"/> containing the <see cref="ExperimentAssignment"/> or an error.</returns>
+    Task<Result<ExperimentAssignment>> GetExperimentAsync(string experimentKey, FlagContext ctx, CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.FeatureFlags/Models/ExperimentAssignment.cs
+++ b/src/Abstractions/Compendium.Abstractions.FeatureFlags/Models/ExperimentAssignment.cs
@@ -1,0 +1,22 @@
+// -----------------------------------------------------------------------
+// <copyright file="ExperimentAssignment.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.FeatureFlags.Models;
+
+/// <summary>
+/// Represents the result of evaluating an experiment for a given <see cref="FlagContext"/>.
+/// </summary>
+/// <param name="VariationKey">The key of the variation assigned to the caller (e.g. "control", "v1").</param>
+/// <param name="Value">The payload associated with the assigned variation.</param>
+/// <param name="InExperiment">
+/// <c>true</c> when the caller was actually enrolled in the experiment;
+/// <c>false</c> when the value comes from a fallback / default cohort.
+/// </param>
+public sealed record ExperimentAssignment(
+    string VariationKey,
+    object Value,
+    bool InExperiment);

--- a/src/Abstractions/Compendium.Abstractions.FeatureFlags/Models/FlagContext.cs
+++ b/src/Abstractions/Compendium.Abstractions.FeatureFlags/Models/FlagContext.cs
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="FlagContext.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.FeatureFlags.Models;
+
+/// <summary>
+/// Evaluation context passed to a feature flag provider.
+/// </summary>
+/// <remarks>
+/// A non-empty <see cref="TenantId"/> is mandatory: feature flag and experiment
+/// evaluation in Compendium is always tenant-scoped to prevent cross-tenant leakage of
+/// rollouts, gradual exposures and experiment cohorts.
+/// </remarks>
+public sealed record FlagContext
+{
+    private static readonly IReadOnlyDictionary<string, object> EmptyAttributes =
+        new Dictionary<string, object>(0);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FlagContext"/> record.
+    /// </summary>
+    /// <param name="tenantId">The mandatory tenant identifier evaluating the flag.</param>
+    /// <param name="userId">Optional stable identifier for the user requesting the flag, used for sticky bucketing.</param>
+    /// <param name="attributes">Optional targeting attributes used by provider rules.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="tenantId"/> is null, empty or whitespace.</exception>
+    public FlagContext(string tenantId, string? userId = null, IReadOnlyDictionary<string, object>? attributes = null)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new ArgumentException(
+                "TenantId is required for feature flag evaluation and cannot be null, empty or whitespace.",
+                nameof(tenantId));
+        }
+
+        TenantId = tenantId;
+        UserId = userId;
+        Attributes = attributes ?? EmptyAttributes;
+    }
+
+    /// <summary>
+    /// Gets the mandatory tenant identifier evaluating the flag.
+    /// </summary>
+    public string TenantId { get; }
+
+    /// <summary>
+    /// Gets the optional stable identifier of the user requesting the flag.
+    /// </summary>
+    public string? UserId { get; }
+
+    /// <summary>
+    /// Gets the additional targeting attributes provided to the flag provider.
+    /// </summary>
+    public IReadOnlyDictionary<string, object> Attributes { get; }
+}

--- a/tests/Unit/Compendium.Abstractions.FeatureFlags.Tests/Compendium.Abstractions.FeatureFlags.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.FeatureFlags.Tests/Compendium.Abstractions.FeatureFlags.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.FeatureFlags.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.FeatureFlags.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.FeatureFlags\Compendium.Abstractions.FeatureFlags.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.FeatureFlags.Tests/FeatureFlagErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.FeatureFlags.Tests/FeatureFlagErrorsTests.cs
@@ -1,0 +1,78 @@
+// -----------------------------------------------------------------------
+// <copyright file="FeatureFlagErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.FeatureFlags.Tests;
+
+public class FeatureFlagErrorsTests
+{
+    [Fact]
+    public void Prefix_IsFeatureFlags()
+    {
+        // Assert
+        FeatureFlagErrors.Prefix.Should().Be("FeatureFlags");
+    }
+
+    [Fact]
+    public void FlagNotFound_ReturnsNotFoundError()
+    {
+        // Act
+        var error = FeatureFlagErrors.FlagNotFound("checkout-v2");
+
+        // Assert
+        error.Code.Should().Be("FeatureFlags.FlagNotFound");
+        error.Message.Should().Contain("checkout-v2");
+        error.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public void InvalidContext_ReturnsValidationError()
+    {
+        // Act
+        var error = FeatureFlagErrors.InvalidContext("missing tenantId");
+
+        // Assert
+        error.Code.Should().Be("FeatureFlags.InvalidContext");
+        error.Message.Should().Contain("missing tenantId");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
+
+    [Fact]
+    public void ProviderUnreachable_ReturnsUnavailableError()
+    {
+        // Act
+        var error = FeatureFlagErrors.ProviderUnreachable("growthbook");
+
+        // Assert
+        error.Code.Should().Be("FeatureFlags.ProviderUnreachable");
+        error.Message.Should().Contain("growthbook");
+        error.Type.Should().Be(ErrorType.Unavailable);
+    }
+
+    [Fact]
+    public void RateLimited_WithoutRetryAfter_ReturnsTooManyRequestsErrorWithGenericMessage()
+    {
+        // Act
+        var error = FeatureFlagErrors.RateLimited();
+
+        // Assert
+        error.Code.Should().Be("FeatureFlags.RateLimited");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().Contain("rate limited");
+    }
+
+    [Fact]
+    public void RateLimited_WithRetryAfter_IncludesRetrySeconds()
+    {
+        // Act
+        var error = FeatureFlagErrors.RateLimited(TimeSpan.FromSeconds(60));
+
+        // Assert
+        error.Code.Should().Be("FeatureFlags.RateLimited");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().Contain("60");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.FeatureFlags.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.FeatureFlags.Tests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using Xunit;
+global using FluentAssertions;
+global using NSubstitute;
+global using Compendium.Abstractions.FeatureFlags;
+global using Compendium.Abstractions.FeatureFlags.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.FeatureFlags.Tests/Models/ExperimentAssignmentTests.cs
+++ b/tests/Unit/Compendium.Abstractions.FeatureFlags.Tests/Models/ExperimentAssignmentTests.cs
@@ -1,0 +1,88 @@
+// -----------------------------------------------------------------------
+// <copyright file="ExperimentAssignmentTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.FeatureFlags.Tests.Models;
+
+public class ExperimentAssignmentTests
+{
+    [Fact]
+    public void Constructor_AssignsAllProperties()
+    {
+        // Arrange
+        var value = new { copy = "Buy now" };
+
+        // Act
+        var assignment = new ExperimentAssignment("v1", value, InExperiment: true);
+
+        // Assert
+        assignment.VariationKey.Should().Be("v1");
+        assignment.Value.Should().BeSameAs(value);
+        assignment.InExperiment.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_AllowsFallbackAssignment()
+    {
+        // Act
+        var assignment = new ExperimentAssignment("control", "default", InExperiment: false);
+
+        // Assert
+        assignment.VariationKey.Should().Be("control");
+        assignment.Value.Should().Be("default");
+        assignment.InExperiment.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Records_WithSameValues_AreEqual()
+    {
+        // Act
+        var a = new ExperimentAssignment("v1", 42, true);
+        var b = new ExperimentAssignment("v1", 42, true);
+
+        // Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Records_WithDifferentVariation_AreNotEqual()
+    {
+        // Act
+        var a = new ExperimentAssignment("v1", 42, true);
+        var b = new ExperimentAssignment("v2", 42, true);
+
+        // Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void Records_WithDifferentEnrollment_AreNotEqual()
+    {
+        // Act
+        var a = new ExperimentAssignment("v1", 42, true);
+        var b = new ExperimentAssignment("v1", 42, false);
+
+        // Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void With_AllowsNonDestructiveMutation()
+    {
+        // Arrange
+        var original = new ExperimentAssignment("v1", 42, true);
+
+        // Act
+        var mutated = original with { VariationKey = "v2" };
+
+        // Assert
+        mutated.VariationKey.Should().Be("v2");
+        mutated.Value.Should().Be(42);
+        mutated.InExperiment.Should().BeTrue();
+        original.VariationKey.Should().Be("v1");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.FeatureFlags.Tests/Models/FlagContextTests.cs
+++ b/tests/Unit/Compendium.Abstractions.FeatureFlags.Tests/Models/FlagContextTests.cs
@@ -1,0 +1,108 @@
+// -----------------------------------------------------------------------
+// <copyright file="FlagContextTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.FeatureFlags.Tests.Models;
+
+public class FlagContextTests
+{
+    [Fact]
+    public void Constructor_WithTenantOnly_DefaultsUserAndAttributes()
+    {
+        // Act
+        var ctx = new FlagContext("tenant-1");
+
+        // Assert
+        ctx.TenantId.Should().Be("tenant-1");
+        ctx.UserId.Should().BeNull();
+        ctx.Attributes.Should().NotBeNull();
+        ctx.Attributes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Constructor_WithAllArguments_AssignsEveryProperty()
+    {
+        // Arrange
+        var attributes = new Dictionary<string, object>
+        {
+            ["plan"] = "pro",
+            ["country"] = "FR",
+        };
+
+        // Act
+        var ctx = new FlagContext("tenant-9", "user-42", attributes);
+
+        // Assert
+        ctx.TenantId.Should().Be("tenant-9");
+        ctx.UserId.Should().Be("user-42");
+        ctx.Attributes.Should().BeSameAs(attributes);
+        ctx.Attributes.Should().HaveCount(2);
+        ctx.Attributes["plan"].Should().Be("pro");
+    }
+
+    [Fact]
+    public void Constructor_WithNullAttributes_FallsBackToEmptyDictionary()
+    {
+        // Act
+        var ctx = new FlagContext("tenant-1", "user-1", attributes: null);
+
+        // Assert
+        ctx.Attributes.Should().NotBeNull();
+        ctx.Attributes.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void Constructor_WithBlankTenantId_Throws(string? tenantId)
+    {
+        // Act
+        var act = () => new FlagContext(tenantId!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .Which.ParamName.Should().Be("tenantId");
+    }
+
+    [Fact]
+    public void Records_WithSameValues_AreEqual()
+    {
+        // Arrange
+        var attributes = new Dictionary<string, object> { ["k"] = "v" };
+
+        // Act
+        var a = new FlagContext("tenant-1", "user-1", attributes);
+        var b = new FlagContext("tenant-1", "user-1", attributes);
+
+        // Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Records_WithDifferentTenant_AreNotEqual()
+    {
+        // Act
+        var a = new FlagContext("tenant-1");
+        var b = new FlagContext("tenant-2");
+
+        // Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void Records_WithDifferentUser_AreNotEqual()
+    {
+        // Act
+        var a = new FlagContext("tenant-1", "user-1");
+        var b = new FlagContext("tenant-1", "user-2");
+
+        // Assert
+        a.Should().NotBe(b);
+    }
+}


### PR DESCRIPTION
## Summary
Defines IFeatureFlags port in new Compendium.Abstractions.FeatureFlags assembly. Unblocks compendium-adapter-growthbook / flagsmith / launchdarkly per ADR-0006.

## Surface
- IFeatureFlags (IsOn / GetVariant<T> / GetExperiment)
- FlagContext (tenant-mandatory), ExperimentAssignment records
- FeatureFlagErrors factories

## Coverage >= 90 % line.

## Test plan
- [x] dotnet build green
- [x] dotnet test green
- [x] Coverage >= 90 %
- [ ] CI green