### PR TITLE
feat(abstractions/notifications): define IPushNotificationSender port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -145,6 +145,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Fea
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.FeatureFlags.Tests", "tests\Unit\Compendium.Abstractions.FeatureFlags.Tests\Compendium.Abstractions.FeatureFlags.Tests.csproj", "{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Notifications", "src\Abstractions\Compendium.Abstractions.Notifications\Compendium.Abstractions.Notifications.csproj", "{93524074-B12D-4509-80AE-2F7EE620A8E8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Notifications.Tests", "tests\Unit\Compendium.Abstractions.Notifications.Tests\Compendium.Abstractions.Notifications.Tests.csproj", "{324F5FC3-B793-4ABC-A42A-A08E9786FC31}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -370,6 +374,14 @@ Global
 		{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93524074-B12D-4509-80AE-2F7EE620A8E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93524074-B12D-4509-80AE-2F7EE620A8E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93524074-B12D-4509-80AE-2F7EE620A8E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93524074-B12D-4509-80AE-2F7EE620A8E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{324F5FC3-B793-4ABC-A42A-A08E9786FC31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{324F5FC3-B793-4ABC-A42A-A08E9786FC31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{324F5FC3-B793-4ABC-A42A-A08E9786FC31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{324F5FC3-B793-4ABC-A42A-A08E9786FC31}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -438,5 +450,7 @@ Global
 		{AA96B706-D6F9-4858-850B-5D71F7CFCFD3} = {17245130-8317-4D67-B86D-BFA713DE2C1C}
 		{D0DE6EBF-7414-4A5C-B65C-D0711D6B383C} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
 		{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{93524074-B12D-4509-80AE-2F7EE620A8E8} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
+		{324F5FC3-B793-4ABC-A42A-A08E9786FC31} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Notifications/Compendium.Abstractions.Notifications.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/Compendium.Abstractions.Notifications.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Notifications</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Notifications</RootNamespace>
+    <PackageId>Compendium.Abstractions.Notifications</PackageId>
+    <Description>Notification abstractions for Compendium Framework: IPushNotificationSender (and forthcoming ISmsSender). Provider-agnostic interfaces for push notifications across FCM, APNS, and Web Push.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Notifications.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Notifications/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.Notifications/IPushNotificationSender.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/IPushNotificationSender.cs
@@ -1,0 +1,42 @@
+// -----------------------------------------------------------------------
+// <copyright file="IPushNotificationSender.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Notifications.Models;
+
+namespace Compendium.Abstractions.Notifications;
+
+/// <summary>
+/// Provides operations for sending push notifications to one or more device tokens.
+/// This interface is provider-agnostic and can be implemented by adapters targeting
+/// FCM, APNS, Web Push, OneSignal, and similar services.
+/// </summary>
+public interface IPushNotificationSender
+{
+    /// <summary>
+    /// Sends a push notification to the supplied device tokens.
+    /// </summary>
+    /// <param name="notification">The notification payload to deliver.</param>
+    /// <param name="targets">The device tokens that should receive the notification.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the delivery outcome or an error.</returns>
+    Task<Result<PushDeliveryResult>> SendAsync(
+        PushNotification notification,
+        IEnumerable<DeviceToken> targets,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Sends a push notification to the supplied device tokens using provider-side batching.
+    /// </summary>
+    /// <param name="notification">The notification payload to deliver.</param>
+    /// <param name="targets">The device tokens that should receive the notification.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the aggregated batch delivery outcome or an error.</returns>
+    Task<Result<BatchPushDeliveryResult>> SendBatchAsync(
+        PushNotification notification,
+        IReadOnlyList<DeviceToken> targets,
+        CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/Models/BatchPushDeliveryResult.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/Models/BatchPushDeliveryResult.cs
@@ -1,0 +1,30 @@
+// -----------------------------------------------------------------------
+// <copyright file="BatchPushDeliveryResult.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Models;
+
+/// <summary>
+/// Represents the aggregated result of delivering a push notification to multiple device tokens
+/// across one or more provider batches.
+/// </summary>
+public sealed record BatchPushDeliveryResult
+{
+    /// <summary>
+    /// Gets the total number of device tokens that successfully received the notification.
+    /// </summary>
+    public required int SuccessCount { get; init; }
+
+    /// <summary>
+    /// Gets the total number of device tokens that failed to receive the notification.
+    /// </summary>
+    public required int FailureCount { get; init; }
+
+    /// <summary>
+    /// Gets the per-batch delivery results that compose this aggregated result.
+    /// </summary>
+    public required IReadOnlyList<PushDeliveryResult> Results { get; init; }
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/Models/DeviceToken.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/Models/DeviceToken.cs
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------
+// <copyright file="DeviceToken.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Models;
+
+/// <summary>
+/// Represents a registered device token for a specific tenant and (optionally) user.
+/// </summary>
+public sealed record DeviceToken
+{
+    /// <summary>
+    /// Gets the push provider that issued this token.
+    /// </summary>
+    public required PushProvider Provider { get; init; }
+
+    /// <summary>
+    /// Gets the opaque device token value as understood by the provider.
+    /// </summary>
+    public required string Token { get; init; }
+
+    /// <summary>
+    /// Gets the tenant identifier the token belongs to.
+    /// </summary>
+    public required string TenantId { get; init; }
+
+    /// <summary>
+    /// Gets the optional user identifier the token is bound to.
+    /// </summary>
+    public string? UserId { get; init; }
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/Models/PushDeliveryResult.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/Models/PushDeliveryResult.cs
@@ -1,0 +1,24 @@
+// -----------------------------------------------------------------------
+// <copyright file="PushDeliveryResult.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Models;
+
+/// <summary>
+/// Represents the result of delivering a single push notification to a set of device tokens.
+/// </summary>
+public sealed record PushDeliveryResult
+{
+    /// <summary>
+    /// Gets the number of device tokens the notification was successfully sent to.
+    /// </summary>
+    public required int Sent { get; init; }
+
+    /// <summary>
+    /// Gets the device tokens that the provider rejected, with the reason for each failure.
+    /// </summary>
+    public required IReadOnlyList<PushFailure> Failed { get; init; }
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/Models/PushFailure.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/Models/PushFailure.cs
@@ -1,0 +1,24 @@
+// -----------------------------------------------------------------------
+// <copyright file="PushFailure.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Models;
+
+/// <summary>
+/// Describes a single device token that failed to receive a push notification.
+/// </summary>
+public sealed record PushFailure
+{
+    /// <summary>
+    /// Gets the device token value that failed.
+    /// </summary>
+    public required string Token { get; init; }
+
+    /// <summary>
+    /// Gets a human-readable reason describing why the delivery failed.
+    /// </summary>
+    public required string Reason { get; init; }
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/Models/PushNotification.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/Models/PushNotification.cs
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------------------
+// <copyright file="PushNotification.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Models;
+
+/// <summary>
+/// Represents a push notification payload to be delivered to one or more devices.
+/// </summary>
+public sealed record PushNotification
+{
+    /// <summary>
+    /// Gets the title shown at the top of the notification.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Gets the body text of the notification.
+    /// </summary>
+    public required string Body { get; init; }
+
+    /// <summary>
+    /// Gets the custom data payload delivered alongside the notification (provider-specific limits apply).
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Data { get; init; } =
+        new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets the optional sound identifier to play on the device when the notification is delivered.
+    /// </summary>
+    public string? Sound { get; init; }
+
+    /// <summary>
+    /// Gets the optional badge count to display on the application icon (primarily APNS).
+    /// </summary>
+    public int? Badge { get; init; }
+
+    /// <summary>
+    /// Gets the optional click action that the device should invoke when the notification is tapped.
+    /// </summary>
+    public string? ClickAction { get; init; }
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/Models/PushProvider.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/Models/PushProvider.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------
+// <copyright file="PushProvider.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Models;
+
+/// <summary>
+/// Identifies the push notification provider associated with a device token.
+/// </summary>
+public enum PushProvider
+{
+    /// <summary>
+    /// Firebase Cloud Messaging (Android, iOS, Web).
+    /// </summary>
+    FCM = 0,
+
+    /// <summary>
+    /// Apple Push Notification service (iOS, macOS).
+    /// </summary>
+    APNS = 1,
+
+    /// <summary>
+    /// Web Push protocol (browsers).
+    /// </summary>
+    WebPush = 2,
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/NotificationErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/NotificationErrors.cs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------
+// <copyright file="NotificationErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications;
+
+/// <summary>
+/// Provides standard error definitions for notification (push / SMS) operations.
+/// </summary>
+public static class NotificationErrors
+{
+    /// <summary>
+    /// Error returned when the supplied device token is invalid, unregistered, or expired.
+    /// </summary>
+    public static Error InvalidToken(string token) =>
+        Error.Validation("Notification.InvalidToken", $"The device token '{token}' is invalid or no longer registered.");
+
+    /// <summary>
+    /// Error returned when the notification provider cannot be reached.
+    /// </summary>
+    public static Error ProviderUnreachable(string reason) =>
+        Error.Unavailable("Notification.ProviderUnreachable", $"The notification provider is unreachable: {reason}");
+
+    /// <summary>
+    /// Error returned when the request rate limit has been exceeded.
+    /// </summary>
+    public static Error RateLimited(string reason) =>
+        Error.TooManyRequests("Notification.RateLimited", $"Rate limit exceeded: {reason}");
+
+    /// <summary>
+    /// Error returned when the notification payload exceeds the provider-imposed size limit.
+    /// </summary>
+    public static Error PayloadTooLarge(int sizeBytes, int maxBytes) =>
+        Error.Validation(
+            "Notification.PayloadTooLarge",
+            $"Notification payload of {sizeBytes} bytes exceeds the maximum allowed size of {maxBytes} bytes.");
+}

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/Compendium.Abstractions.Notifications.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/Compendium.Abstractions.Notifications.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Notifications.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Notifications.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Core\Compendium.Core\Compendium.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Notifications\Compendium.Abstractions.Notifications.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/GlobalUsings.cs
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Xunit;
+global using FluentAssertions;
+global using Compendium.Abstractions.Notifications;
+global using Compendium.Abstractions.Notifications.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/BatchPushDeliveryResultTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/BatchPushDeliveryResultTests.cs
@@ -1,0 +1,76 @@
+// -----------------------------------------------------------------------
+// <copyright file="BatchPushDeliveryResultTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Tests.Models;
+
+public class BatchPushDeliveryResultTests
+{
+    [Fact]
+    public void BatchPushDeliveryResult_WithNoBatches_HasZeroCounts()
+    {
+        // Arrange / Act
+        var result = new BatchPushDeliveryResult
+        {
+            SuccessCount = 0,
+            FailureCount = 0,
+            Results = Array.Empty<PushDeliveryResult>(),
+        };
+
+        // Assert
+        result.SuccessCount.Should().Be(0);
+        result.FailureCount.Should().Be(0);
+        result.Results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BatchPushDeliveryResult_WithMultipleBatches_PreservesValues()
+    {
+        // Arrange
+        var batches = new[]
+        {
+            new PushDeliveryResult { Sent = 3, Failed = Array.Empty<PushFailure>() },
+            new PushDeliveryResult
+            {
+                Sent = 2,
+                Failed = new[] { new PushFailure { Token = "t", Reason = "r" } },
+            },
+        };
+
+        // Act
+        var result = new BatchPushDeliveryResult
+        {
+            SuccessCount = 5,
+            FailureCount = 1,
+            Results = batches,
+        };
+
+        // Assert
+        result.SuccessCount.Should().Be(5);
+        result.FailureCount.Should().Be(1);
+        result.Results.Should().HaveCount(2);
+        result.Results.Should().BeEquivalentTo(batches);
+    }
+
+    [Fact]
+    public void BatchPushDeliveryResult_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new BatchPushDeliveryResult
+        {
+            SuccessCount = 1,
+            FailureCount = 0,
+            Results = Array.Empty<PushDeliveryResult>(),
+        };
+
+        // Act
+        var updated = original with { FailureCount = 2 };
+
+        // Assert
+        updated.FailureCount.Should().Be(2);
+        original.FailureCount.Should().Be(0);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/DeviceTokenTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/DeviceTokenTests.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="DeviceTokenTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Tests.Models;
+
+public class DeviceTokenTests
+{
+    [Fact]
+    public void DeviceToken_WithRequiredOnly_LeavesUserIdNull()
+    {
+        // Arrange / Act
+        var token = new DeviceToken
+        {
+            Provider = PushProvider.FCM,
+            Token = "abc",
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        token.Provider.Should().Be(PushProvider.FCM);
+        token.Token.Should().Be("abc");
+        token.TenantId.Should().Be("tenant-1");
+        token.UserId.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(PushProvider.FCM)]
+    [InlineData(PushProvider.APNS)]
+    [InlineData(PushProvider.WebPush)]
+    public void DeviceToken_WithEachProvider_PreservesProvider(PushProvider provider)
+    {
+        // Arrange / Act
+        var token = new DeviceToken
+        {
+            Provider = provider,
+            Token = "tok",
+            TenantId = "t",
+            UserId = "u",
+        };
+
+        // Assert
+        token.Provider.Should().Be(provider);
+        token.UserId.Should().Be("u");
+    }
+
+    [Fact]
+    public void DeviceToken_RecordEquality_TwoIdenticalTokens_AreEqual()
+    {
+        // Arrange
+        var first = new DeviceToken { Provider = PushProvider.APNS, Token = "t", TenantId = "tn", UserId = "u" };
+        var second = new DeviceToken { Provider = PushProvider.APNS, Token = "t", TenantId = "tn", UserId = "u" };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void DeviceToken_RecordEquality_DifferingTenant_AreNotEqual()
+    {
+        // Arrange
+        var first = new DeviceToken { Provider = PushProvider.FCM, Token = "t", TenantId = "a" };
+        var second = new DeviceToken { Provider = PushProvider.FCM, Token = "t", TenantId = "b" };
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void DeviceToken_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new DeviceToken { Provider = PushProvider.FCM, Token = "t", TenantId = "tn" };
+
+        // Act
+        var updated = original with { UserId = "u-1" };
+
+        // Assert
+        updated.UserId.Should().Be("u-1");
+        original.UserId.Should().BeNull();
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/PushDeliveryResultTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/PushDeliveryResultTests.cs
@@ -1,0 +1,56 @@
+// -----------------------------------------------------------------------
+// <copyright file="PushDeliveryResultTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Tests.Models;
+
+public class PushDeliveryResultTests
+{
+    [Fact]
+    public void PushDeliveryResult_AllSucceeded_HasEmptyFailedList()
+    {
+        // Arrange / Act
+        var result = new PushDeliveryResult
+        {
+            Sent = 10,
+            Failed = Array.Empty<PushFailure>(),
+        };
+
+        // Assert
+        result.Sent.Should().Be(10);
+        result.Failed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PushDeliveryResult_WithMixedOutcomes_PreservesValues()
+    {
+        // Arrange
+        var failed = new[]
+        {
+            new PushFailure { Token = "bad-1", Reason = "InvalidRegistration" },
+            new PushFailure { Token = "bad-2", Reason = "Unregistered" },
+        };
+
+        // Act
+        var result = new PushDeliveryResult { Sent = 8, Failed = failed };
+
+        // Assert
+        result.Sent.Should().Be(8);
+        result.Failed.Should().BeEquivalentTo(failed);
+    }
+
+    [Fact]
+    public void PushDeliveryResult_RecordEquality_SameContent_NotEqualAcrossDistinctLists()
+    {
+        // Arrange — record equality on IReadOnlyList uses reference equality, not structural equality
+        var failed = new[] { new PushFailure { Token = "t", Reason = "r" } };
+        var first = new PushDeliveryResult { Sent = 1, Failed = failed };
+        var second = new PushDeliveryResult { Sent = 1, Failed = failed };
+
+        // Act / Assert
+        first.Should().Be(second);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/PushFailureTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/PushFailureTests.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------
+// <copyright file="PushFailureTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Tests.Models;
+
+public class PushFailureTests
+{
+    [Fact]
+    public void PushFailure_WithRequired_PreservesValues()
+    {
+        // Arrange / Act
+        var failure = new PushFailure { Token = "tok-1", Reason = "InvalidRegistration" };
+
+        // Assert
+        failure.Token.Should().Be("tok-1");
+        failure.Reason.Should().Be("InvalidRegistration");
+    }
+
+    [Fact]
+    public void PushFailure_RecordEquality_TwoIdenticalFailures_AreEqual()
+    {
+        // Arrange
+        var first = new PushFailure { Token = "t", Reason = "r" };
+        var second = new PushFailure { Token = "t", Reason = "r" };
+
+        // Act / Assert
+        first.Should().Be(second);
+    }
+
+    [Fact]
+    public void PushFailure_RecordEquality_DifferingReason_AreNotEqual()
+    {
+        // Arrange
+        var first = new PushFailure { Token = "t", Reason = "InvalidToken" };
+        var second = new PushFailure { Token = "t", Reason = "RateLimited" };
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/PushNotificationTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/PushNotificationTests.cs
@@ -1,0 +1,102 @@
+// -----------------------------------------------------------------------
+// <copyright file="PushNotificationTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Tests.Models;
+
+public class PushNotificationTests
+{
+    [Fact]
+    public void PushNotification_WithRequiredOnly_DefaultsOptionalProperties()
+    {
+        // Arrange / Act
+        var notification = new PushNotification
+        {
+            Title = "Hello",
+            Body = "World",
+        };
+
+        // Assert
+        notification.Title.Should().Be("Hello");
+        notification.Body.Should().Be("World");
+        notification.Data.Should().NotBeNull().And.BeEmpty();
+        notification.Sound.Should().BeNull();
+        notification.Badge.Should().BeNull();
+        notification.ClickAction.Should().BeNull();
+    }
+
+    [Fact]
+    public void PushNotification_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var data = new Dictionary<string, string>
+        {
+            ["orderId"] = "ord-1",
+            ["deepLink"] = "app://orders/1",
+        };
+
+        // Act
+        var notification = new PushNotification
+        {
+            Title = "Order shipped",
+            Body = "Your order is on its way.",
+            Data = data,
+            Sound = "default",
+            Badge = 3,
+            ClickAction = "OPEN_ORDER",
+        };
+
+        // Assert
+        notification.Title.Should().Be("Order shipped");
+        notification.Body.Should().Be("Your order is on its way.");
+        notification.Data.Should().BeEquivalentTo(data);
+        notification.Sound.Should().Be("default");
+        notification.Badge.Should().Be(3);
+        notification.ClickAction.Should().Be("OPEN_ORDER");
+    }
+
+    [Fact]
+    public void PushNotification_RecordEquality_TwoIdenticalNotifications_AreEqual()
+    {
+        // Arrange — share the Data dictionary so reference equality holds for that property
+        var data = new Dictionary<string, string> { ["k"] = "v" };
+        var first = new PushNotification { Title = "T", Body = "B", Data = data };
+        var second = new PushNotification { Title = "T", Body = "B", Data = data };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void PushNotification_RecordEquality_DifferingTitle_AreNotEqual()
+    {
+        // Arrange
+        var data = new Dictionary<string, string>();
+        var first = new PushNotification { Title = "A", Body = "B", Data = data };
+        var second = new PushNotification { Title = "X", Body = "B", Data = data };
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void PushNotification_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new PushNotification { Title = "Hello", Body = "World", Badge = 1 };
+
+        // Act
+        var updated = original with { Badge = 5 };
+
+        // Assert
+        updated.Should().NotBeSameAs(original);
+        updated.Badge.Should().Be(5);
+        original.Badge.Should().Be(1);
+        updated.Title.Should().Be(original.Title);
+        updated.Body.Should().Be(original.Body);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/PushProviderTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/PushProviderTests.cs
@@ -1,0 +1,52 @@
+// -----------------------------------------------------------------------
+// <copyright file="PushProviderTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Tests.Models;
+
+public class PushProviderTests
+{
+    [Theory]
+    [InlineData(PushProvider.FCM, 0)]
+    [InlineData(PushProvider.APNS, 1)]
+    [InlineData(PushProvider.WebPush, 2)]
+    public void PushProvider_HasStableUnderlyingValues(PushProvider provider, int expected)
+    {
+        // Act
+        var value = (int)provider;
+
+        // Assert
+        value.Should().Be(expected);
+    }
+
+    [Fact]
+    public void PushProvider_DefinesExactlyThreeMembers()
+    {
+        // Act
+        var members = Enum.GetValues<PushProvider>();
+
+        // Assert
+        members.Should().BeEquivalentTo(new[]
+        {
+            PushProvider.FCM,
+            PushProvider.APNS,
+            PushProvider.WebPush,
+        });
+    }
+
+    [Theory]
+    [InlineData("FCM", PushProvider.FCM)]
+    [InlineData("APNS", PushProvider.APNS)]
+    [InlineData("WebPush", PushProvider.WebPush)]
+    public void PushProvider_Parse_ReturnsExpectedMember(string name, PushProvider expected)
+    {
+        // Act
+        var parsed = Enum.Parse<PushProvider>(name);
+
+        // Assert
+        parsed.Should().Be(expected);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/NotificationErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/NotificationErrorsTests.cs
@@ -1,0 +1,113 @@
+// -----------------------------------------------------------------------
+// <copyright file="NotificationErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Tests;
+
+public class NotificationErrorsTests
+{
+    [Fact]
+    public void InvalidToken_WithToken_ReturnsValidationError()
+    {
+        // Arrange
+        const string token = "tok-xyz";
+
+        // Act
+        var error = NotificationErrors.InvalidToken(token);
+
+        // Assert
+        error.Code.Should().Be("Notification.InvalidToken");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain($"'{token}'");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("short")]
+    [InlineData("a-very-long-device-token-value-that-could-be-256-chars")]
+    public void InvalidToken_WithVariousTokens_EmbedsTokenInMessage(string token)
+    {
+        // Act
+        var error = NotificationErrors.InvalidToken(token);
+
+        // Assert
+        error.Code.Should().Be("Notification.InvalidToken");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain($"'{token}'");
+    }
+
+    [Fact]
+    public void ProviderUnreachable_WithReason_ReturnsUnavailableError()
+    {
+        // Arrange
+        const string reason = "DNS resolution failed";
+
+        // Act
+        var error = NotificationErrors.ProviderUnreachable(reason);
+
+        // Assert
+        error.Code.Should().Be("Notification.ProviderUnreachable");
+        error.Type.Should().Be(ErrorType.Unavailable);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Fact]
+    public void RateLimited_WithReason_ReturnsTooManyRequestsError()
+    {
+        // Arrange
+        const string reason = "100 req/sec exceeded";
+
+        // Act
+        var error = NotificationErrors.RateLimited(reason);
+
+        // Assert
+        error.Code.Should().Be("Notification.RateLimited");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Theory]
+    [InlineData(5000, 4096)]
+    [InlineData(1, 0)]
+    [InlineData(int.MaxValue, 1024)]
+    public void PayloadTooLarge_WithSizes_ReturnsValidationErrorEmbeddingBothSizes(int sizeBytes, int maxBytes)
+    {
+        // Act
+        var error = NotificationErrors.PayloadTooLarge(sizeBytes, maxBytes);
+
+        // Assert
+        error.Code.Should().Be("Notification.PayloadTooLarge");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain(sizeBytes.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        error.Message.Should().Contain(maxBytes.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void AllErrorFactories_ReturnNonNullErrorInstances()
+    {
+        // Act / Assert
+        NotificationErrors.InvalidToken("t").Should().NotBeNull();
+        NotificationErrors.ProviderUnreachable("r").Should().NotBeNull();
+        NotificationErrors.RateLimited("r").Should().NotBeNull();
+        NotificationErrors.PayloadTooLarge(1, 0).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AllErrorCodes_StartWithNotificationPrefix()
+    {
+        // Act
+        var codes = new[]
+        {
+            NotificationErrors.InvalidToken("t").Code,
+            NotificationErrors.ProviderUnreachable("r").Code,
+            NotificationErrors.RateLimited("r").Code,
+            NotificationErrors.PayloadTooLarge(1, 0).Code,
+        };
+
+        // Assert
+        codes.Should().OnlyContain(c => c.StartsWith("Notification.", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary
Defines IPushNotificationSender port in new Compendium.Abstractions.Notifications assembly. Unblocks compendium-adapter-fcm / apns / onesignal per ADR-0006.

Note : the sibling ISmsSender will follow in a separate PR — same assembly.

## Surface
- IPushNotificationSender (Send / SendBatch)
- PushNotification, DeviceToken records, PushProvider enum
- PushDeliveryResult, PushFailure, BatchPushDeliveryResult records
- NotificationErrors factories

## Coverage ≥ 90 % line.

## Test plan
- [x] dotnet build green
- [x] dotnet test green
- [x] Coverage ≥ 90 %
- [ ] CI green