### PR TITLE
feat(abstractions/documents): define IDocumentParser port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -161,6 +161,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Rea
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Realtime.Tests", "tests\Unit\Compendium.Abstractions.Realtime.Tests\Compendium.Abstractions.Realtime.Tests.csproj", "{C4F5F335-9884-4321-BC80-59BE20552A69}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Documents", "src\Abstractions\Compendium.Abstractions.Documents\Compendium.Abstractions.Documents.csproj", "{8A431F46-2962-4DFA-BF63-79DD4AF7BB52}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Abstractions", "Abstractions", "{0048DED2-AA2D-4CA2-A7CF-088F26F6D7A7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Documents.Tests", "tests\Unit\Compendium.Abstractions.Documents.Tests\Compendium.Abstractions.Documents.Tests.csproj", "{FB420FBA-5109-4AEC-B006-6C1F12608F5B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -418,6 +424,14 @@ Global
 		{C4F5F335-9884-4321-BC80-59BE20552A69}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4F5F335-9884-4321-BC80-59BE20552A69}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4F5F335-9884-4321-BC80-59BE20552A69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A431F46-2962-4DFA-BF63-79DD4AF7BB52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A431F46-2962-4DFA-BF63-79DD4AF7BB52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A431F46-2962-4DFA-BF63-79DD4AF7BB52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A431F46-2962-4DFA-BF63-79DD4AF7BB52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB420FBA-5109-4AEC-B006-6C1F12608F5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB420FBA-5109-4AEC-B006-6C1F12608F5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB420FBA-5109-4AEC-B006-6C1F12608F5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB420FBA-5109-4AEC-B006-6C1F12608F5B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -494,5 +508,8 @@ Global
 		{D93B7204-8B08-4B10-B925-3043EE24907C} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{EADB57C8-FB25-4250-ACB7-AD2DB09428B3} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
 		{C4F5F335-9884-4321-BC80-59BE20552A69} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{8A431F46-2962-4DFA-BF63-79DD4AF7BB52} = {25C6CE4F-1EE7-4448-AC41-F3C3584AF7BA}
+		{0048DED2-AA2D-4CA2-A7CF-088F26F6D7A7} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{FB420FBA-5109-4AEC-B006-6C1F12608F5B} = {0048DED2-AA2D-4CA2-A7CF-088F26F6D7A7}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Documents/Compendium.Abstractions.Documents.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Documents/Compendium.Abstractions.Documents.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Documents</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Documents</RootNamespace>
+    <PackageId>Compendium.Abstractions.Documents</PackageId>
+    <Description>Document parsing abstractions for Compendium Framework: IDocumentParser. Provider-agnostic interface for OCR and structured document extraction (receipts, invoices, IDs).</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Documents.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Documents/DocumentsErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Documents/DocumentsErrors.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------
+// <copyright file="DocumentsErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents;
+
+/// <summary>
+/// Provides standardized error definitions for document parsing operations.
+/// </summary>
+public static class DocumentsErrors
+{
+    /// <summary>
+    /// Gets the error code prefix for document errors.
+    /// </summary>
+    public const string Prefix = "Documents";
+
+    /// <summary>
+    /// The supplied MIME type / format is not supported by the parser.
+    /// </summary>
+    public static Error UnsupportedFormat(string mimeType) =>
+        Error.Validation(
+            $"{Prefix}.UnsupportedFormat",
+            $"Document MIME type '{mimeType}' is not supported.");
+
+    /// <summary>
+    /// The document exceeds the provider's size limit.
+    /// </summary>
+    public static Error DocumentTooLarge(long sizeBytes, long maxBytes) =>
+        Error.Validation(
+            $"{Prefix}.DocumentTooLarge",
+            $"Document size {sizeBytes} bytes exceeds the maximum of {maxBytes} bytes.");
+
+    /// <summary>
+    /// The document parsing provider is unreachable (network / DNS / 5xx).
+    /// </summary>
+    public static Error ProviderUnreachable(string provider, string? reason = null) =>
+        Error.Failure(
+            $"{Prefix}.ProviderUnreachable",
+            reason != null
+                ? $"Document parsing provider '{provider}' is unreachable: {reason}."
+                : $"Document parsing provider '{provider}' is unreachable.");
+
+    /// <summary>
+    /// The provider rate-limited the request.
+    /// </summary>
+    public static Error RateLimited(TimeSpan? retryAfter = null) =>
+        Error.Failure(
+            $"{Prefix}.RateLimited",
+            retryAfter.HasValue
+                ? $"Document parsing rate limit exceeded. Retry after {retryAfter.Value.TotalSeconds} seconds."
+                : "Document parsing rate limit exceeded. Please try again later.");
+}

--- a/src/Abstractions/Compendium.Abstractions.Documents/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Documents/GlobalUsings.cs
@@ -1,0 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;
+global using System.Text.Json.Serialization;

--- a/src/Abstractions/Compendium.Abstractions.Documents/IDocumentParser.cs
+++ b/src/Abstractions/Compendium.Abstractions.Documents/IDocumentParser.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------
+// <copyright file="IDocumentParser.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Documents.Models;
+
+namespace Compendium.Abstractions.Documents;
+
+/// <summary>
+/// Provides document parsing operations including OCR and structured extraction.
+/// This interface is provider-agnostic and can be implemented by various providers
+/// such as Azure Document Intelligence, AWS Textract, Google Document AI, or local engines.
+/// </summary>
+public interface IDocumentParser
+{
+    /// <summary>
+    /// Parses the supplied document and returns extracted text, pages, tables and key/value fields.
+    /// </summary>
+    /// <param name="doc">The document input (binary stream + MIME type).</param>
+    /// <param name="opts">The parsing options (target model, language, OCR-only mode).</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A <see cref="Result{T}"/> containing the <see cref="ParsedDocument"/> on success or an <see cref="Error"/> on failure.</returns>
+    Task<Result<ParsedDocument>> ParseAsync(DocumentInput doc, ParseOptions opts, CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Documents/Models/DocumentInput.cs
+++ b/src/Abstractions/Compendium.Abstractions.Documents/Models/DocumentInput.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------
+// <copyright file="DocumentInput.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Models;
+
+/// <summary>
+/// Represents the binary content of a document submitted for parsing.
+/// </summary>
+/// <param name="Stream">The document binary stream. Caller retains ownership and is responsible for disposal.</param>
+/// <param name="MimeType">The MIME type of the document (e.g. <c>application/pdf</c>, <c>image/png</c>).</param>
+public sealed record DocumentInput(Stream Stream, string MimeType);

--- a/src/Abstractions/Compendium.Abstractions.Documents/Models/DocumentModel.cs
+++ b/src/Abstractions/Compendium.Abstractions.Documents/Models/DocumentModel.cs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------
+// <copyright file="DocumentModel.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Models;
+
+/// <summary>
+/// Identifies the structured document model the parser should apply.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum DocumentModel
+{
+    /// <summary>
+    /// Generic OCR / layout extraction with no domain-specific schema.
+    /// </summary>
+    Generic,
+
+    /// <summary>
+    /// Receipt model — line items, totals, taxes, merchant.
+    /// </summary>
+    Receipt,
+
+    /// <summary>
+    /// Invoice model — billing/shipping addresses, line items, totals, due date.
+    /// </summary>
+    Invoice,
+
+    /// <summary>
+    /// Identification document model — passport, driver's licence, national ID.
+    /// </summary>
+    IdDocument,
+
+    /// <summary>
+    /// Caller-defined custom model identified out-of-band (provider-specific id).
+    /// </summary>
+    Custom,
+}

--- a/src/Abstractions/Compendium.Abstractions.Documents/Models/ParseOptions.cs
+++ b/src/Abstractions/Compendium.Abstractions.Documents/Models/ParseOptions.cs
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParseOptions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Models;
+
+/// <summary>
+/// Options controlling how a document is parsed.
+/// </summary>
+/// <param name="Model">The structured document model to apply.</param>
+/// <param name="Language">Optional BCP-47 language hint (e.g. <c>en</c>, <c>fr-CA</c>); <c>null</c> = auto-detect.</param>
+/// <param name="OcrOnly">When <c>true</c>, only raw OCR text is requested; structured extraction is skipped.</param>
+public sealed record ParseOptions(DocumentModel Model, string? Language = null, bool OcrOnly = false);

--- a/src/Abstractions/Compendium.Abstractions.Documents/Models/ParsedDocument.cs
+++ b/src/Abstractions/Compendium.Abstractions.Documents/Models/ParsedDocument.cs
@@ -1,0 +1,23 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParsedDocument.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Models;
+
+/// <summary>
+/// Represents the full result of parsing a document.
+/// </summary>
+/// <param name="RawText">Concatenated raw text across all pages.</param>
+/// <param name="Pages">Per-page parsed content.</param>
+/// <param name="Tables">Tables detected across the document.</param>
+/// <param name="KeyValues">Structured key/value fields extracted by the model.</param>
+/// <param name="Confidence">Aggregate confidence in the range [0.0, 1.0].</param>
+public sealed record ParsedDocument(
+    string RawText,
+    IReadOnlyList<ParsedPage> Pages,
+    IReadOnlyList<ParsedTable> Tables,
+    IReadOnlyDictionary<string, ParsedField> KeyValues,
+    double Confidence);

--- a/src/Abstractions/Compendium.Abstractions.Documents/Models/ParsedField.cs
+++ b/src/Abstractions/Compendium.Abstractions.Documents/Models/ParsedField.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParsedField.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Models;
+
+/// <summary>
+/// Represents a single key/value field extracted from a document.
+/// </summary>
+/// <param name="Value">The extracted field value (raw string — caller may parse to typed value).</param>
+/// <param name="Confidence">Provider-reported confidence in the range [0.0, 1.0].</param>
+public sealed record ParsedField(string Value, double Confidence);

--- a/src/Abstractions/Compendium.Abstractions.Documents/Models/ParsedPage.cs
+++ b/src/Abstractions/Compendium.Abstractions.Documents/Models/ParsedPage.cs
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParsedPage.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Models;
+
+/// <summary>
+/// Represents a single parsed page of a document.
+/// </summary>
+/// <param name="PageNumber">1-based page index.</param>
+/// <param name="Text">Raw text extracted from the page.</param>
+/// <param name="Confidence">Provider-reported confidence in the range [0.0, 1.0].</param>
+public sealed record ParsedPage(int PageNumber, string Text, double Confidence);

--- a/src/Abstractions/Compendium.Abstractions.Documents/Models/ParsedTable.cs
+++ b/src/Abstractions/Compendium.Abstractions.Documents/Models/ParsedTable.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParsedTable.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Models;
+
+/// <summary>
+/// Represents a tabular region extracted from a document.
+/// </summary>
+/// <param name="PageNumber">1-based page index where the table was found.</param>
+/// <param name="Rows">Row-major cell content; outer list = rows, inner list = cells in the row.</param>
+public sealed record ParsedTable(int PageNumber, IReadOnlyList<IReadOnlyList<string>> Rows);

--- a/tests/Unit/Compendium.Abstractions.Documents.Tests/Compendium.Abstractions.Documents.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Documents.Tests/Compendium.Abstractions.Documents.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Documents.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Documents.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Documents\Compendium.Abstractions.Documents.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Documents.Tests/DocumentsErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Documents.Tests/DocumentsErrorsTests.cs
@@ -1,0 +1,94 @@
+// -----------------------------------------------------------------------
+// <copyright file="DocumentsErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Tests;
+
+public sealed class DocumentsErrorsTests
+{
+    [Fact]
+    public void Prefix_IsDocuments()
+    {
+        // Assert
+        DocumentsErrors.Prefix.Should().Be("Documents");
+    }
+
+    [Fact]
+    public void UnsupportedFormat_ShouldReturnValidationErrorWithMime()
+    {
+        // Act
+        var error = DocumentsErrors.UnsupportedFormat("application/x-bogus");
+
+        // Assert
+        error.Code.Should().Be("Documents.UnsupportedFormat");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain("application/x-bogus");
+    }
+
+    [Fact]
+    public void DocumentTooLarge_ShouldReturnValidationErrorWithSizes()
+    {
+        // Act
+        var error = DocumentsErrors.DocumentTooLarge(20_000_000, 10_485_760);
+
+        // Assert
+        error.Code.Should().Be("Documents.DocumentTooLarge");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain("20000000");
+        error.Message.Should().Contain("10485760");
+    }
+
+    [Fact]
+    public void ProviderUnreachable_WithoutReason_ShouldUseGenericMessage()
+    {
+        // Act
+        var error = DocumentsErrors.ProviderUnreachable("azure-document-intelligence");
+
+        // Assert
+        error.Code.Should().Be("Documents.ProviderUnreachable");
+        error.Type.Should().Be(ErrorType.Failure);
+        error.Message.Should().Contain("azure-document-intelligence");
+        error.Message.Should().NotContain(":");
+    }
+
+    [Fact]
+    public void ProviderUnreachable_WithReason_ShouldIncludeReason()
+    {
+        // Act
+        var error = DocumentsErrors.ProviderUnreachable("aws-textract", "DNS lookup failed");
+
+        // Assert
+        error.Code.Should().Be("Documents.ProviderUnreachable");
+        error.Message.Should().Contain("aws-textract");
+        error.Message.Should().Contain("DNS lookup failed");
+    }
+
+    [Fact]
+    public void RateLimited_WithoutRetryAfter_ShouldReturnGenericMessage()
+    {
+        // Act
+        var error = DocumentsErrors.RateLimited();
+
+        // Assert
+        error.Code.Should().Be("Documents.RateLimited");
+        error.Type.Should().Be(ErrorType.Failure);
+        error.Message.Should().Contain("rate limit");
+    }
+
+    [Fact]
+    public void RateLimited_WithRetryAfter_ShouldIncludeSeconds()
+    {
+        // Arrange
+        var retryAfter = TimeSpan.FromSeconds(45);
+
+        // Act
+        var error = DocumentsErrors.RateLimited(retryAfter);
+
+        // Assert
+        error.Code.Should().Be("Documents.RateLimited");
+        error.Message.Should().Contain("45");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Documents.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Documents.Tests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using Xunit;
+global using FluentAssertions;
+global using NSubstitute;
+global using Compendium.Abstractions.Documents;
+global using Compendium.Abstractions.Documents.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Documents.Tests/IDocumentParserTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Documents.Tests/IDocumentParserTests.cs
@@ -1,0 +1,59 @@
+// -----------------------------------------------------------------------
+// <copyright file="IDocumentParserTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Tests;
+
+public sealed class IDocumentParserTests
+{
+    [Fact]
+    public async Task ParseAsync_WhenSubstituteReturnsSuccess_PropagatesValue()
+    {
+        // Arrange
+        var parser = Substitute.For<IDocumentParser>();
+        using var stream = new MemoryStream();
+        var input = new DocumentInput(stream, "application/pdf");
+        var opts = new ParseOptions(DocumentModel.Receipt, "en");
+        var parsed = new ParsedDocument(
+            "raw",
+            Array.Empty<ParsedPage>(),
+            Array.Empty<ParsedTable>(),
+            new Dictionary<string, ParsedField>(),
+            0.9);
+        parser
+            .ParseAsync(input, opts, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success(parsed)));
+
+        // Act
+        var result = await parser.ParseAsync(input, opts, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeSameAs(parsed);
+        await parser.Received(1).ParseAsync(input, opts, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ParseAsync_WhenSubstituteReturnsFailure_PropagatesError()
+    {
+        // Arrange
+        var parser = Substitute.For<IDocumentParser>();
+        using var stream = new MemoryStream();
+        var input = new DocumentInput(stream, "application/x-bogus");
+        var opts = new ParseOptions(DocumentModel.Generic);
+        var error = DocumentsErrors.UnsupportedFormat("application/x-bogus");
+        parser
+            .ParseAsync(input, opts, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Failure<ParsedDocument>(error)));
+
+        // Act
+        var result = await parser.ParseAsync(input, opts, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Documents.UnsupportedFormat");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/DocumentInputTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/DocumentInputTests.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------
+// <copyright file="DocumentInputTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Tests.Models;
+
+public sealed class DocumentInputTests
+{
+    [Fact]
+    public void DocumentInput_WithStreamAndMimeType_ExposesProperties()
+    {
+        // Arrange
+        using var stream = new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 });
+
+        // Act
+        var input = new DocumentInput(stream, "application/pdf");
+
+        // Assert
+        input.Stream.Should().BeSameAs(stream);
+        input.MimeType.Should().Be("application/pdf");
+    }
+
+    [Fact]
+    public void DocumentInput_WithSameValues_ShouldBeEqualByValue()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+
+        // Act
+        var a = new DocumentInput(stream, "image/png");
+        var b = new DocumentInput(stream, "image/png");
+
+        // Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void DocumentInput_WithDifferentMime_ShouldNotBeEqual()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+
+        // Act
+        var a = new DocumentInput(stream, "image/png");
+        var b = new DocumentInput(stream, "image/jpeg");
+
+        // Assert
+        a.Should().NotBe(b);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/DocumentModelTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/DocumentModelTests.cs
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="DocumentModelTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Text.Json;
+
+namespace Compendium.Abstractions.Documents.Tests.Models;
+
+public sealed class DocumentModelTests
+{
+    [Theory]
+    [InlineData(DocumentModel.Generic, "Generic")]
+    [InlineData(DocumentModel.Receipt, "Receipt")]
+    [InlineData(DocumentModel.Invoice, "Invoice")]
+    [InlineData(DocumentModel.IdDocument, "IdDocument")]
+    [InlineData(DocumentModel.Custom, "Custom")]
+    public void DocumentModel_DefinesExpectedMembers(DocumentModel value, string name)
+    {
+        // Act
+        var actual = value.ToString();
+
+        // Assert
+        actual.Should().Be(name);
+    }
+
+    [Fact]
+    public void DocumentModel_HasExactlyFiveMembers()
+    {
+        // Act
+        var members = Enum.GetValues<DocumentModel>();
+
+        // Assert
+        members.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public void DocumentModel_SerializesAsString()
+    {
+        // Act
+        var json = JsonSerializer.Serialize(DocumentModel.Invoice);
+
+        // Assert
+        json.Should().Be("\"Invoice\"");
+    }
+
+    [Fact]
+    public void DocumentModel_DeserializesFromString()
+    {
+        // Act
+        var value = JsonSerializer.Deserialize<DocumentModel>("\"Receipt\"");
+
+        // Assert
+        value.Should().Be(DocumentModel.Receipt);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/ParseOptionsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/ParseOptionsTests.cs
@@ -1,0 +1,51 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParseOptionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Tests.Models;
+
+public sealed class ParseOptionsTests
+{
+    [Fact]
+    public void ParseOptions_WithModelOnly_DefaultsLanguageNullAndOcrOnlyFalse()
+    {
+        // Act
+        var opts = new ParseOptions(DocumentModel.Generic);
+
+        // Assert
+        opts.Model.Should().Be(DocumentModel.Generic);
+        opts.Language.Should().BeNull();
+        opts.OcrOnly.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(DocumentModel.Receipt, "fr-CA", false)]
+    [InlineData(DocumentModel.Invoice, "en", true)]
+    [InlineData(DocumentModel.IdDocument, null, true)]
+    [InlineData(DocumentModel.Custom, "de", false)]
+    public void ParseOptions_WithAllProperties_ExposesValues(DocumentModel model, string? language, bool ocrOnly)
+    {
+        // Act
+        var opts = new ParseOptions(model, language, ocrOnly);
+
+        // Assert
+        opts.Model.Should().Be(model);
+        opts.Language.Should().Be(language);
+        opts.OcrOnly.Should().Be(ocrOnly);
+    }
+
+    [Fact]
+    public void ParseOptions_WithSameValues_ShouldBeEqualByValue()
+    {
+        // Act
+        var a = new ParseOptions(DocumentModel.Receipt, "en", true);
+        var b = new ParseOptions(DocumentModel.Receipt, "en", true);
+
+        // Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/ParsedDocumentTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/ParsedDocumentTests.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParsedDocumentTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Tests.Models;
+
+public sealed class ParsedDocumentTests
+{
+    [Fact]
+    public void ParsedDocument_ExposesAllSections()
+    {
+        // Arrange
+        var pages = new List<ParsedPage> { new(1, "page-1", 0.9) };
+        var tables = new List<ParsedTable> { new(1, new List<IReadOnlyList<string>> { new[] { "a" } }) };
+        var keyValues = new Dictionary<string, ParsedField> { ["Total"] = new("42.00", 0.99) };
+
+        // Act
+        var doc = new ParsedDocument("page-1", pages, tables, keyValues, 0.95);
+
+        // Assert
+        doc.RawText.Should().Be("page-1");
+        doc.Pages.Should().BeSameAs(pages);
+        doc.Tables.Should().BeSameAs(tables);
+        doc.KeyValues.Should().ContainKey("Total");
+        doc.KeyValues["Total"].Value.Should().Be("42.00");
+        doc.Confidence.Should().Be(0.95);
+    }
+
+    [Fact]
+    public void ParsedDocument_WithEmptyCollections_IsValid()
+    {
+        // Act
+        var doc = new ParsedDocument(
+            string.Empty,
+            Array.Empty<ParsedPage>(),
+            Array.Empty<ParsedTable>(),
+            new Dictionary<string, ParsedField>(),
+            0.0);
+
+        // Assert
+        doc.Pages.Should().BeEmpty();
+        doc.Tables.Should().BeEmpty();
+        doc.KeyValues.Should().BeEmpty();
+        doc.Confidence.Should().Be(0.0);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/ParsedFieldTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/ParsedFieldTests.cs
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParsedFieldTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Tests.Models;
+
+public sealed class ParsedFieldTests
+{
+    [Fact]
+    public void ParsedField_ExposesValueAndConfidence()
+    {
+        // Act
+        var field = new ParsedField("ACME Inc.", 0.87);
+
+        // Assert
+        field.Value.Should().Be("ACME Inc.");
+        field.Confidence.Should().Be(0.87);
+    }
+
+    [Fact]
+    public void ParsedField_WithSameValues_ShouldBeEqualByValue()
+    {
+        // Act
+        var a = new ParsedField("v", 1.0);
+        var b = new ParsedField("v", 1.0);
+
+        // Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/ParsedPageTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/ParsedPageTests.cs
@@ -1,0 +1,35 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParsedPageTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Tests.Models;
+
+public sealed class ParsedPageTests
+{
+    [Fact]
+    public void ParsedPage_ExposesAllProperties()
+    {
+        // Act
+        var page = new ParsedPage(2, "hello", 0.95);
+
+        // Assert
+        page.PageNumber.Should().Be(2);
+        page.Text.Should().Be("hello");
+        page.Confidence.Should().Be(0.95);
+    }
+
+    [Fact]
+    public void ParsedPage_WithSameValues_ShouldBeEqualByValue()
+    {
+        // Act
+        var a = new ParsedPage(1, "x", 0.5);
+        var b = new ParsedPage(1, "x", 0.5);
+
+        // Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/ParsedTableTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Documents.Tests/Models/ParsedTableTests.cs
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParsedTableTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Documents.Tests.Models;
+
+public sealed class ParsedTableTests
+{
+    [Fact]
+    public void ParsedTable_ExposesPageNumberAndRows()
+    {
+        // Arrange
+        var rows = new List<IReadOnlyList<string>>
+        {
+            new[] { "Item", "Qty", "Price" },
+            new[] { "Coffee", "2", "8.00" },
+        };
+
+        // Act
+        var table = new ParsedTable(3, rows);
+
+        // Assert
+        table.PageNumber.Should().Be(3);
+        table.Rows.Should().HaveCount(2);
+        table.Rows[1][0].Should().Be("Coffee");
+        table.Rows[1][2].Should().Be("8.00");
+    }
+
+    [Fact]
+    public void ParsedTable_WithSameReferenceRows_ShouldBeEqualByValue()
+    {
+        // Arrange
+        var rows = new List<IReadOnlyList<string>> { new[] { "a" } };
+
+        // Act
+        var a = new ParsedTable(1, rows);
+        var b = new ParsedTable(1, rows);
+
+        // Assert
+        a.Should().Be(b);
+    }
+}


### PR DESCRIPTION
## Summary
Defines `IDocumentParser` port (OCR + structured extraction) in new `Compendium.Abstractions.Documents` assembly. Unblocks `compendium-adapter-azure-document-intelligence` / `aws-textract` per ADR-0006.

## Surface
- `IDocumentParser` (`ParseAsync`)
- `DocumentInput`, `ParseOptions`, `ParsedDocument`, `ParsedPage`, `ParsedTable`, `ParsedField` records
- `DocumentModel` enum, `DocumentsErrors` factories (`UnsupportedFormat`, `DocumentTooLarge`, `ProviderUnreachable`, `RateLimited`)

## Coverage
Line: **100 %** | Branch: **100 %** (per cobertura on `Compendium.Abstractions.Documents`).

## Test plan
- [x] `dotnet build Compendium.sln -c Release` green
- [x] `dotnet test tests/Unit/Compendium.Abstractions.Documents.Tests -c Release` green (34/34 passed)
- [x] Coverage ≥ 90 %
- [ ] CI green