### PR TITLE
feat(abstractions/realtime): define IRealtimeChannel port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -157,6 +157,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Job
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Jobs.Tests", "tests\Unit\Compendium.Abstractions.Jobs.Tests\Compendium.Abstractions.Jobs.Tests.csproj", "{D93B7204-8B08-4B10-B925-3043EE24907C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Realtime", "src\Abstractions\Compendium.Abstractions.Realtime\Compendium.Abstractions.Realtime.csproj", "{EADB57C8-FB25-4250-ACB7-AD2DB09428B3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Realtime.Tests", "tests\Unit\Compendium.Abstractions.Realtime.Tests\Compendium.Abstractions.Realtime.Tests.csproj", "{C4F5F335-9884-4321-BC80-59BE20552A69}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -406,6 +410,14 @@ Global
 		{D93B7204-8B08-4B10-B925-3043EE24907C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D93B7204-8B08-4B10-B925-3043EE24907C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D93B7204-8B08-4B10-B925-3043EE24907C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EADB57C8-FB25-4250-ACB7-AD2DB09428B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EADB57C8-FB25-4250-ACB7-AD2DB09428B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EADB57C8-FB25-4250-ACB7-AD2DB09428B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EADB57C8-FB25-4250-ACB7-AD2DB09428B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4F5F335-9884-4321-BC80-59BE20552A69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4F5F335-9884-4321-BC80-59BE20552A69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4F5F335-9884-4321-BC80-59BE20552A69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4F5F335-9884-4321-BC80-59BE20552A69}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -480,5 +492,7 @@ Global
 		{C499B149-30E7-4631-AC74-B233DE6EDE06} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{5D6D8364-AC8D-41E5-9AE6-E8791168D92C} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
 		{D93B7204-8B08-4B10-B925-3043EE24907C} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{EADB57C8-FB25-4250-ACB7-AD2DB09428B3} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
+		{C4F5F335-9884-4321-BC80-59BE20552A69} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Realtime/Compendium.Abstractions.Realtime.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Realtime/Compendium.Abstractions.Realtime.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Realtime</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Realtime</RootNamespace>
+    <PackageId>Compendium.Abstractions.Realtime</PackageId>
+    <Description>Realtime channel abstractions for Compendium Framework: IRealtimeChannel. Provider-agnostic port for realtime messaging, subscriber authorization, and presence (Pusher, Ably, SignalR, etc.).</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Realtime.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Realtime/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Realtime/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.Realtime/IRealtimeChannel.cs
+++ b/src/Abstractions/Compendium.Abstractions.Realtime/IRealtimeChannel.cs
@@ -1,0 +1,56 @@
+// -----------------------------------------------------------------------
+// <copyright file="IRealtimeChannel.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Realtime.Models;
+
+namespace Compendium.Abstractions.Realtime;
+
+/// <summary>
+/// Provider-agnostic realtime channel port. Implementations (Pusher, Ably, SignalR, …)
+/// adapt this interface to their transport. Channel names MUST follow the tenant-prefixed
+/// convention <c>{tenantId}:{scope}</c> so authorization can be enforced uniformly.
+/// </summary>
+public interface IRealtimeChannel
+{
+    /// <summary>
+    /// Publishes <paramref name="payload"/> as <paramref name="eventName"/> on
+    /// <paramref name="channel"/>.
+    /// </summary>
+    /// <param name="channel">Tenant-prefixed channel name (<c>{tenantId}:{scope}</c>).</param>
+    /// <param name="eventName">The event name to publish under.</param>
+    /// <param name="payload">The payload object; serialization is adapter-defined.</param>
+    /// <param name="opts">Publish options including tenant id, ttl, and headers.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="Result"/> indicating success or a typed realtime error.</returns>
+    Task<Result> PublishAsync(
+        string channel,
+        string eventName,
+        object payload,
+        PublishOptions opts,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Authorizes <paramref name="subscriber"/> to subscribe to <paramref name="channel"/>.
+    /// Implementations must reject when the subscriber's tenant does not match the channel prefix.
+    /// </summary>
+    /// <param name="subscriber">The subscriber requesting access.</param>
+    /// <param name="channel">Tenant-prefixed channel name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<Result> AuthorizeSubscriberAsync(
+        SubscriberContext subscriber,
+        string channel,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Returns the current presence roster for <paramref name="channel"/>.
+    /// </summary>
+    /// <param name="channel">Tenant-prefixed presence channel name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<Result<IReadOnlyList<PresenceMember>>> GetPresenceAsync(
+        string channel,
+        CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Realtime/Models/PresenceMember.cs
+++ b/src/Abstractions/Compendium.Abstractions.Realtime/Models/PresenceMember.cs
@@ -1,0 +1,17 @@
+// -----------------------------------------------------------------------
+// <copyright file="PresenceMember.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Realtime.Models;
+
+/// <summary>
+/// A member currently present on a realtime presence channel.
+/// </summary>
+/// <param name="Id">The provider-stable member identifier.</param>
+/// <param name="Info">Arbitrary provider-supplied presence info for the member.</param>
+public sealed record PresenceMember(
+    string Id,
+    IReadOnlyDictionary<string, object> Info);

--- a/src/Abstractions/Compendium.Abstractions.Realtime/Models/PublishOptions.cs
+++ b/src/Abstractions/Compendium.Abstractions.Realtime/Models/PublishOptions.cs
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------
+// <copyright file="PublishOptions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Realtime.Models;
+
+/// <summary>
+/// Options for publishing a realtime message. <see cref="TenantId"/> is required so adapters
+/// can enforce the tenant-prefixed channel naming convention (<c>{tenantId}:{scope}</c>).
+/// </summary>
+/// <param name="TenantId">The tenant the message is being published on behalf of.</param>
+/// <param name="Ttl">Optional time-to-live for transient messages.</param>
+/// <param name="Headers">Optional opaque headers forwarded to the provider.</param>
+public sealed record PublishOptions(
+    string TenantId,
+    TimeSpan? Ttl = null,
+    IReadOnlyDictionary<string, string>? Headers = null);

--- a/src/Abstractions/Compendium.Abstractions.Realtime/Models/SubscriberContext.cs
+++ b/src/Abstractions/Compendium.Abstractions.Realtime/Models/SubscriberContext.cs
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------
+// <copyright file="SubscriberContext.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Realtime.Models;
+
+/// <summary>
+/// Context describing a subscriber attempting to join a realtime channel.
+/// Adapters use this to authorize the subscription and bind presence metadata.
+/// </summary>
+/// <param name="UserId">The subscriber's user identifier.</param>
+/// <param name="TenantId">The subscriber's tenant; must match the channel prefix.</param>
+/// <param name="Info">Optional presence info to attach for presence channels.</param>
+public sealed record SubscriberContext(
+    string UserId,
+    string TenantId,
+    IReadOnlyDictionary<string, object>? Info = null);

--- a/src/Abstractions/Compendium.Abstractions.Realtime/RealtimeErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Realtime/RealtimeErrors.cs
@@ -1,0 +1,56 @@
+// -----------------------------------------------------------------------
+// <copyright file="RealtimeErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Realtime;
+
+/// <summary>
+/// Provides standardized error definitions for realtime channel operations.
+/// </summary>
+public static class RealtimeErrors
+{
+    /// <summary>
+    /// Gets the error code prefix for realtime errors.
+    /// </summary>
+    public const string Prefix = "Realtime";
+
+    /// <summary>
+    /// The subscriber is not authorized for the requested channel
+    /// (typically a tenant mismatch against the <c>{tenantId}:{scope}</c> prefix).
+    /// </summary>
+    public static Error ChannelNotAuthorized(string channel) =>
+        Error.Failure(
+            $"{Prefix}.ChannelNotAuthorized",
+            $"Subscriber is not authorized for channel '{channel}'.");
+
+    /// <summary>
+    /// The payload exceeds the provider's per-message size limit.
+    /// </summary>
+    public static Error MessageTooLarge(int sizeBytes, int maximumBytes) =>
+        Error.Validation(
+            $"{Prefix}.MessageTooLarge",
+            $"Message size {sizeBytes} bytes exceeds maximum of {maximumBytes} bytes.");
+
+    /// <summary>
+    /// The realtime provider is unreachable.
+    /// </summary>
+    public static Error ProviderUnreachable(string provider, string? reason = null) =>
+        Error.Failure(
+            $"{Prefix}.ProviderUnreachable",
+            reason is null
+                ? $"Realtime provider '{provider}' is unreachable."
+                : $"Realtime provider '{provider}' is unreachable: {reason}");
+
+    /// <summary>
+    /// The publish request was rejected for exceeding the rate limit.
+    /// </summary>
+    public static Error RateLimited(TimeSpan? retryAfter = null) =>
+        Error.Failure(
+            $"{Prefix}.RateLimited",
+            retryAfter.HasValue
+                ? $"Rate limit exceeded. Retry after {retryAfter.Value.TotalSeconds} seconds."
+                : "Rate limit exceeded. Please try again later.");
+}

--- a/tests/Unit/Compendium.Abstractions.Realtime.Tests/Compendium.Abstractions.Realtime.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Realtime.Tests/Compendium.Abstractions.Realtime.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Realtime.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Realtime.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Realtime\Compendium.Abstractions.Realtime.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Realtime.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Realtime.Tests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using Xunit;
+global using FluentAssertions;
+global using NSubstitute;
+global using Compendium.Abstractions.Realtime;
+global using Compendium.Abstractions.Realtime.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Realtime.Tests/Models/PresenceMemberTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Realtime.Tests/Models/PresenceMemberTests.cs
@@ -1,0 +1,66 @@
+// -----------------------------------------------------------------------
+// <copyright file="PresenceMemberTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Realtime.Tests.Models;
+
+public class PresenceMemberTests
+{
+    [Fact]
+    public void Ctor_AssignsIdAndInfo()
+    {
+        // Arrange
+        var info = new Dictionary<string, object> { ["status"] = "online" };
+
+        // Act
+        var member = new PresenceMember("user-1", info);
+
+        // Assert
+        member.Id.Should().Be("user-1");
+        member.Info.Should().BeSameAs(info);
+    }
+
+    [Fact]
+    public void Equality_SameIdAndInfo_AreEqual()
+    {
+        // Arrange
+        var info = new Dictionary<string, object> { ["k"] = 1 };
+        var a = new PresenceMember("user-1", info);
+        var b = new PresenceMember("user-1", info);
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_DifferentId_AreNotEqual()
+    {
+        // Arrange
+        var info = new Dictionary<string, object>();
+        var a = new PresenceMember("user-1", info);
+        var b = new PresenceMember("user-2", info);
+
+        // Act / Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void With_RebindsIdImmutably()
+    {
+        // Arrange
+        var info = new Dictionary<string, object>();
+        var original = new PresenceMember("user-1", info);
+
+        // Act
+        var rebound = original with { Id = "user-2" };
+
+        // Assert
+        original.Id.Should().Be("user-1");
+        rebound.Id.Should().Be("user-2");
+        rebound.Info.Should().BeSameAs(info);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Realtime.Tests/Models/PublishOptionsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Realtime.Tests/Models/PublishOptionsTests.cs
@@ -1,0 +1,77 @@
+// -----------------------------------------------------------------------
+// <copyright file="PublishOptionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Realtime.Tests.Models;
+
+public class PublishOptionsTests
+{
+    [Fact]
+    public void Ctor_WithTenantIdOnly_DefaultsTtlAndHeadersToNull()
+    {
+        // Arrange / Act
+        var opts = new PublishOptions("tenant-1");
+
+        // Assert
+        opts.TenantId.Should().Be("tenant-1");
+        opts.Ttl.Should().BeNull();
+        opts.Headers.Should().BeNull();
+    }
+
+    [Fact]
+    public void Ctor_WithAllFields_AssignsAllValues()
+    {
+        // Arrange
+        var headers = new Dictionary<string, string> { ["x-source"] = "tests" };
+        var ttl = TimeSpan.FromMinutes(5);
+
+        // Act
+        var opts = new PublishOptions("tenant-1", ttl, headers);
+
+        // Assert
+        opts.TenantId.Should().Be("tenant-1");
+        opts.Ttl.Should().Be(ttl);
+        opts.Headers.Should().BeSameAs(headers);
+    }
+
+    [Fact]
+    public void Equality_SameValues_AreEqual()
+    {
+        // Arrange
+        var a = new PublishOptions("tenant-1", TimeSpan.FromSeconds(30));
+        var b = new PublishOptions("tenant-1", TimeSpan.FromSeconds(30));
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_DifferentTenantId_AreNotEqual()
+    {
+        // Arrange
+        var a = new PublishOptions("tenant-1");
+        var b = new PublishOptions("tenant-2");
+
+        // Act / Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void With_ChangesTenantIdWithoutMutatingOriginal()
+    {
+        // Arrange
+        var original = new PublishOptions("tenant-1", TimeSpan.FromSeconds(10));
+
+        // Act
+        var modified = original with { TenantId = "tenant-2" };
+
+        // Assert
+        original.TenantId.Should().Be("tenant-1");
+        modified.TenantId.Should().Be("tenant-2");
+        modified.Ttl.Should().Be(TimeSpan.FromSeconds(10));
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Realtime.Tests/Models/SubscriberContextTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Realtime.Tests/Models/SubscriberContextTests.cs
@@ -1,0 +1,74 @@
+// -----------------------------------------------------------------------
+// <copyright file="SubscriberContextTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Realtime.Tests.Models;
+
+public class SubscriberContextTests
+{
+    [Fact]
+    public void Ctor_WithUserAndTenant_DefaultsInfoToNull()
+    {
+        // Arrange / Act
+        var ctx = new SubscriberContext("user-1", "tenant-1");
+
+        // Assert
+        ctx.UserId.Should().Be("user-1");
+        ctx.TenantId.Should().Be("tenant-1");
+        ctx.Info.Should().BeNull();
+    }
+
+    [Fact]
+    public void Ctor_WithInfo_AssignsInfoReference()
+    {
+        // Arrange
+        var info = new Dictionary<string, object> { ["name"] = "Ada" };
+
+        // Act
+        var ctx = new SubscriberContext("user-1", "tenant-1", info);
+
+        // Assert
+        ctx.Info.Should().BeSameAs(info);
+        ctx.Info!["name"].Should().Be("Ada");
+    }
+
+    [Fact]
+    public void Equality_SameValues_AreEqual()
+    {
+        // Arrange
+        var a = new SubscriberContext("user-1", "tenant-1");
+        var b = new SubscriberContext("user-1", "tenant-1");
+
+        // Act / Assert
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void Equality_DifferentUserId_AreNotEqual()
+    {
+        // Arrange
+        var a = new SubscriberContext("user-1", "tenant-1");
+        var b = new SubscriberContext("user-2", "tenant-1");
+
+        // Act / Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void With_RebindsTenantIdImmutably()
+    {
+        // Arrange
+        var original = new SubscriberContext("user-1", "tenant-1");
+
+        // Act
+        var rebound = original with { TenantId = "tenant-2" };
+
+        // Assert
+        original.TenantId.Should().Be("tenant-1");
+        rebound.TenantId.Should().Be("tenant-2");
+        rebound.UserId.Should().Be("user-1");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Realtime.Tests/RealtimeErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Realtime.Tests/RealtimeErrorsTests.cs
@@ -1,0 +1,94 @@
+// -----------------------------------------------------------------------
+// <copyright file="RealtimeErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Realtime.Tests;
+
+public class RealtimeErrorsTests
+{
+    [Fact]
+    public void Prefix_IsRealtime()
+    {
+        // Arrange / Act / Assert
+        RealtimeErrors.Prefix.Should().Be("Realtime");
+    }
+
+    [Fact]
+    public void ChannelNotAuthorized_ReturnsFailureWithChannelName()
+    {
+        // Act
+        var error = RealtimeErrors.ChannelNotAuthorized("tenant-1:orders");
+
+        // Assert
+        error.Code.Should().Be("Realtime.ChannelNotAuthorized");
+        error.Message.Should().Contain("tenant-1:orders");
+        error.Type.Should().Be(ErrorType.Failure);
+    }
+
+    [Fact]
+    public void MessageTooLarge_ReturnsValidationErrorWithSizes()
+    {
+        // Act
+        var error = RealtimeErrors.MessageTooLarge(20_000, 10_240);
+
+        // Assert
+        error.Code.Should().Be("Realtime.MessageTooLarge");
+        error.Message.Should().Contain("20000");
+        error.Message.Should().Contain("10240");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
+
+    [Fact]
+    public void ProviderUnreachable_WithoutReason_ReturnsGenericMessage()
+    {
+        // Act
+        var error = RealtimeErrors.ProviderUnreachable("pusher");
+
+        // Assert
+        error.Code.Should().Be("Realtime.ProviderUnreachable");
+        error.Message.Should().Contain("pusher");
+        error.Message.Should().EndWith("is unreachable.");
+        error.Type.Should().Be(ErrorType.Failure);
+    }
+
+    [Fact]
+    public void ProviderUnreachable_WithReason_IncludesReason()
+    {
+        // Act
+        var error = RealtimeErrors.ProviderUnreachable("ably", "DNS failure");
+
+        // Assert
+        error.Code.Should().Be("Realtime.ProviderUnreachable");
+        error.Message.Should().Contain("ably");
+        error.Message.Should().Contain("DNS failure");
+    }
+
+    [Fact]
+    public void RateLimited_WithoutRetryAfter_ReturnsGenericMessage()
+    {
+        // Act
+        var error = RealtimeErrors.RateLimited();
+
+        // Assert
+        error.Code.Should().Be("Realtime.RateLimited");
+        error.Message.Should().Contain("Rate limit exceeded");
+        error.Type.Should().Be(ErrorType.Failure);
+    }
+
+    [Fact]
+    public void RateLimited_WithRetryAfter_IncludesSeconds()
+    {
+        // Arrange
+        var retry = TimeSpan.FromSeconds(45);
+
+        // Act
+        var error = RealtimeErrors.RateLimited(retry);
+
+        // Assert
+        error.Code.Should().Be("Realtime.RateLimited");
+        error.Message.Should().Contain("45");
+    }
+}


### PR DESCRIPTION
## Summary
Defines IRealtimeChannel port in new Compendium.Abstractions.Realtime assembly. Unblocks compendium-adapter-pusher / ably per ADR-0006.

## Surface
- IRealtimeChannel (Publish / AuthorizeSubscriber / GetPresence)
- PublishOptions, SubscriberContext, PresenceMember records
- RealtimeErrors factories (ChannelNotAuthorized, MessageTooLarge, ProviderUnreachable, RateLimited)

Tenant scoping mandatory via channel-naming convention (`{tenantId}:{scope}`).

## Coverage >= 90 % line.
Per-class line-rate = 1.0 on all four production types (21 tests, 0 failures).

## Test plan
- [x] dotnet build green
- [x] dotnet test green
- [x] Coverage >= 90 %
- [ ] CI green