### PR TITLE
feat(abstractions/authorization): define IAuthorizationCheck port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -149,6 +149,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Not
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Notifications.Tests", "tests\Unit\Compendium.Abstractions.Notifications.Tests\Compendium.Abstractions.Notifications.Tests.csproj", "{324F5FC3-B793-4ABC-A42A-A08E9786FC31}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Authorization", "src\Abstractions\Compendium.Abstractions.Authorization\Compendium.Abstractions.Authorization.csproj", "{448094F8-77C7-47D8-8773-2BCC7CF91260}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Authorization.Tests", "tests\Unit\Compendium.Abstractions.Authorization.Tests\Compendium.Abstractions.Authorization.Tests.csproj", "{C499B149-30E7-4631-AC74-B233DE6EDE06}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -382,6 +386,14 @@ Global
 		{324F5FC3-B793-4ABC-A42A-A08E9786FC31}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{324F5FC3-B793-4ABC-A42A-A08E9786FC31}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{324F5FC3-B793-4ABC-A42A-A08E9786FC31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{448094F8-77C7-47D8-8773-2BCC7CF91260}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{448094F8-77C7-47D8-8773-2BCC7CF91260}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{448094F8-77C7-47D8-8773-2BCC7CF91260}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{448094F8-77C7-47D8-8773-2BCC7CF91260}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C499B149-30E7-4631-AC74-B233DE6EDE06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C499B149-30E7-4631-AC74-B233DE6EDE06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C499B149-30E7-4631-AC74-B233DE6EDE06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C499B149-30E7-4631-AC74-B233DE6EDE06}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -452,5 +464,7 @@ Global
 		{5AFD25BC-3B19-49EC-9D2F-568BC1B32D82} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{93524074-B12D-4509-80AE-2F7EE620A8E8} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
 		{324F5FC3-B793-4ABC-A42A-A08E9786FC31} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{448094F8-77C7-47D8-8773-2BCC7CF91260} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
+		{C499B149-30E7-4631-AC74-B233DE6EDE06} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Authorization/AuthorizationErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Authorization/AuthorizationErrors.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------
+// <copyright file="AuthorizationErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Authorization;
+
+/// <summary>
+/// Provides standard error definitions for relationship-based authorization operations.
+/// </summary>
+public static class AuthorizationErrors
+{
+    /// <summary>
+    /// Error returned when a subject is not authorized to perform the requested relation on the object.
+    /// </summary>
+    /// <param name="subject">The subject that was denied.</param>
+    /// <param name="relation">The relation that was checked.</param>
+    /// <param name="object">The object the relation was checked against.</param>
+    /// <returns>A forbidden error describing the denial.</returns>
+    public static Error NotAuthorized(string subject, string relation, string @object) =>
+        Error.Forbidden(
+            "Authorization.NotAuthorized",
+            $"Subject '{subject}' is not authorized for relation '{relation}' on object '{@object}'.");
+
+    /// <summary>
+    /// Error returned when a supplied relation tuple is malformed or violates the authorization model.
+    /// </summary>
+    /// <param name="reason">The validation reason.</param>
+    /// <returns>A validation error describing the invalid tuple.</returns>
+    public static Error InvalidTuple(string reason) =>
+        Error.Validation("Authorization.InvalidTuple", $"The relation tuple is invalid: {reason}");
+
+    /// <summary>
+    /// Error returned when no authorization store exists for the supplied tenant.
+    /// </summary>
+    /// <param name="tenantId">The tenant whose store could not be located.</param>
+    /// <returns>A not-found error describing the missing store.</returns>
+    public static Error StoreNotFound(string tenantId) =>
+        Error.NotFound(
+            "Authorization.StoreNotFound",
+            $"No authorization store was found for tenant '{tenantId}'.");
+
+    /// <summary>
+    /// Error returned when the authorization provider cannot be reached.
+    /// </summary>
+    /// <param name="reason">The underlying transport / connectivity reason.</param>
+    /// <returns>An unavailable error describing the connectivity failure.</returns>
+    public static Error ProviderUnreachable(string reason) =>
+        Error.Unavailable(
+            "Authorization.ProviderUnreachable",
+            $"The authorization provider is unreachable: {reason}");
+}

