### PR TITLE
feat(abstractions/notifications): define ISmsSender port

### DIFF
--- a/src/Abstractions/Compendium.Abstractions.Notifications/ISmsSender.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/ISmsSender.cs
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------
+// <copyright file="ISmsSender.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Notifications.Models;
+
+namespace Compendium.Abstractions.Notifications;
+
+/// <summary>
+/// Provides operations for sending SMS / MMS messages. This interface is provider-agnostic
+/// and can be implemented by adapters targeting Twilio, MessageBird, Vonage, and similar services.
+/// </summary>
+public interface ISmsSender
+{
+    /// <summary>
+    /// Sends a single SMS (or MMS) message to a recipient.
+    /// </summary>
+    /// <param name="message">The message payload to deliver.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the per-message delivery outcome or an error.</returns>
+    Task<Result<SmsDeliveryResult>> SendAsync(SmsMessage message, CancellationToken ct);
+
+    /// <summary>
+    /// Sends multiple SMS messages in a single batch using provider-side batching where supported.
+    /// </summary>
+    /// <param name="messages">The messages to deliver.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the aggregated batch delivery outcome or an error.</returns>
+    Task<Result<BatchSmsDeliveryResult>> SendBatchAsync(IReadOnlyList<SmsMessage> messages, CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/Models/BatchSmsDeliveryResult.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/Models/BatchSmsDeliveryResult.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------
+// <copyright file="BatchSmsDeliveryResult.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Models;
+
+/// <summary>
+/// Represents the aggregated result of submitting multiple SMS messages in a single batch.
+/// </summary>
+public sealed record BatchSmsDeliveryResult
+{
+    /// <summary>
+    /// Gets the total number of messages that were accepted by the provider.
+    /// </summary>
+    public required int SuccessCount { get; init; }
+
+    /// <summary>
+    /// Gets the total number of messages that the provider rejected at submission time.
+    /// </summary>
+    public required int FailureCount { get; init; }
+
+    /// <summary>
+    /// Gets the per-message delivery results that compose this aggregated result.
+    /// </summary>
+    public required IReadOnlyList<SmsDeliveryResult> Results { get; init; }
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/Models/SmsDeliveryResult.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/Models/SmsDeliveryResult.cs
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------
+// <copyright file="SmsDeliveryResult.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Models;
+
+/// <summary>
+/// Represents the result of submitting a single SMS message to a provider.
+/// </summary>
+public sealed record SmsDeliveryResult
+{
+    /// <summary>
+    /// Gets the provider-assigned identifier for the submitted message (used for status callbacks).
+    /// </summary>
+    public required string ProviderMessageId { get; init; }
+
+    /// <summary>
+    /// Gets the current delivery status of the message as reported by the provider at submission time.
+    /// </summary>
+    public required SmsStatus Status { get; init; }
+
+    /// <summary>
+    /// Gets the number of SMS segments the body was split into (drives billing on most providers).
+    /// </summary>
+    public required int SegmentCount { get; init; }
+
+    /// <summary>
+    /// Gets an optional provider-reported cost hint (e.g. "0.0075 USD"). May be null when the provider does not return one.
+    /// </summary>
+    public string? CostHint { get; init; }
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/Models/SmsMessage.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/Models/SmsMessage.cs
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------
+// <copyright file="SmsMessage.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Models;
+
+/// <summary>
+/// Represents an SMS (or MMS) message payload to be delivered to a single recipient.
+/// </summary>
+public sealed record SmsMessage
+{
+    /// <summary>
+    /// Gets the sender phone number in E.164 format (e.g. "+15551234567") or a provider-registered alphanumeric sender ID.
+    /// </summary>
+    public required string From { get; init; }
+
+    /// <summary>
+    /// Gets the recipient phone number in E.164 format (e.g. "+15557654321").
+    /// </summary>
+    public required string To { get; init; }
+
+    /// <summary>
+    /// Gets the textual body of the message.
+    /// </summary>
+    public required string Body { get; init; }
+
+    /// <summary>
+    /// Gets the tenant identifier the message belongs to.
+    /// </summary>
+    public required string TenantId { get; init; }
+
+    /// <summary>
+    /// Gets the optional collection of media URLs to attach (turning the message into an MMS).
+    /// </summary>
+    public IReadOnlyList<string>? MediaUrls { get; init; }
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/Models/SmsStatus.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/Models/SmsStatus.cs
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------
+// <copyright file="SmsStatus.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Models;
+
+/// <summary>
+/// Represents the delivery status of an SMS message as reported by a provider.
+/// </summary>
+public enum SmsStatus
+{
+    /// <summary>
+    /// The message has been accepted by the provider and is queued for delivery.
+    /// </summary>
+    Queued = 0,
+
+    /// <summary>
+    /// The message has been sent by the provider to the carrier.
+    /// </summary>
+    Sent = 1,
+
+    /// <summary>
+    /// The carrier has confirmed delivery to the recipient handset.
+    /// </summary>
+    Delivered = 2,
+
+    /// <summary>
+    /// The message failed to be sent or delivered.
+    /// </summary>
+    Failed = 3,
+
+    /// <summary>
+    /// The carrier reported that the message could not be delivered to the recipient.
+    /// </summary>
+    Undelivered = 4,
+}

--- a/src/Abstractions/Compendium.Abstractions.Notifications/NotificationErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Notifications/NotificationErrors.cs
@@ -37,4 +37,20 @@ public static class NotificationErrors
         Error.Validation(
             "Notification.PayloadTooLarge",
             $"Notification payload of {sizeBytes} bytes exceeds the maximum allowed size of {maxBytes} bytes.");
+
+    /// <summary>
+    /// Error returned when the supplied SMS phone number is not a valid E.164 value.
+    /// </summary>
+    public static Error InvalidPhoneNumber(string phoneNumber) =>
+        Error.Validation(
+            "Notification.InvalidPhoneNumber",
+            $"The phone number '{phoneNumber}' is not a valid E.164 number.");
+
+    /// <summary>
+    /// Error returned when the SMS message body exceeds the provider-imposed length limit.
+    /// </summary>
+    public static Error MessageTooLong(int length, int maxLength) =>
+        Error.Validation(
+            "Notification.MessageTooLong",
+            $"SMS message body of {length} characters exceeds the maximum allowed length of {maxLength} characters.");
 }

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/BatchSmsDeliveryResultTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/BatchSmsDeliveryResultTests.cs
@@ -1,0 +1,85 @@
+// -----------------------------------------------------------------------
+// <copyright file="BatchSmsDeliveryResultTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Tests.Models;
+
+public class BatchSmsDeliveryResultTests
+{
+    [Fact]
+    public void BatchSmsDeliveryResult_WithNoMessages_HasZeroCounts()
+    {
+        // Arrange / Act
+        var result = new BatchSmsDeliveryResult
+        {
+            SuccessCount = 0,
+            FailureCount = 0,
+            Results = Array.Empty<SmsDeliveryResult>(),
+        };
+
+        // Assert
+        result.SuccessCount.Should().Be(0);
+        result.FailureCount.Should().Be(0);
+        result.Results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BatchSmsDeliveryResult_WithMixedResults_PreservesValues()
+    {
+        // Arrange
+        var results = new[]
+        {
+            new SmsDeliveryResult { ProviderMessageId = "SM1", Status = SmsStatus.Sent, SegmentCount = 1 },
+            new SmsDeliveryResult { ProviderMessageId = "SM2", Status = SmsStatus.Failed, SegmentCount = 0 },
+        };
+
+        // Act
+        var batch = new BatchSmsDeliveryResult
+        {
+            SuccessCount = 1,
+            FailureCount = 1,
+            Results = results,
+        };
+
+        // Assert
+        batch.SuccessCount.Should().Be(1);
+        batch.FailureCount.Should().Be(1);
+        batch.Results.Should().HaveCount(2);
+        batch.Results.Should().BeEquivalentTo(results);
+    }
+
+    [Fact]
+    public void BatchSmsDeliveryResult_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new BatchSmsDeliveryResult
+        {
+            SuccessCount = 1,
+            FailureCount = 0,
+            Results = Array.Empty<SmsDeliveryResult>(),
+        };
+
+        // Act
+        var updated = original with { FailureCount = 3 };
+
+        // Assert
+        updated.FailureCount.Should().Be(3);
+        original.FailureCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void BatchSmsDeliveryResult_RecordEquality_TwoIdenticalBatches_AreEqual()
+    {
+        // Arrange
+        var results = new[] { new SmsDeliveryResult { ProviderMessageId = "SM", Status = SmsStatus.Sent, SegmentCount = 1 } };
+        var first = new BatchSmsDeliveryResult { SuccessCount = 1, FailureCount = 0, Results = results };
+        var second = new BatchSmsDeliveryResult { SuccessCount = 1, FailureCount = 0, Results = results };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/SmsDeliveryResultTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/SmsDeliveryResultTests.cs
@@ -1,0 +1,107 @@
+// -----------------------------------------------------------------------
+// <copyright file="SmsDeliveryResultTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Tests.Models;
+
+public class SmsDeliveryResultTests
+{
+    [Fact]
+    public void SmsDeliveryResult_WithRequiredOnly_DefaultsCostHintToNull()
+    {
+        // Arrange / Act
+        var result = new SmsDeliveryResult
+        {
+            ProviderMessageId = "SM123",
+            Status = SmsStatus.Queued,
+            SegmentCount = 1,
+        };
+
+        // Assert
+        result.ProviderMessageId.Should().Be("SM123");
+        result.Status.Should().Be(SmsStatus.Queued);
+        result.SegmentCount.Should().Be(1);
+        result.CostHint.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(SmsStatus.Queued, 1, "0.0075 USD")]
+    [InlineData(SmsStatus.Sent, 2, "0.015 USD")]
+    [InlineData(SmsStatus.Delivered, 3, null)]
+    [InlineData(SmsStatus.Failed, 0, null)]
+    [InlineData(SmsStatus.Undelivered, 1, "0.0075 USD")]
+    public void SmsDeliveryResult_WithVariousStatuses_PreservesValues(SmsStatus status, int segments, string? costHint)
+    {
+        // Act
+        var result = new SmsDeliveryResult
+        {
+            ProviderMessageId = "SM-abc",
+            Status = status,
+            SegmentCount = segments,
+            CostHint = costHint,
+        };
+
+        // Assert
+        result.Status.Should().Be(status);
+        result.SegmentCount.Should().Be(segments);
+        result.CostHint.Should().Be(costHint);
+    }
+
+    [Fact]
+    public void SmsDeliveryResult_RecordEquality_TwoIdenticalResults_AreEqual()
+    {
+        // Arrange
+        var first = new SmsDeliveryResult
+        {
+            ProviderMessageId = "SM1",
+            Status = SmsStatus.Sent,
+            SegmentCount = 2,
+            CostHint = "0.015 USD",
+        };
+        var second = new SmsDeliveryResult
+        {
+            ProviderMessageId = "SM1",
+            Status = SmsStatus.Sent,
+            SegmentCount = 2,
+            CostHint = "0.015 USD",
+        };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void SmsDeliveryResult_RecordEquality_DifferingStatus_AreNotEqual()
+    {
+        // Arrange
+        var first = new SmsDeliveryResult { ProviderMessageId = "SM1", Status = SmsStatus.Sent, SegmentCount = 1 };
+        var second = new SmsDeliveryResult { ProviderMessageId = "SM1", Status = SmsStatus.Failed, SegmentCount = 1 };
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void SmsDeliveryResult_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new SmsDeliveryResult
+        {
+            ProviderMessageId = "SM1",
+            Status = SmsStatus.Queued,
+            SegmentCount = 1,
+        };
+
+        // Act
+        var updated = original with { Status = SmsStatus.Delivered };
+
+        // Assert
+        updated.Status.Should().Be(SmsStatus.Delivered);
+        original.Status.Should().Be(SmsStatus.Queued);
+        updated.ProviderMessageId.Should().Be(original.ProviderMessageId);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/SmsMessageTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/SmsMessageTests.cs
@@ -1,0 +1,113 @@
+// -----------------------------------------------------------------------
+// <copyright file="SmsMessageTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Tests.Models;
+
+public class SmsMessageTests
+{
+    [Fact]
+    public void SmsMessage_WithRequiredOnly_DefaultsMediaUrlsToNull()
+    {
+        // Arrange / Act
+        var message = new SmsMessage
+        {
+            From = "+15551234567",
+            To = "+15557654321",
+            Body = "Hello",
+            TenantId = "tenant-1",
+        };
+
+        // Assert
+        message.From.Should().Be("+15551234567");
+        message.To.Should().Be("+15557654321");
+        message.Body.Should().Be("Hello");
+        message.TenantId.Should().Be("tenant-1");
+        message.MediaUrls.Should().BeNull();
+    }
+
+    [Fact]
+    public void SmsMessage_WithMediaUrls_PreservesValues()
+    {
+        // Arrange
+        var media = new[] { "https://cdn.example.com/a.jpg", "https://cdn.example.com/b.png" };
+
+        // Act
+        var message = new SmsMessage
+        {
+            From = "+15551234567",
+            To = "+15557654321",
+            Body = "See attached",
+            TenantId = "tenant-1",
+            MediaUrls = media,
+        };
+
+        // Assert
+        message.MediaUrls.Should().BeEquivalentTo(media);
+    }
+
+    [Fact]
+    public void SmsMessage_RecordEquality_TwoIdenticalMessages_AreEqual()
+    {
+        // Arrange
+        var media = new[] { "https://cdn.example.com/a.jpg" };
+        var first = new SmsMessage
+        {
+            From = "+15551234567",
+            To = "+15557654321",
+            Body = "B",
+            TenantId = "t-1",
+            MediaUrls = media,
+        };
+        var second = new SmsMessage
+        {
+            From = "+15551234567",
+            To = "+15557654321",
+            Body = "B",
+            TenantId = "t-1",
+            MediaUrls = media,
+        };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void SmsMessage_RecordEquality_DifferingTo_AreNotEqual()
+    {
+        // Arrange
+        var first = new SmsMessage { From = "+1", To = "+15557654321", Body = "B", TenantId = "t" };
+        var second = new SmsMessage { From = "+1", To = "+15557654322", Body = "B", TenantId = "t" };
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void SmsMessage_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new SmsMessage
+        {
+            From = "+15551234567",
+            To = "+15557654321",
+            Body = "Hello",
+            TenantId = "tenant-1",
+        };
+
+        // Act
+        var updated = original with { Body = "Bye" };
+
+        // Assert
+        updated.Should().NotBeSameAs(original);
+        updated.Body.Should().Be("Bye");
+        original.Body.Should().Be("Hello");
+        updated.From.Should().Be(original.From);
+        updated.To.Should().Be(original.To);
+        updated.TenantId.Should().Be(original.TenantId);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/SmsStatusTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/Models/SmsStatusTests.cs
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="SmsStatusTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Notifications.Tests.Models;
+
+public class SmsStatusTests
+{
+    [Theory]
+    [InlineData(SmsStatus.Queued, 0)]
+    [InlineData(SmsStatus.Sent, 1)]
+    [InlineData(SmsStatus.Delivered, 2)]
+    [InlineData(SmsStatus.Failed, 3)]
+    [InlineData(SmsStatus.Undelivered, 4)]
+    public void SmsStatus_HasStableUnderlyingValues(SmsStatus status, int expected)
+    {
+        // Act
+        var value = (int)status;
+
+        // Assert
+        value.Should().Be(expected);
+    }
+
+    [Fact]
+    public void SmsStatus_DefinesExactlyFiveMembers()
+    {
+        // Act
+        var members = Enum.GetValues<SmsStatus>();
+
+        // Assert
+        members.Should().BeEquivalentTo(new[]
+        {
+            SmsStatus.Queued,
+            SmsStatus.Sent,
+            SmsStatus.Delivered,
+            SmsStatus.Failed,
+            SmsStatus.Undelivered,
+        });
+    }
+
+    [Theory]
+    [InlineData("Queued", SmsStatus.Queued)]
+    [InlineData("Sent", SmsStatus.Sent)]
+    [InlineData("Delivered", SmsStatus.Delivered)]
+    [InlineData("Failed", SmsStatus.Failed)]
+    [InlineData("Undelivered", SmsStatus.Undelivered)]
+    public void SmsStatus_Parse_ReturnsExpectedMember(string name, SmsStatus expected)
+    {
+        // Act
+        var parsed = Enum.Parse<SmsStatus>(name);
+
+        // Assert
+        parsed.Should().Be(expected);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Notifications.Tests/NotificationErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Notifications.Tests/NotificationErrorsTests.cs
@@ -93,6 +93,8 @@ public class NotificationErrorsTests
         NotificationErrors.ProviderUnreachable("r").Should().NotBeNull();
         NotificationErrors.RateLimited("r").Should().NotBeNull();
         NotificationErrors.PayloadTooLarge(1, 0).Should().NotBeNull();
+        NotificationErrors.InvalidPhoneNumber("+1").Should().NotBeNull();
+        NotificationErrors.MessageTooLong(1, 0).Should().NotBeNull();
     }
 
     [Fact]
@@ -105,9 +107,42 @@ public class NotificationErrorsTests
             NotificationErrors.ProviderUnreachable("r").Code,
             NotificationErrors.RateLimited("r").Code,
             NotificationErrors.PayloadTooLarge(1, 0).Code,
+            NotificationErrors.InvalidPhoneNumber("+1").Code,
+            NotificationErrors.MessageTooLong(1, 0).Code,
         };
 
         // Assert
         codes.Should().OnlyContain(c => c.StartsWith("Notification.", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("+15551234567")]
+    [InlineData("not-a-number")]
+    [InlineData("")]
+    public void InvalidPhoneNumber_WithVariousInputs_EmbedsNumberInMessage(string phoneNumber)
+    {
+        // Act
+        var error = NotificationErrors.InvalidPhoneNumber(phoneNumber);
+
+        // Assert
+        error.Code.Should().Be("Notification.InvalidPhoneNumber");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain($"'{phoneNumber}'");
+    }
+
+    [Theory]
+    [InlineData(1700, 1600)]
+    [InlineData(161, 160)]
+    [InlineData(1, 0)]
+    public void MessageTooLong_WithLengths_EmbedsBothLengthsInMessage(int length, int maxLength)
+    {
+        // Act
+        var error = NotificationErrors.MessageTooLong(length, maxLength);
+
+        // Assert
+        error.Code.Should().Be("Notification.MessageTooLong");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain(length.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        error.Message.Should().Contain(maxLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
     }
 }


### PR DESCRIPTION
## Summary
Defines ISmsSender port in the existing Compendium.Abstractions.Notifications assembly. Unblocks compendium-adapter-twilio per ADR-0006.

## Surface
- ISmsSender (Send / SendBatch)
- SmsMessage (E.164 from/to + MMS media URLs)
- SmsDeliveryResult, BatchSmsDeliveryResult records
- SmsStatus enum
- NotificationErrors extended with SMS factories

## Coverage ≥ 90 % line.

## Test plan
- [x] dotnet build green
- [x] dotnet test green
- [x] Coverage ≥ 90 %
- [ ] CI green