### PR TITLE
feat(abstractions/speech): define ISpeechToText port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -167,6 +167,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Abstractions", "Abstraction
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Documents.Tests", "tests\Unit\Compendium.Abstractions.Documents.Tests\Compendium.Abstractions.Documents.Tests.csproj", "{FB420FBA-5109-4AEC-B006-6C1F12608F5B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Speech", "src\Abstractions\Compendium.Abstractions.Speech\Compendium.Abstractions.Speech.csproj", "{A19F2183-2233-4E83-8E81-600F1C5DE505}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Speech.Tests", "tests\Unit\Compendium.Abstractions.Speech.Tests\Compendium.Abstractions.Speech.Tests.csproj", "{57A7F68F-6CCA-4544-8AEE-D66D90DE5197}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -432,6 +436,14 @@ Global
 		{FB420FBA-5109-4AEC-B006-6C1F12608F5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FB420FBA-5109-4AEC-B006-6C1F12608F5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FB420FBA-5109-4AEC-B006-6C1F12608F5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A19F2183-2233-4E83-8E81-600F1C5DE505}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A19F2183-2233-4E83-8E81-600F1C5DE505}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A19F2183-2233-4E83-8E81-600F1C5DE505}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A19F2183-2233-4E83-8E81-600F1C5DE505}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57A7F68F-6CCA-4544-8AEE-D66D90DE5197}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57A7F68F-6CCA-4544-8AEE-D66D90DE5197}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57A7F68F-6CCA-4544-8AEE-D66D90DE5197}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57A7F68F-6CCA-4544-8AEE-D66D90DE5197}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -511,5 +523,7 @@ Global
 		{8A431F46-2962-4DFA-BF63-79DD4AF7BB52} = {25C6CE4F-1EE7-4448-AC41-F3C3584AF7BA}
 		{0048DED2-AA2D-4CA2-A7CF-088F26F6D7A7} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{FB420FBA-5109-4AEC-B006-6C1F12608F5B} = {0048DED2-AA2D-4CA2-A7CF-088F26F6D7A7}
