### PR TITLE
feat(abstractions/jobs): define IBackgroundJobScheduler port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -153,6 +153,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Aut
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Authorization.Tests", "tests\Unit\Compendium.Abstractions.Authorization.Tests\Compendium.Abstractions.Authorization.Tests.csproj", "{C499B149-30E7-4631-AC74-B233DE6EDE06}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Jobs", "src\Abstractions\Compendium.Abstractions.Jobs\Compendium.Abstractions.Jobs.csproj", "{5D6D8364-AC8D-41E5-9AE6-E8791168D92C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Jobs.Tests", "tests\Unit\Compendium.Abstractions.Jobs.Tests\Compendium.Abstractions.Jobs.Tests.csproj", "{D93B7204-8B08-4B10-B925-3043EE24907C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -394,6 +398,14 @@ Global
 		{C499B149-30E7-4631-AC74-B233DE6EDE06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C499B149-30E7-4631-AC74-B233DE6EDE06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C499B149-30E7-4631-AC74-B233DE6EDE06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D6D8364-AC8D-41E5-9AE6-E8791168D92C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D6D8364-AC8D-41E5-9AE6-E8791168D92C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D6D8364-AC8D-41E5-9AE6-E8791168D92C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D6D8364-AC8D-41E5-9AE6-E8791168D92C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D93B7204-8B08-4B10-B925-3043EE24907C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D93B7204-8B08-4B10-B925-3043EE24907C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D93B7204-8B08-4B10-B925-3043EE24907C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D93B7204-8B08-4B10-B925-3043EE24907C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -466,5 +478,7 @@ Global
 		{324F5FC3-B793-4ABC-A42A-A08E9786FC31} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{448094F8-77C7-47D8-8773-2BCC7CF91260} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
 		{C499B149-30E7-4631-AC74-B233DE6EDE06} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{5D6D8364-AC8D-41E5-9AE6-E8791168D92C} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
+		{D93B7204-8B08-4B10-B925-3043EE24907C} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Jobs/Compendium.Abstractions.Jobs.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Jobs/Compendium.Abstractions.Jobs.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Jobs</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Jobs</RootNamespace>
+    <PackageId>Compendium.Abstractions.Jobs</PackageId>
+    <Description>Background job abstractions for Compendium Framework: IBackgroundJobScheduler. Provider-agnostic interface for enqueueing, scheduling, recurring, and cancelling background jobs across Hangfire, Temporal, and similar engines.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Jobs.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Jobs/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Jobs/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.Jobs/IBackgroundJobScheduler.cs
+++ b/src/Abstractions/Compendium.Abstractions.Jobs/IBackgroundJobScheduler.cs
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------
+// <copyright file="IBackgroundJobScheduler.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Jobs.Models;
+
+namespace Compendium.Abstractions.Jobs;
+
+/// <summary>
+/// Provides operations for enqueueing, scheduling, recurring, and cancelling background jobs.
+/// This interface is provider-agnostic and can be implemented by adapters targeting
+/// Hangfire, Temporal, Quartz, or similar engines.
+/// </summary>
+public interface IBackgroundJobScheduler
+{
+    /// <summary>
+    /// Enqueues a job for immediate background execution.
+    /// </summary>
+    /// <typeparam name="TPayload">The payload type carried by the job.</typeparam>
+    /// <param name="jobName">The logical job name used to route to a handler.</param>
+    /// <param name="payload">The payload to deliver to the handler.</param>
+    /// <param name="opts">The tenant-aware job options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the adapter-assigned job identifier or an error.</returns>
+    Task<Result<string>> EnqueueAsync<TPayload>(
+        string jobName,
+        TPayload payload,
+        JobOptions opts,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Schedules a job for one-shot execution at the supplied future time.
+    /// </summary>
+    /// <typeparam name="TPayload">The payload type carried by the job.</typeparam>
+    /// <param name="jobName">The logical job name used to route to a handler.</param>
+    /// <param name="payload">The payload to deliver to the handler.</param>
+    /// <param name="runAt">The absolute time at which the job should run.</param>
+    /// <param name="opts">The tenant-aware job options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the adapter-assigned job identifier or an error.</returns>
+    Task<Result<string>> ScheduleAsync<TPayload>(
+        string jobName,
+        TPayload payload,
+        DateTimeOffset runAt,
+        JobOptions opts,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Registers (or replaces) a recurring job described by a cron expression.
+    /// </summary>
+    /// <typeparam name="TPayload">The payload type carried by the job.</typeparam>
+    /// <param name="jobName">The logical job name used to route to a handler. Acts as the recurrence key.</param>
+    /// <param name="payload">The payload to deliver to the handler on every tick.</param>
+    /// <param name="cronExpression">The cron expression describing the recurrence.</param>
+    /// <param name="opts">The tenant-aware job options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the adapter-assigned recurring-job identifier or an error.</returns>
+    Task<Result<string>> RecurAsync<TPayload>(
+        string jobName,
+        TPayload payload,
+        string cronExpression,
+        JobOptions opts,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Cancels a previously enqueued, scheduled, or recurring job by adapter-assigned identifier.
+    /// </summary>
+    /// <param name="jobId">The adapter-assigned job identifier.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result indicating whether the cancellation succeeded.</returns>
+    Task<Result> CancelAsync(string jobId, CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Jobs/JobsErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Jobs/JobsErrors.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------
+// <copyright file="JobsErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Jobs;
+
+/// <summary>
+/// Provides standard error definitions for background-job operations.
+/// </summary>
+public static class JobsErrors
+{
+    /// <summary>
+    /// Error returned when the requested job identifier cannot be located by the adapter.
+    /// </summary>
+    public static Error JobNotFound(string jobId) =>
+        Error.NotFound("Jobs.JobNotFound", $"The background job '{jobId}' was not found.");
+
+    /// <summary>
+    /// Error returned when the supplied payload cannot be serialized or fails adapter-side validation.
+    /// </summary>
+    public static Error InvalidPayload(string reason) =>
+        Error.Validation("Jobs.InvalidPayload", $"The job payload is invalid: {reason}");
+
+    /// <summary>
+    /// Error returned when the supplied cron expression is not parseable by the adapter.
+    /// </summary>
+    public static Error CronInvalid(string cronExpression) =>
+        Error.Validation("Jobs.CronInvalid", $"The cron expression '{cronExpression}' is invalid.");
+
+    /// <summary>
+    /// Error returned when the request rate limit has been exceeded.
+    /// </summary>
+    public static Error RateLimited(string reason) =>
+        Error.TooManyRequests("Jobs.RateLimited", $"Rate limit exceeded: {reason}");
+
+    /// <summary>
+    /// Error returned when the background-job provider cannot be reached.
+    /// </summary>
+    public static Error ProviderUnreachable(string reason) =>
+        Error.Unavailable("Jobs.ProviderUnreachable", $"The background-job provider is unreachable: {reason}");
+}

--- a/src/Abstractions/Compendium.Abstractions.Jobs/Models/JobOptions.cs
+++ b/src/Abstractions/Compendium.Abstractions.Jobs/Models/JobOptions.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// <copyright file="JobOptions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Jobs.Models;
+
+/// <summary>
+/// Defines the priority bands a background job can be enqueued with.
+/// Adapters map these onto provider-specific queues / weights.
+/// </summary>
+public enum JobPriority
+{
+    /// <summary>
+    /// Low priority work that may be deferred under load.
+    /// </summary>
+    Low = 0,
+
+    /// <summary>
+    /// Default priority for ordinary background work.
+    /// </summary>
+    Normal = 1,
+
+    /// <summary>
+    /// Elevated priority — handled before normal work.
+    /// </summary>
+    High = 2,
+
+    /// <summary>
+    /// Critical priority — must run as soon as possible.
+    /// </summary>
+    Critical = 3,
+}
+
+/// <summary>
+/// Describes the retry behaviour applied to a background job.
+/// </summary>
+/// <param name="MaxAttempts">The maximum number of attempts (including the initial run).</param>
+/// <param name="InitialBackoff">The initial backoff between retries.</param>
+/// <param name="MaxBackoff">The optional cap for the exponential backoff.</param>
+public sealed record RetryPolicy(
+    int MaxAttempts,
+    TimeSpan InitialBackoff,
+    TimeSpan? MaxBackoff = null);
+
+/// <summary>
+/// Tenant-aware options describing how a background job should be enqueued, scheduled, or recurred.
+/// </summary>
+/// <param name="TenantId">The tenant the job belongs to. Required so adapters can isolate work per tenant.</param>
+/// <param name="Retry">The optional retry policy. Adapters may apply a sensible default when null.</param>
+/// <param name="Queue">The optional queue (or task list) name the adapter should target.</param>
+/// <param name="Priority">The job priority band.</param>
+/// <param name="ScheduledAt">The optional scheduled execution time. Ignored by <c>EnqueueAsync</c>.</param>
+public sealed record JobOptions(
+    string TenantId,
+    RetryPolicy? Retry = null,
+    string? Queue = null,
+    JobPriority Priority = JobPriority.Normal,
+    DateTimeOffset? ScheduledAt = null);

--- a/tests/Unit/Compendium.Abstractions.Jobs.Tests/Compendium.Abstractions.Jobs.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Jobs.Tests/Compendium.Abstractions.Jobs.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Jobs.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Jobs.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Core\Compendium.Core\Compendium.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Jobs\Compendium.Abstractions.Jobs.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Jobs.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Jobs.Tests/GlobalUsings.cs
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Xunit;
+global using FluentAssertions;
+global using Compendium.Abstractions.Jobs;
+global using Compendium.Abstractions.Jobs.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Jobs.Tests/JobsErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Jobs.Tests/JobsErrorsTests.cs
@@ -1,0 +1,129 @@
+// -----------------------------------------------------------------------
+// <copyright file="JobsErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Jobs.Tests;
+
+public class JobsErrorsTests
+{
+    [Fact]
+    public void JobNotFound_WithJobId_ReturnsNotFoundError()
+    {
+        // Arrange
+        const string jobId = "job-123";
+
+        // Act
+        var error = JobsErrors.JobNotFound(jobId);
+
+        // Assert
+        error.Code.Should().Be("Jobs.JobNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain($"'{jobId}'");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("short")]
+    [InlineData("very-long-job-identifier-2026-05-10-abc-def")]
+    public void JobNotFound_WithVariousIds_EmbedsIdInMessage(string jobId)
+    {
+        // Act
+        var error = JobsErrors.JobNotFound(jobId);
+
+        // Assert
+        error.Code.Should().Be("Jobs.JobNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain($"'{jobId}'");
+    }
+
+    [Fact]
+    public void InvalidPayload_WithReason_ReturnsValidationError()
+    {
+        // Arrange
+        const string reason = "payload exceeds 1MB limit";
+
+        // Act
+        var error = JobsErrors.InvalidPayload(reason);
+
+        // Assert
+        error.Code.Should().Be("Jobs.InvalidPayload");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Fact]
+    public void CronInvalid_WithExpression_ReturnsValidationError()
+    {
+        // Arrange
+        const string cron = "not-a-cron";
+
+        // Act
+        var error = JobsErrors.CronInvalid(cron);
+
+        // Assert
+        error.Code.Should().Be("Jobs.CronInvalid");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain($"'{cron}'");
+    }
+
+    [Fact]
+    public void RateLimited_WithReason_ReturnsTooManyRequestsError()
+    {
+        // Arrange
+        const string reason = "100 enqueues/sec exceeded";
+
+        // Act
+        var error = JobsErrors.RateLimited(reason);
+
+        // Assert
+        error.Code.Should().Be("Jobs.RateLimited");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Fact]
+    public void ProviderUnreachable_WithReason_ReturnsUnavailableError()
+    {
+        // Arrange
+        const string reason = "TCP connection refused";
+
+        // Act
+        var error = JobsErrors.ProviderUnreachable(reason);
+
+        // Assert
+        error.Code.Should().Be("Jobs.ProviderUnreachable");
+        error.Type.Should().Be(ErrorType.Unavailable);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Fact]
+    public void AllErrorFactories_ReturnNonNullErrorInstances()
+    {
+        // Act / Assert
+        JobsErrors.JobNotFound("j").Should().NotBeNull();
+        JobsErrors.InvalidPayload("r").Should().NotBeNull();
+        JobsErrors.CronInvalid("c").Should().NotBeNull();
+        JobsErrors.RateLimited("r").Should().NotBeNull();
+        JobsErrors.ProviderUnreachable("r").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AllErrorCodes_StartWithJobsPrefix()
+    {
+        // Act
+        var codes = new[]
+        {
+            JobsErrors.JobNotFound("j").Code,
+            JobsErrors.InvalidPayload("r").Code,
+            JobsErrors.CronInvalid("c").Code,
+            JobsErrors.RateLimited("r").Code,
+            JobsErrors.ProviderUnreachable("r").Code,
+        };
+
+        // Assert
+        codes.Should().OnlyContain(c => c.StartsWith("Jobs.", StringComparison.Ordinal));
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Jobs.Tests/Models/JobOptionsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Jobs.Tests/Models/JobOptionsTests.cs
@@ -1,0 +1,146 @@
+// -----------------------------------------------------------------------
+// <copyright file="JobOptionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Jobs.Tests.Models;
+
+public class JobOptionsTests
+{
+    [Fact]
+    public void JobOptions_WithTenantOnly_LeavesOptionalsAtDefaults()
+    {
+        // Arrange / Act
+        var opts = new JobOptions(TenantId: "tenant-1");
+
+        // Assert
+        opts.TenantId.Should().Be("tenant-1");
+        opts.Retry.Should().BeNull();
+        opts.Queue.Should().BeNull();
+        opts.Priority.Should().Be(JobPriority.Normal);
+        opts.ScheduledAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void JobOptions_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var retry = new RetryPolicy(MaxAttempts: 5, InitialBackoff: TimeSpan.FromSeconds(2), MaxBackoff: TimeSpan.FromMinutes(1));
+        var scheduledAt = new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+        // Act
+        var opts = new JobOptions(
+            TenantId: "tenant-2",
+            Retry: retry,
+            Queue: "critical",
+            Priority: JobPriority.Critical,
+            ScheduledAt: scheduledAt);
+
+        // Assert
+        opts.TenantId.Should().Be("tenant-2");
+        opts.Retry.Should().BeSameAs(retry);
+        opts.Queue.Should().Be("critical");
+        opts.Priority.Should().Be(JobPriority.Critical);
+        opts.ScheduledAt.Should().Be(scheduledAt);
+    }
+
+    [Theory]
+    [InlineData(JobPriority.Low)]
+    [InlineData(JobPriority.Normal)]
+    [InlineData(JobPriority.High)]
+    [InlineData(JobPriority.Critical)]
+    public void JobOptions_WithEachPriority_PreservesPriority(JobPriority priority)
+    {
+        // Arrange / Act
+        var opts = new JobOptions(TenantId: "t", Priority: priority);
+
+        // Assert
+        opts.Priority.Should().Be(priority);
+    }
+
+    [Fact]
+    public void JobOptions_RecordEquality_TwoIdenticalOptions_AreEqual()
+    {
+        // Arrange
+        var first = new JobOptions("t", new RetryPolicy(3, TimeSpan.FromSeconds(1)), "q", JobPriority.High);
+        var second = new JobOptions("t", new RetryPolicy(3, TimeSpan.FromSeconds(1)), "q", JobPriority.High);
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void JobOptions_RecordEquality_DifferingTenant_AreNotEqual()
+    {
+        // Arrange
+        var first = new JobOptions("a");
+        var second = new JobOptions("b");
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void JobOptions_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new JobOptions("t");
+
+        // Act
+        var updated = original with { Queue = "high", Priority = JobPriority.High };
+
+        // Assert
+        updated.Queue.Should().Be("high");
+        updated.Priority.Should().Be(JobPriority.High);
+        original.Queue.Should().BeNull();
+        original.Priority.Should().Be(JobPriority.Normal);
+    }
+
+    [Fact]
+    public void JobPriority_EnumValues_AreOrderedFromLowToCritical()
+    {
+        // Act / Assert
+        ((int)JobPriority.Low).Should().BeLessThan((int)JobPriority.Normal);
+        ((int)JobPriority.Normal).Should().BeLessThan((int)JobPriority.High);
+        ((int)JobPriority.High).Should().BeLessThan((int)JobPriority.Critical);
+    }
+
+    [Fact]
+    public void RetryPolicy_WithRequiredOnly_LeavesMaxBackoffNull()
+    {
+        // Arrange / Act
+        var policy = new RetryPolicy(MaxAttempts: 3, InitialBackoff: TimeSpan.FromSeconds(1));
+
+        // Assert
+        policy.MaxAttempts.Should().Be(3);
+        policy.InitialBackoff.Should().Be(TimeSpan.FromSeconds(1));
+        policy.MaxBackoff.Should().BeNull();
+    }
+
+    [Fact]
+    public void RetryPolicy_WithMaxBackoff_PreservesValue()
+    {
+        // Arrange / Act
+        var policy = new RetryPolicy(MaxAttempts: 10, InitialBackoff: TimeSpan.FromMilliseconds(500), MaxBackoff: TimeSpan.FromMinutes(5));
+
+        // Assert
+        policy.MaxAttempts.Should().Be(10);
+        policy.InitialBackoff.Should().Be(TimeSpan.FromMilliseconds(500));
+        policy.MaxBackoff.Should().Be(TimeSpan.FromMinutes(5));
+    }
+
+    [Fact]
+    public void RetryPolicy_RecordEquality_TwoIdenticalPolicies_AreEqual()
+    {
+        // Arrange
+        var first = new RetryPolicy(3, TimeSpan.FromSeconds(2), TimeSpan.FromMinutes(1));
+        var second = new RetryPolicy(3, TimeSpan.FromSeconds(2), TimeSpan.FromMinutes(1));
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+}


### PR DESCRIPTION
## Summary
Defines IBackgroundJobScheduler port in new Compendium.Abstractions.Jobs assembly. Unblocks compendium-adapter-hangfire / temporal per ADR-0006.

## Surface
- IBackgroundJobScheduler (Enqueue / Schedule / Recur / Cancel)
- JobOptions record (tenant-aware, retry, priority)
- JobPriority enum, JobsErrors factories

## Coverage >= 90 % line.

## Test plan
- [x] dotnet build green
- [x] dotnet test green
- [x] Coverage >= 90 %
- [ ] CI green