--- a/src/Abstractions/Compendium.Abstractions.Authorization/Compendium.Abstractions.Authorization.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Authorization/Compendium.Abstractions.Authorization.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Authorization</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Authorization</RootNamespace>
+    <PackageId>Compendium.Abstractions.Authorization</PackageId>
+    <Description>Authorization abstractions for Compendium Framework: IAuthorizationCheck (relationship-based access control / ReBAC). Provider-agnostic interface for relationship-based authorization across OpenFGA, SpiceDB, and similar Zanzibar-style stores.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Authorization.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Authorization/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Authorization/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.Authorization/IAuthorizationCheck.cs
+++ b/src/Abstractions/Compendium.Abstractions.Authorization/IAuthorizationCheck.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// <copyright file="IAuthorizationCheck.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Authorization.Models;
+
+namespace Compendium.Abstractions.Authorization;
+
+/// <summary>
+/// Provides operations for relationship-based authorization (ReBAC) against a Zanzibar-style store.
+/// This interface is provider-agnostic and can be implemented by adapters targeting
+/// OpenFGA, SpiceDB, AuthZed, and similar relationship-based authorization services.
+/// Each tenant has its own authorization store; tenant scoping is mandatory on every call.
+/// </summary>
+public interface IAuthorizationCheck
+{
+    /// <summary>
+    /// Evaluates whether the supplied subject has the requested relation with the requested object.
+    /// </summary>
+    /// <param name="request">The authorization request, including tenant and optional contextual tuples.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>
+    /// A result containing <see langword="true"/> when the subject is authorized, <see langword="false"/> otherwise,
+    /// or an error when the store cannot evaluate the check.
+    /// </returns>
+    Task<Result<bool>> CheckAsync(AuthorizationRequest request, CancellationToken ct);
+
+    /// <summary>
+    /// Lists the object identifiers of <paramref name="objectType"/> that the supplied subject has
+    /// the requested relation with.
+    /// </summary>
+    /// <param name="subject">The subject whose objects should be listed (typically <c>user:&lt;id&gt;</c>).</param>
+    /// <param name="relation">The relation to enumerate.</param>
+    /// <param name="objectType">The type of object to enumerate (without the <c>&lt;id&gt;</c> suffix).</param>
+    /// <param name="tenantId">The tenant whose authorization store should answer the request.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the matching object identifiers or an error.</returns>
+    Task<Result<IReadOnlyList<string>>> ListObjectsAsync(
+        string subject,
+        string relation,
+        string objectType,
+        string tenantId,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Writes and / or deletes relationship tuples in the tenant's authorization store atomically.
+    /// </summary>
+    /// <param name="writes">Tuples to insert; may be empty.</param>
+    /// <param name="deletes">Tuples to remove; may be empty.</param>
+    /// <param name="tenantId">The tenant whose authorization store should be mutated.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A success result when the mutation has been applied, or an error otherwise.</returns>
+    Task<Result> WriteAsync(
+        IEnumerable<RelationTuple> writes,
+        IEnumerable<RelationTuple> deletes,
+        string tenantId,
+        CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Authorization/Models/AuthorizationRequest.cs
+++ b/src/Abstractions/Compendium.Abstractions.Authorization/Models/AuthorizationRequest.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------
+// <copyright file="AuthorizationRequest.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Authorization.Models;
+
+/// <summary>
+/// Represents a relationship-based authorization check request.
+/// Asks whether <paramref name="Subject"/> has <paramref name="Relation"/> with <paramref name="Object"/>
+/// in the store identified by <paramref name="TenantId"/>, optionally augmented with <paramref name="ContextualTuples"/>
+/// that exist only for the duration of the check.
+/// </summary>
+/// <param name="Subject">The subject under evaluation (typically <c>user:&lt;id&gt;</c> or a userset reference).</param>
+/// <param name="Relation">The relation to check, as defined in the authorization model.</param>
+/// <param name="Object">The object the relation is checked against (typically <c>&lt;type&gt;:&lt;id&gt;</c>).</param>
+/// <param name="TenantId">The tenant whose authorization store should answer the check.</param>
+/// <param name="ContextualTuples">
+/// Optional in-flight tuples added to the evaluation context but not persisted to the store. Use for
+/// "what-if" evaluations or for relationships that exist only within the request scope.
+/// </param>
+public sealed record AuthorizationRequest(
+    string Subject,
+    string Relation,
+    string Object,
+    string TenantId,
+    IReadOnlyList<RelationTuple>? ContextualTuples = null);

--- a/src/Abstractions/Compendium.Abstractions.Authorization/Models/RelationTuple.cs
+++ b/src/Abstractions/Compendium.Abstractions.Authorization/Models/RelationTuple.cs
@@ -1,0 +1,17 @@
+// -----------------------------------------------------------------------
+// <copyright file="RelationTuple.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Authorization.Models;
+
+/// <summary>
+/// Represents a relationship tuple in a Zanzibar-style relationship-based authorization store.
+/// A tuple expresses the fact that <paramref name="Subject"/> has <paramref name="Relation"/> with <paramref name="Object"/>.
+/// </summary>
+/// <param name="Subject">The subject of the relationship (typically <c>user:&lt;id&gt;</c> or a userset reference).</param>
+/// <param name="Relation">The name of the relation as defined in the authorization model.</param>
+/// <param name="Object">The object of the relationship (typically <c>&lt;type&gt;:&lt;id&gt;</c>).</param>
+public sealed record RelationTuple(string Subject, string Relation, string Object);

--- a/tests/Unit/Compendium.Abstractions.Authorization.Tests/AuthorizationErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Authorization.Tests/AuthorizationErrorsTests.cs
@@ -1,0 +1,118 @@
+// -----------------------------------------------------------------------
+// <copyright file="AuthorizationErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Authorization.Tests;
+
+public class AuthorizationErrorsTests
+{
+    [Fact]
+    public void NotAuthorized_WithSubjectRelationObject_ReturnsForbiddenError()
+    {
+        // Arrange
+        const string subject = "user:1";
+        const string relation = "viewer";
+        const string @object = "doc:1";
+
+        // Act
+        var error = AuthorizationErrors.NotAuthorized(subject, relation, @object);
+
+        // Assert
+        error.Code.Should().Be("Authorization.NotAuthorized");
+        error.Type.Should().Be(ErrorType.Forbidden);
+        error.Message.Should().Contain(subject);
+        error.Message.Should().Contain(relation);
+        error.Message.Should().Contain(@object);
+    }
+
+    [Theory]
+    [InlineData("user:1", "viewer", "doc:1")]
+    [InlineData("group:eng#member", "editor", "folder:specs")]
+    [InlineData("user:*", "owner", "doc:public")]
+    public void NotAuthorized_EmbedsAllThreeArgumentsInMessage(string subject, string relation, string @object)
+    {
+        // Act
+        var error = AuthorizationErrors.NotAuthorized(subject, relation, @object);
+
+        // Assert
+        error.Code.Should().Be("Authorization.NotAuthorized");
+        error.Type.Should().Be(ErrorType.Forbidden);
+        error.Message.Should().Contain(subject);
+        error.Message.Should().Contain(relation);
+        error.Message.Should().Contain(@object);
+    }
+
+    [Fact]
+    public void InvalidTuple_WithReason_ReturnsValidationError()
+    {
+        // Arrange
+        const string reason = "subject cannot be empty";
+
+        // Act
+        var error = AuthorizationErrors.InvalidTuple(reason);
+
+        // Assert
+        error.Code.Should().Be("Authorization.InvalidTuple");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Fact]
+    public void StoreNotFound_WithTenantId_ReturnsNotFoundError()
+    {
+        // Arrange
+        const string tenantId = "tenant-xyz";
+
+        // Act
+        var error = AuthorizationErrors.StoreNotFound(tenantId);
+
+        // Assert
+        error.Code.Should().Be("Authorization.StoreNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain($"'{tenantId}'");
+    }
+
+    [Fact]
+    public void ProviderUnreachable_WithReason_ReturnsUnavailableError()
+    {
+        // Arrange
+        const string reason = "connection timeout";
+
+        // Act
+        var error = AuthorizationErrors.ProviderUnreachable(reason);
+
+        // Assert
+        error.Code.Should().Be("Authorization.ProviderUnreachable");
+        error.Type.Should().Be(ErrorType.Unavailable);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Fact]
+    public void AllErrorFactories_ReturnNonNullErrorInstances()
+    {
+        // Act / Assert
+        AuthorizationErrors.NotAuthorized("s", "r", "o").Should().NotBeNull();
+        AuthorizationErrors.InvalidTuple("r").Should().NotBeNull();
+        AuthorizationErrors.StoreNotFound("t").Should().NotBeNull();
+        AuthorizationErrors.ProviderUnreachable("r").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AllErrorCodes_StartWithAuthorizationPrefix()
+    {
+        // Act
+        var codes = new[]
+        {
+            AuthorizationErrors.NotAuthorized("s", "r", "o").Code,
+            AuthorizationErrors.InvalidTuple("r").Code,
+            AuthorizationErrors.StoreNotFound("t").Code,
+            AuthorizationErrors.ProviderUnreachable("r").Code,
+        };
+
+        // Assert
+        codes.Should().OnlyContain(c => c.StartsWith("Authorization.", StringComparison.Ordinal));
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Authorization.Tests/Compendium.Abstractions.Authorization.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Authorization.Tests/Compendium.Abstractions.Authorization.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Authorization.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Authorization.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Core\Compendium.Core\Compendium.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Authorization\Compendium.Abstractions.Authorization.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Authorization.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Authorization.Tests/GlobalUsings.cs
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Xunit;
+global using FluentAssertions;
+global using Compendium.Abstractions.Authorization;
+global using Compendium.Abstractions.Authorization.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Authorization.Tests/Models/AuthorizationRequestTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Authorization.Tests/Models/AuthorizationRequestTests.cs
@@ -1,0 +1,116 @@
+// -----------------------------------------------------------------------
+// <copyright file="AuthorizationRequestTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Authorization.Tests.Models;
+
+public class AuthorizationRequestTests
+{
+    [Fact]
+    public void AuthorizationRequest_WithRequiredOnly_LeavesContextualTuplesNull()
+    {
+        // Arrange / Act
+        var request = new AuthorizationRequest("user:1", "viewer", "doc:1", "tenant-a");
+
+        // Assert
+        request.Subject.Should().Be("user:1");
+        request.Relation.Should().Be("viewer");
+        request.Object.Should().Be("doc:1");
+        request.TenantId.Should().Be("tenant-a");
+        request.ContextualTuples.Should().BeNull();
+    }
+
+    [Fact]
+    public void AuthorizationRequest_WithContextualTuples_PreservesList()
+    {
+        // Arrange
+        var ctx = new[]
+        {
+            new RelationTuple("user:1", "member", "group:eng"),
+            new RelationTuple("group:eng", "viewer", "doc:1"),
+        };
+
+        // Act
+        var request = new AuthorizationRequest("user:1", "viewer", "doc:1", "tenant-a", ctx);
+
+        // Assert
+        request.ContextualTuples.Should().NotBeNull();
+        request.ContextualTuples!.Should().HaveCount(2);
+        request.ContextualTuples!.Should().ContainInOrder(ctx);
+    }
+
+    [Theory]
+    [InlineData("user:1", "viewer", "doc:1", "tenant-a")]
+    [InlineData("group:eng#member", "editor", "folder:specs", "tenant-b")]
+    [InlineData("user:*", "viewer", "doc:public", "tenant-c")]
+    public void AuthorizationRequest_AcrossShapes_PreservesAllFields(string subject, string relation, string @object, string tenantId)
+    {
+        // Arrange / Act
+        var request = new AuthorizationRequest(subject, relation, @object, tenantId);
+
+        // Assert
+        request.Subject.Should().Be(subject);
+        request.Relation.Should().Be(relation);
+        request.Object.Should().Be(@object);
+        request.TenantId.Should().Be(tenantId);
+    }
+
+    [Fact]
+    public void AuthorizationRequest_RecordEquality_TwoIdenticalRequests_AreEqual()
+    {
+        // Arrange
+        var ctx = new[] { new RelationTuple("user:1", "member", "group:eng") };
+        var first = new AuthorizationRequest("user:1", "viewer", "doc:1", "tenant-a", ctx);
+        var second = first with { };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void AuthorizationRequest_RecordEquality_DifferingTenant_AreNotEqual()
+    {
+        // Arrange
+        var first = new AuthorizationRequest("user:1", "viewer", "doc:1", "tenant-a");
+        var second = new AuthorizationRequest("user:1", "viewer", "doc:1", "tenant-b");
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void AuthorizationRequest_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new AuthorizationRequest("user:1", "viewer", "doc:1", "tenant-a");
+
+        // Act
+        var updated = original with { Relation = "editor" };
+
+        // Assert
+        updated.Relation.Should().Be("editor");
+        original.Relation.Should().Be("viewer");
+    }
+
+    [Fact]
+    public void AuthorizationRequest_Deconstruction_YieldsAllPositionalFields()
+    {
+        // Arrange
+        var ctx = new[] { new RelationTuple("user:1", "member", "group:eng") };
+        var request = new AuthorizationRequest("user:1", "viewer", "doc:1", "tenant-a", ctx);
+
+        // Act
+        var (subject, relation, @object, tenantId, contextual) = request;
+
+        // Assert
+        subject.Should().Be("user:1");
+        relation.Should().Be("viewer");
+        @object.Should().Be("doc:1");
+        tenantId.Should().Be("tenant-a");
+        contextual.Should().BeEquivalentTo(ctx);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Authorization.Tests/Models/RelationTupleTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Authorization.Tests/Models/RelationTupleTests.cs
@@ -1,0 +1,90 @@
+// -----------------------------------------------------------------------
+// <copyright file="RelationTupleTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Authorization.Tests.Models;
+
+public class RelationTupleTests
+{
+    [Fact]
+    public void RelationTuple_WithAllFields_PreservesValues()
+    {
+        // Arrange / Act
+        var tuple = new RelationTuple("user:alice", "viewer", "doc:readme");
+
+        // Assert
+        tuple.Subject.Should().Be("user:alice");
+        tuple.Relation.Should().Be("viewer");
+        tuple.Object.Should().Be("doc:readme");
+    }
+
+    [Theory]
+    [InlineData("user:alice", "viewer", "doc:readme")]
+    [InlineData("group:eng#member", "editor", "folder:specs")]
+    [InlineData("user:*", "viewer", "doc:public")]
+    public void RelationTuple_WithVariousSubjectShapes_PreservesValues(string subject, string relation, string @object)
+    {
+        // Arrange / Act
+        var tuple = new RelationTuple(subject, relation, @object);
+
+        // Assert
+        tuple.Subject.Should().Be(subject);
+        tuple.Relation.Should().Be(relation);
+        tuple.Object.Should().Be(@object);
+    }
+
+    [Fact]
+    public void RelationTuple_RecordEquality_TwoIdenticalTuples_AreEqual()
+    {
+        // Arrange
+        var first = new RelationTuple("user:1", "owner", "doc:1");
+        var second = new RelationTuple("user:1", "owner", "doc:1");
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void RelationTuple_RecordEquality_DifferingRelation_AreNotEqual()
+    {
+        // Arrange
+        var first = new RelationTuple("user:1", "viewer", "doc:1");
+        var second = new RelationTuple("user:1", "editor", "doc:1");
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void RelationTuple_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new RelationTuple("user:1", "viewer", "doc:1");
+
+        // Act
+        var updated = original with { Relation = "editor" };
+
+        // Assert
+        updated.Relation.Should().Be("editor");
+        original.Relation.Should().Be("viewer");
+    }
+
+    [Fact]
+    public void RelationTuple_Deconstruction_YieldsAllPositionalFields()
+    {
+        // Arrange
+        var tuple = new RelationTuple("user:1", "viewer", "doc:1");
+
+        // Act
+        var (subject, relation, @object) = tuple;
+
+        // Assert
+        subject.Should().Be("user:1");
+        relation.Should().Be("viewer");
+        @object.Should().Be("doc:1");
+    }
+}


### PR DESCRIPTION
## Summary
Defines IAuthorizationCheck port (relationship-based authorization / ReBAC) in new Compendium.Abstractions.Authorization assembly. Unblocks compendium-adapter-openfga per ADR-0006.

## Surface
- IAuthorizationCheck (Check / ListObjects / Write)
- AuthorizationRequest, RelationTuple records
- AuthorizationErrors factories

Tenant scoping mandatory — each tenant has its own store.

## Coverage ≥ 90 % line.

## Test plan
- [x] dotnet build green
- [x] dotnet test green
- [x] Coverage ≥ 90 %
- [ ] CI green