+		{A19F2183-2233-4E83-8E81-600F1C5DE505} = {25C6CE4F-1EE7-4448-AC41-F3C3584AF7BA}
+		{57A7F68F-6CCA-4544-8AEE-D66D90DE5197} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Speech/Compendium.Abstractions.Speech.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Speech/Compendium.Abstractions.Speech.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Speech</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Speech</RootNamespace>
+    <PackageId>Compendium.Abstractions.Speech</PackageId>
+    <Description>Speech abstractions for Compendium Framework: ISpeechToText. Provider-agnostic interfaces for speech-to-text transcription (batch + streaming) across Whisper, Deepgram, and similar engines.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Speech.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Speech/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.Speech/ISpeechToText.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/ISpeechToText.cs
@@ -1,0 +1,36 @@
+// -----------------------------------------------------------------------
+// <copyright file="ISpeechToText.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Speech.Models;
+
+namespace Compendium.Abstractions.Speech;
+
+/// <summary>
+/// Provides speech-to-text transcription operations.
+/// This interface is provider-agnostic and can be implemented by adapters targeting
+/// Whisper, Deepgram, Azure Speech, or similar engines.
+/// </summary>
+public interface ISpeechToText
+{
+    /// <summary>
+    /// Transcribes the supplied audio payload in a single batch request.
+    /// </summary>
+    /// <param name="audio">The audio payload to transcribe.</param>
+    /// <param name="opts">The transcription tuning options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the finalized transcription or an error.</returns>
+    Task<Result<TranscriptionResult>> TranscribeAsync(AudioInput audio, TranscriptionOptions opts, CancellationToken ct);
+
+    /// <summary>
+    /// Transcribes a streaming sequence of audio chunks, emitting incremental updates as they arrive.
+    /// </summary>
+    /// <param name="audio">The asynchronous sequence of audio chunks composing the live stream.</param>
+    /// <param name="opts">The transcription tuning options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>An asynchronous sequence of transcription chunks emitted by the provider.</returns>
+    IAsyncEnumerable<TranscriptionChunk> TranscribeStreamAsync(IAsyncEnumerable<AudioChunk> audio, TranscriptionOptions opts, CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Speech/Models/AudioChunk.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/Models/AudioChunk.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------
+// <copyright file="AudioChunk.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Models;
+
+/// <summary>
+/// Represents a single audio frame used to feed a streaming speech-to-text provider.
+/// </summary>
+/// <param name="Bytes">The raw PCM (or codec-defined) bytes of the chunk.</param>
+/// <param name="SampleRate">The audio sample rate in Hertz (for example 16000 or 48000).</param>
+public sealed record AudioChunk(ReadOnlyMemory<byte> Bytes, int SampleRate);

--- a/src/Abstractions/Compendium.Abstractions.Speech/Models/AudioInput.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/Models/AudioInput.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------
+// <copyright file="AudioInput.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Models;
+
+/// <summary>
+/// Represents an audio payload submitted to a speech-to-text provider for batch transcription.
+/// </summary>
+/// <param name="Stream">The audio stream to transcribe. The caller retains ownership and is responsible for disposal.</param>
+/// <param name="MimeType">The MIME type describing the audio container/codec (for example <c>audio/wav</c>, <c>audio/mpeg</c>, <c>audio/ogg</c>).</param>
+public sealed record AudioInput(Stream Stream, string MimeType);

--- a/src/Abstractions/Compendium.Abstractions.Speech/Models/TranscriptionChunk.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/Models/TranscriptionChunk.cs
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranscriptionChunk.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Models;
+
+/// <summary>
+/// Represents an incremental transcription update emitted by a streaming speech-to-text provider.
+/// </summary>
+/// <param name="PartialText">The partial transcript text accumulated up to this chunk.</param>
+/// <param name="IsFinal">When <c>true</c>, this chunk is the terminal update for the current utterance.</param>
+/// <param name="Timestamp">The timestamp of this chunk relative to the beginning of the audio stream.</param>
+public sealed record TranscriptionChunk(string PartialText, bool IsFinal, TimeSpan Timestamp);

--- a/src/Abstractions/Compendium.Abstractions.Speech/Models/TranscriptionOptions.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/Models/TranscriptionOptions.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranscriptionOptions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Models;
+
+/// <summary>
+/// Captures the tunable parameters submitted to a speech-to-text provider.
+/// </summary>
+/// <param name="Language">Optional BCP-47 language hint (for example <c>en-US</c>, <c>fr-FR</c>). When <c>null</c>, the provider is expected to auto-detect.</param>
+/// <param name="Model">Optional provider-specific model identifier (for example <c>whisper-large-v3</c>, <c>nova-3</c>).</param>
+/// <param name="Diarization">When <c>true</c>, the provider should label speaker turns in the output. Defaults to <c>false</c>.</param>
+/// <param name="Punctuation">When <c>true</c>, the provider should insert punctuation and capitalisation. Defaults to <c>true</c>.</param>
+public sealed record TranscriptionOptions(
+    string? Language = null,
+    string? Model = null,
+    bool Diarization = false,
+    bool Punctuation = true);

--- a/src/Abstractions/Compendium.Abstractions.Speech/Models/TranscriptionResult.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/Models/TranscriptionResult.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranscriptionResult.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Models;
+
+/// <summary>
+/// Represents the finalized output of a batch transcription request.
+/// </summary>
+/// <param name="Text">The full transcript text concatenated across all segments.</param>
+/// <param name="Segments">The time-aligned segments composing the transcript.</param>
+public sealed record TranscriptionResult(string Text, IReadOnlyList<TranscriptionSegment> Segments);

--- a/src/Abstractions/Compendium.Abstractions.Speech/Models/TranscriptionSegment.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/Models/TranscriptionSegment.cs
@@ -1,0 +1,17 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranscriptionSegment.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Models;
+
+/// <summary>
+/// Represents a single, time-aligned segment of a finalized transcription.
+/// </summary>
+/// <param name="Text">The transcribed text for the segment.</param>
+/// <param name="Start">The segment start time relative to the beginning of the audio.</param>
+/// <param name="End">The segment end time relative to the beginning of the audio.</param>
+/// <param name="Speaker">Optional speaker label when diarization is enabled.</param>
+public sealed record TranscriptionSegment(string Text, TimeSpan Start, TimeSpan End, string? Speaker);

--- a/src/Abstractions/Compendium.Abstractions.Speech/SpeechErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/SpeechErrors.cs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------
+// <copyright file="SpeechErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech;
+
+/// <summary>
+/// Provides standard error definitions for speech-to-text operations.
+/// </summary>
+public static class SpeechErrors
+{
+    /// <summary>
+    /// Error returned when the supplied audio MIME type or codec is not supported by the adapter.
+    /// </summary>
+    public static Error UnsupportedFormat(string mimeType) =>
+        Error.Validation("Speech.UnsupportedFormat", $"The audio format '{mimeType}' is not supported.");
+
+    /// <summary>
+    /// Error returned when the audio payload exceeds the adapter's maximum duration.
+    /// </summary>
+    public static Error AudioTooLong(TimeSpan duration, TimeSpan maximum) =>
+        Error.Validation(
+            "Speech.AudioTooLong",
+            $"The audio duration {duration.TotalSeconds:0.##}s exceeds the maximum of {maximum.TotalSeconds:0.##}s.");
+
+    /// <summary>
+    /// Error returned when the speech-to-text provider cannot be reached.
+    /// </summary>
+    public static Error ProviderUnreachable(string reason) =>
+        Error.Unavailable("Speech.ProviderUnreachable", $"The speech-to-text provider is unreachable: {reason}");
+
+    /// <summary>
+    /// Error returned when the request rate limit has been exceeded.
+    /// </summary>
+    public static Error RateLimited(string reason) =>
+        Error.TooManyRequests("Speech.RateLimited", $"Rate limit exceeded: {reason}");
+}

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/Compendium.Abstractions.Speech.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/Compendium.Abstractions.Speech.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Speech.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Speech.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Core\Compendium.Core\Compendium.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Speech\Compendium.Abstractions.Speech.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/GlobalUsings.cs
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Xunit;
+global using FluentAssertions;
+global using Compendium.Abstractions.Speech;
+global using Compendium.Abstractions.Speech.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/AudioChunkTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/AudioChunkTests.cs
@@ -1,0 +1,77 @@
+// -----------------------------------------------------------------------
+// <copyright file="AudioChunkTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Tests.Models;
+
+public class AudioChunkTests
+{
+    [Fact]
+    public void AudioChunk_Constructor_PreservesValues()
+    {
+        // Arrange
+        var bytes = new byte[] { 0x10, 0x20, 0x30 };
+
+        // Act
+        var chunk = new AudioChunk(bytes, SampleRate: 16000);
+
+        // Assert
+        chunk.Bytes.ToArray().Should().Equal(bytes);
+        chunk.SampleRate.Should().Be(16000);
+    }
+
+    [Theory]
+    [InlineData(8000)]
+    [InlineData(16000)]
+    [InlineData(44100)]
+    [InlineData(48000)]
+    public void AudioChunk_WithCommonSampleRates_PreservesValue(int sampleRate)
+    {
+        // Act
+        var chunk = new AudioChunk(ReadOnlyMemory<byte>.Empty, sampleRate);
+
+        // Assert
+        chunk.SampleRate.Should().Be(sampleRate);
+    }
+
+    [Fact]
+    public void AudioChunk_WithEmptyBytes_HasZeroLength()
+    {
+        // Act
+        var chunk = new AudioChunk(ReadOnlyMemory<byte>.Empty, 16000);
+
+        // Assert
+        chunk.Bytes.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AudioChunk_RecordEquality_SameBackingArray_AreEqual()
+    {
+        // Arrange
+        var buffer = new byte[] { 1, 2, 3 };
+        var memory = new ReadOnlyMemory<byte>(buffer);
+        var first = new AudioChunk(memory, 16000);
+        var second = new AudioChunk(memory, 16000);
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void AudioChunk_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new AudioChunk(new byte[] { 1 }, 16000);
+
+        // Act
+        var updated = original with { SampleRate = 48000 };
+
+        // Assert
+        updated.SampleRate.Should().Be(48000);
+        original.SampleRate.Should().Be(16000);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/AudioInputTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/AudioInputTests.cs
@@ -1,0 +1,66 @@
+// -----------------------------------------------------------------------
+// <copyright file="AudioInputTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Tests.Models;
+
+public class AudioInputTests
+{
+    [Fact]
+    public void AudioInput_Constructor_PreservesValues()
+    {
+        // Arrange
+        using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+
+        // Act
+        var input = new AudioInput(stream, "audio/wav");
+
+        // Assert
+        input.Stream.Should().BeSameAs(stream);
+        input.MimeType.Should().Be("audio/wav");
+    }
+
+    [Fact]
+    public void AudioInput_RecordEquality_TwoInstancesWithSameRefs_AreEqual()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var first = new AudioInput(stream, "audio/mpeg");
+        var second = new AudioInput(stream, "audio/mpeg");
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void AudioInput_RecordEquality_DifferentMime_AreNotEqual()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var first = new AudioInput(stream, "audio/wav");
+        var second = new AudioInput(stream, "audio/mpeg");
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void AudioInput_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var original = new AudioInput(stream, "audio/wav");
+
+        // Act
+        var updated = original with { MimeType = "audio/ogg" };
+
+        // Assert
+        updated.MimeType.Should().Be("audio/ogg");
+        updated.Stream.Should().BeSameAs(stream);
+        original.MimeType.Should().Be("audio/wav");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/TranscriptionChunkTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/TranscriptionChunkTests.cs
@@ -1,0 +1,77 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranscriptionChunkTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Tests.Models;
+
+public class TranscriptionChunkTests
+{
+    [Fact]
+    public void TranscriptionChunk_Constructor_PreservesValues()
+    {
+        // Arrange
+        var timestamp = TimeSpan.FromMilliseconds(250);
+
+        // Act
+        var chunk = new TranscriptionChunk("hello", IsFinal: false, timestamp);
+
+        // Assert
+        chunk.PartialText.Should().Be("hello");
+        chunk.IsFinal.Should().BeFalse();
+        chunk.Timestamp.Should().Be(timestamp);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TranscriptionChunk_WithIsFinal_PreservesFlag(bool isFinal)
+    {
+        // Act
+        var chunk = new TranscriptionChunk("text", isFinal, TimeSpan.Zero);
+
+        // Assert
+        chunk.IsFinal.Should().Be(isFinal);
+    }
+
+    [Fact]
+    public void TranscriptionChunk_RecordEquality_TwoIdentical_AreEqual()
+    {
+        // Arrange
+        var first = new TranscriptionChunk("hi", true, TimeSpan.FromSeconds(1));
+        var second = new TranscriptionChunk("hi", true, TimeSpan.FromSeconds(1));
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void TranscriptionChunk_RecordEquality_DifferingPartialText_AreNotEqual()
+    {
+        // Arrange
+        var first = new TranscriptionChunk("a", false, TimeSpan.Zero);
+        var second = new TranscriptionChunk("b", false, TimeSpan.Zero);
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void TranscriptionChunk_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new TranscriptionChunk("partial", false, TimeSpan.Zero);
+
+        // Act
+        var updated = original with { PartialText = "complete", IsFinal = true };
+
+        // Assert
+        updated.PartialText.Should().Be("complete");
+        updated.IsFinal.Should().BeTrue();
+        original.PartialText.Should().Be("partial");
+        original.IsFinal.Should().BeFalse();
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/TranscriptionOptionsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/TranscriptionOptionsTests.cs
@@ -1,0 +1,93 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranscriptionOptionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Tests.Models;
+
+public class TranscriptionOptionsTests
+{
+    [Fact]
+    public void TranscriptionOptions_Default_HasExpectedDefaults()
+    {
+        // Arrange / Act
+        var opts = new TranscriptionOptions();
+
+        // Assert
+        opts.Language.Should().BeNull();
+        opts.Model.Should().BeNull();
+        opts.Diarization.Should().BeFalse();
+        opts.Punctuation.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TranscriptionOptions_WithAllProperties_PreservesValues()
+    {
+        // Arrange / Act
+        var opts = new TranscriptionOptions(
+            Language: "fr-FR",
+            Model: "whisper-large-v3",
+            Diarization: true,
+            Punctuation: false);
+
+        // Assert
+        opts.Language.Should().Be("fr-FR");
+        opts.Model.Should().Be("whisper-large-v3");
+        opts.Diarization.Should().BeTrue();
+        opts.Punctuation.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("fr-FR")]
+    [InlineData("de-DE")]
+    public void TranscriptionOptions_WithLanguage_PreservesValue(string language)
+    {
+        // Act
+        var opts = new TranscriptionOptions(Language: language);
+
+        // Assert
+        opts.Language.Should().Be(language);
+    }
+
+    [Fact]
+    public void TranscriptionOptions_RecordEquality_TwoIdentical_AreEqual()
+    {
+        // Arrange
+        var first = new TranscriptionOptions("en", "whisper", true, false);
+        var second = new TranscriptionOptions("en", "whisper", true, false);
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void TranscriptionOptions_RecordEquality_DifferingDiarization_AreNotEqual()
+    {
+        // Arrange
+        var first = new TranscriptionOptions(Diarization: false);
+        var second = new TranscriptionOptions(Diarization: true);
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void TranscriptionOptions_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new TranscriptionOptions();
+
+        // Act
+        var updated = original with { Language = "es-ES", Diarization = true };
+
+        // Assert
+        updated.Language.Should().Be("es-ES");
+        updated.Diarization.Should().BeTrue();
+        original.Language.Should().BeNull();
+        original.Diarization.Should().BeFalse();
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/TranscriptionResultTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/TranscriptionResultTests.cs
@@ -1,0 +1,74 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranscriptionResultTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Tests.Models;
+
+public class TranscriptionResultTests
+{
+    [Fact]
+    public void TranscriptionResult_Constructor_PreservesValues()
+    {
+        // Arrange
+        var segments = new List<TranscriptionSegment>
+        {
+            new("hello", TimeSpan.Zero, TimeSpan.FromSeconds(1), null),
+            new("world", TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), "s1"),
+        };
+
+        // Act
+        var result = new TranscriptionResult("hello world", segments);
+
+        // Assert
+        result.Text.Should().Be("hello world");
+        result.Segments.Should().HaveCount(2);
+        result.Segments.Should().BeSameAs(segments);
+    }
+
+    [Fact]
+    public void TranscriptionResult_WithEmptySegments_HasNoSegments()
+    {
+        // Act
+        var result = new TranscriptionResult(string.Empty, Array.Empty<TranscriptionSegment>());
+
+        // Assert
+        result.Text.Should().BeEmpty();
+        result.Segments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TranscriptionResult_RecordEquality_SameSegmentsRef_AreEqual()
+    {
+        // Arrange
+        IReadOnlyList<TranscriptionSegment> segments = new List<TranscriptionSegment>
+        {
+            new("hi", TimeSpan.Zero, TimeSpan.FromSeconds(1), null),
+        };
+        var first = new TranscriptionResult("hi", segments);
+        var second = new TranscriptionResult("hi", segments);
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void TranscriptionResult_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new TranscriptionResult("a", Array.Empty<TranscriptionSegment>());
+        var newSegments = new[] { new TranscriptionSegment("b", TimeSpan.Zero, TimeSpan.FromSeconds(1), null) };
+
+        // Act
+        var updated = original with { Text = "b", Segments = newSegments };
+
+        // Assert
+        updated.Text.Should().Be("b");
+        updated.Segments.Should().BeSameAs(newSegments);
+        original.Text.Should().Be("a");
+        original.Segments.Should().BeEmpty();
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/TranscriptionSegmentTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/TranscriptionSegmentTests.cs
@@ -1,0 +1,77 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranscriptionSegmentTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Tests.Models;
+
+public class TranscriptionSegmentTests
+{
+    [Fact]
+    public void TranscriptionSegment_Constructor_PreservesValues()
+    {
+        // Arrange
+        var start = TimeSpan.FromSeconds(1);
+        var end = TimeSpan.FromSeconds(2.5);
+
+        // Act
+        var segment = new TranscriptionSegment("hello world", start, end, "speaker-1");
+
+        // Assert
+        segment.Text.Should().Be("hello world");
+        segment.Start.Should().Be(start);
+        segment.End.Should().Be(end);
+        segment.Speaker.Should().Be("speaker-1");
+    }
+
+    [Fact]
+    public void TranscriptionSegment_WithNullSpeaker_LeavesSpeakerNull()
+    {
+        // Act
+        var segment = new TranscriptionSegment("text", TimeSpan.Zero, TimeSpan.FromSeconds(1), null);
+
+        // Assert
+        segment.Speaker.Should().BeNull();
+    }
+
+    [Fact]
+    public void TranscriptionSegment_RecordEquality_TwoIdentical_AreEqual()
+    {
+        // Arrange
+        var first = new TranscriptionSegment("hi", TimeSpan.Zero, TimeSpan.FromSeconds(1), "s1");
+        var second = new TranscriptionSegment("hi", TimeSpan.Zero, TimeSpan.FromSeconds(1), "s1");
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void TranscriptionSegment_RecordEquality_DifferingText_AreNotEqual()
+    {
+        // Arrange
+        var first = new TranscriptionSegment("a", TimeSpan.Zero, TimeSpan.FromSeconds(1), null);
+        var second = new TranscriptionSegment("b", TimeSpan.Zero, TimeSpan.FromSeconds(1), null);
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new TranscriptionSegment("hello", TimeSpan.Zero, TimeSpan.FromSeconds(1), null);
+
+        // Act
+        var updated = original with { Speaker = "s2", Text = "bonjour" };
+
+        // Assert
+        updated.Speaker.Should().Be("s2");
+        updated.Text.Should().Be("bonjour");
+        original.Speaker.Should().BeNull();
+        original.Text.Should().Be("hello");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/SpeechErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/SpeechErrorsTests.cs
@@ -1,0 +1,129 @@
+// -----------------------------------------------------------------------
+// <copyright file="SpeechErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Tests;
+
+public class SpeechErrorsTests
+{
+    [Fact]
+    public void UnsupportedFormat_WithMimeType_ReturnsValidationError()
+    {
+        // Arrange
+        const string mimeType = "audio/x-unknown";
+
+        // Act
+        var error = SpeechErrors.UnsupportedFormat(mimeType);
+
+        // Assert
+        error.Code.Should().Be("Speech.UnsupportedFormat");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain($"'{mimeType}'");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("audio/wav")]
+    [InlineData("application/octet-stream")]
+    public void UnsupportedFormat_WithVariousMimes_EmbedsMimeInMessage(string mimeType)
+    {
+        // Act
+        var error = SpeechErrors.UnsupportedFormat(mimeType);
+
+        // Assert
+        error.Code.Should().Be("Speech.UnsupportedFormat");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain($"'{mimeType}'");
+    }
+
+    [Fact]
+    public void AudioTooLong_WithDurations_ReturnsValidationError()
+    {
+        // Arrange
+        var duration = TimeSpan.FromMinutes(20);
+        var maximum = TimeSpan.FromMinutes(10);
+
+        // Act
+        var error = SpeechErrors.AudioTooLong(duration, maximum);
+
+        // Assert
+        error.Code.Should().Be("Speech.AudioTooLong");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain("1200");
+        error.Message.Should().Contain("600");
+    }
+
+    [Fact]
+    public void AudioTooLong_WithFractionalSeconds_FormatsBothValues()
+    {
+        // Arrange
+        var duration = TimeSpan.FromSeconds(12.5);
+        var maximum = TimeSpan.FromSeconds(10);
+
+        // Act
+        var error = SpeechErrors.AudioTooLong(duration, maximum);
+
+        // Assert
+        error.Message.Should().Contain("12.5");
+        error.Message.Should().Contain("10");
+    }
+
+    [Fact]
+    public void ProviderUnreachable_WithReason_ReturnsUnavailableError()
+    {
+        // Arrange
+        const string reason = "DNS failure";
+
+        // Act
+        var error = SpeechErrors.ProviderUnreachable(reason);
+
+        // Assert
+        error.Code.Should().Be("Speech.ProviderUnreachable");
+        error.Type.Should().Be(ErrorType.Unavailable);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Fact]
+    public void RateLimited_WithReason_ReturnsTooManyRequestsError()
+    {
+        // Arrange
+        const string reason = "10 req/s exceeded";
+
+        // Act
+        var error = SpeechErrors.RateLimited(reason);
+
+        // Assert
+        error.Code.Should().Be("Speech.RateLimited");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Fact]
+    public void AllErrorFactories_ReturnNonNullErrorInstances()
+    {
+        // Act / Assert
+        SpeechErrors.UnsupportedFormat("audio/wav").Should().NotBeNull();
+        SpeechErrors.AudioTooLong(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)).Should().NotBeNull();
+        SpeechErrors.ProviderUnreachable("r").Should().NotBeNull();
+        SpeechErrors.RateLimited("r").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AllErrorCodes_StartWithSpeechPrefix()
+    {
+        // Act
+        var codes = new[]
+        {
+            SpeechErrors.UnsupportedFormat("m").Code,
+            SpeechErrors.AudioTooLong(TimeSpan.Zero, TimeSpan.Zero).Code,
+            SpeechErrors.ProviderUnreachable("r").Code,
+            SpeechErrors.RateLimited("r").Code,
+        };
+
+        // Assert
+        codes.Should().OnlyContain(c => c.StartsWith("Speech.", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary
Defines ISpeechToText port in new Compendium.Abstractions.Speech assembly. Unblocks compendium-adapter-whisper / deepgram per ADR-0006.

Note : ITextToSpeech follows in a sibling PR — same assembly.

## Surface
- ISpeechToText (Transcribe + TranscribeStream IAsyncEnumerable)
- AudioInput, AudioChunk, TranscriptionOptions, TranscriptionResult, TranscriptionSegment, TranscriptionChunk records
- SpeechErrors factories

## Coverage ≥ 90 % line.

## Test plan
- [x] dotnet build green
- [x] dotnet test green
- [x] Coverage ≥ 90 %
- [ ] CI green