### PR TITLE
feat(abstractions/speech): define ITextToSpeech port

### DIFF
--- a/src/Abstractions/Compendium.Abstractions.Speech/ITextToSpeech.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/ITextToSpeech.cs
@@ -1,0 +1,36 @@
+// -----------------------------------------------------------------------
+// <copyright file="ITextToSpeech.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Speech.Models;
+
+namespace Compendium.Abstractions.Speech;
+
+/// <summary>
+/// Provides text-to-speech synthesis operations.
+/// This interface is provider-agnostic and can be implemented by adapters targeting
+/// ElevenLabs, Azure Speech, Google Cloud TTS, OpenAI, or similar engines.
+/// </summary>
+public interface ITextToSpeech
+{
+    /// <summary>
+    /// Synthesizes the supplied text into a complete audio payload in a single batch request.
+    /// </summary>
+    /// <param name="text">The text to synthesize.</param>
+    /// <param name="opts">The synthesis tuning options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the synthesized audio output or an error.</returns>
+    Task<Result<AudioOutput>> SynthesizeAsync(string text, SynthesisOptions opts, CancellationToken ct);
+
+    /// <summary>
+    /// Synthesizes the supplied text into a sequence of audio chunks, emitting them incrementally as the provider streams them.
+    /// </summary>
+    /// <param name="text">The text to synthesize.</param>
+    /// <param name="opts">The synthesis tuning options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>An asynchronous sequence of audio chunks emitted by the provider.</returns>
+    IAsyncEnumerable<AudioChunk> SynthesizeStreamAsync(string text, SynthesisOptions opts, CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Speech/Models/AudioFormat.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/Models/AudioFormat.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------
+// <copyright file="AudioFormat.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Models;
+
+/// <summary>
+/// Enumerates the audio container/codec formats supported as text-to-speech synthesis output.
+/// </summary>
+public enum AudioFormat
+{
+    /// <summary>MPEG-1 Audio Layer III container.</summary>
+    Mp3 = 0,
+
+    /// <summary>Waveform Audio File Format (uncompressed PCM).</summary>
+    Wav = 1,
+
+    /// <summary>Opus codec inside an Ogg container.</summary>
+    Opus = 2,
+
+    /// <summary>Free Lossless Audio Codec.</summary>
+    Flac = 3,
+
+    /// <summary>Raw 16-bit signed PCM samples.</summary>
+    Pcm16 = 4,
+}

--- a/src/Abstractions/Compendium.Abstractions.Speech/Models/AudioOutput.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/Models/AudioOutput.cs
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------
+// <copyright file="AudioOutput.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Models;
+
+/// <summary>
+/// Represents the synthesized audio payload returned by a text-to-speech provider.
+/// </summary>
+/// <param name="Stream">The audio stream containing the synthesized payload. The caller takes ownership and is responsible for disposing it.</param>
+/// <param name="MimeType">The MIME type associated with <paramref name="Stream"/> (for example <c>audio/mpeg</c> or <c>audio/wav</c>).</param>
+/// <param name="Duration">The total duration of the synthesized audio.</param>
+public sealed record AudioOutput(Stream Stream, string MimeType, TimeSpan Duration);

--- a/src/Abstractions/Compendium.Abstractions.Speech/Models/SynthesisOptions.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/Models/SynthesisOptions.cs
@@ -1,0 +1,23 @@
+// -----------------------------------------------------------------------
+// <copyright file="SynthesisOptions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Models;
+
+/// <summary>
+/// Captures the tunable parameters submitted to a text-to-speech provider.
+/// </summary>
+/// <param name="VoiceId">The provider-specific voice identifier to render the synthesized audio with.</param>
+/// <param name="Model">Optional provider-specific model identifier (for example <c>eleven_multilingual_v2</c>). When <c>null</c>, the provider default is used.</param>
+/// <param name="Format">The desired audio container/codec for the synthesized output. Defaults to <see cref="AudioFormat.Mp3"/>.</param>
+/// <param name="SampleRate">The audio sample rate in Hertz. Defaults to <c>22050</c>.</param>
+/// <param name="Stability">The provider-specific voice stability factor in the range <c>[0.0, 1.0]</c>. Defaults to <c>0.5</c>.</param>
+public sealed record SynthesisOptions(
+    string VoiceId,
+    string? Model = null,
+    AudioFormat Format = AudioFormat.Mp3,
+    int SampleRate = 22050,
+    double Stability = 0.5);

--- a/src/Abstractions/Compendium.Abstractions.Speech/SpeechErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Speech/SpeechErrors.cs
@@ -37,4 +37,24 @@ public static class SpeechErrors
     /// </summary>
     public static Error RateLimited(string reason) =>
         Error.TooManyRequests("Speech.RateLimited", $"Rate limit exceeded: {reason}");
+
+    /// <summary>
+    /// Error returned when the supplied text-to-speech voice identifier is not recognised by the adapter.
+    /// </summary>
+    public static Error InvalidVoiceId(string voiceId) =>
+        Error.Validation("Speech.InvalidVoiceId", $"The voice identifier '{voiceId}' is not valid.");
+
+    /// <summary>
+    /// Error returned when the synthesis input text exceeds the adapter's maximum supported length.
+    /// </summary>
+    public static Error TextTooLong(int length, int maximum) =>
+        Error.Validation(
+            "Speech.TextTooLong",
+            $"The input text length {length} exceeds the maximum of {maximum} characters.");
+
+    /// <summary>
+    /// Error returned when the requested BCP-47 language is not supported by the adapter or selected voice.
+    /// </summary>
+    public static Error UnsupportedLanguage(string language) =>
+        Error.Validation("Speech.UnsupportedLanguage", $"The language '{language}' is not supported.");
 }

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/AudioFormatTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/AudioFormatTests.cs
@@ -1,0 +1,46 @@
+// -----------------------------------------------------------------------
+// <copyright file="AudioFormatTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Tests.Models;
+
+public class AudioFormatTests
+{
+    [Fact]
+    public void AudioFormat_DefinesExpectedMembers()
+    {
+        // Act
+        var names = Enum.GetNames<AudioFormat>();
+
+        // Assert
+        names.Should().BeEquivalentTo(new[] { "Mp3", "Wav", "Opus", "Flac", "Pcm16" });
+    }
+
+    [Theory]
+    [InlineData(AudioFormat.Mp3, 0)]
+    [InlineData(AudioFormat.Wav, 1)]
+    [InlineData(AudioFormat.Opus, 2)]
+    [InlineData(AudioFormat.Flac, 3)]
+    [InlineData(AudioFormat.Pcm16, 4)]
+    public void AudioFormat_NumericValues_AreStable(AudioFormat format, int expected)
+    {
+        // Act
+        var value = (int)format;
+
+        // Assert
+        value.Should().Be(expected);
+    }
+
+    [Fact]
+    public void AudioFormat_DefaultValue_IsMp3()
+    {
+        // Arrange
+        AudioFormat defaultValue = default;
+
+        // Act / Assert
+        defaultValue.Should().Be(AudioFormat.Mp3);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/AudioOutputTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/AudioOutputTests.cs
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------
+// <copyright file="AudioOutputTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.IO;
+
+namespace Compendium.Abstractions.Speech.Tests.Models;
+
+public class AudioOutputTests
+{
+    [Fact]
+    public void AudioOutput_Constructor_PreservesValues()
+    {
+        // Arrange
+        using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        var duration = TimeSpan.FromSeconds(2.5);
+
+        // Act
+        var output = new AudioOutput(stream, "audio/mpeg", duration);
+
+        // Assert
+        output.Stream.Should().BeSameAs(stream);
+        output.MimeType.Should().Be("audio/mpeg");
+        output.Duration.Should().Be(duration);
+    }
+
+    [Fact]
+    public void AudioOutput_RecordEquality_SameReferences_AreEqual()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var duration = TimeSpan.FromMilliseconds(500);
+        var a = new AudioOutput(stream, "audio/wav", duration);
+        var b = new AudioOutput(stream, "audio/wav", duration);
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void AudioOutput_RecordEquality_DifferingMimeType_AreNotEqual()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var duration = TimeSpan.FromSeconds(1);
+        var a = new AudioOutput(stream, "audio/mpeg", duration);
+        var b = new AudioOutput(stream, "audio/wav", duration);
+
+        // Act / Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void AudioOutput_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var original = new AudioOutput(stream, "audio/mpeg", TimeSpan.FromSeconds(1));
+
+        // Act
+        var updated = original with { MimeType = "audio/wav", Duration = TimeSpan.FromSeconds(2) };
+
+        // Assert
+        updated.Stream.Should().BeSameAs(stream);
+        updated.MimeType.Should().Be("audio/wav");
+        updated.Duration.Should().Be(TimeSpan.FromSeconds(2));
+        original.MimeType.Should().Be("audio/mpeg");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/SynthesisOptionsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/Models/SynthesisOptionsTests.cs
@@ -1,0 +1,99 @@
+// -----------------------------------------------------------------------
+// <copyright file="SynthesisOptionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Speech.Tests.Models;
+
+public class SynthesisOptionsTests
+{
+    [Fact]
+    public void SynthesisOptions_WithVoiceIdOnly_AppliesDefaults()
+    {
+        // Arrange / Act
+        var opts = new SynthesisOptions(VoiceId: "voice-1");
+
+        // Assert
+        opts.VoiceId.Should().Be("voice-1");
+        opts.Model.Should().BeNull();
+        opts.Format.Should().Be(AudioFormat.Mp3);
+        opts.SampleRate.Should().Be(22050);
+        opts.Stability.Should().Be(0.5);
+    }
+
+    [Fact]
+    public void SynthesisOptions_WithAllProperties_PreservesValues()
+    {
+        // Arrange / Act
+        var opts = new SynthesisOptions(
+            VoiceId: "voice-xyz",
+            Model: "eleven_multilingual_v2",
+            Format: AudioFormat.Wav,
+            SampleRate: 44100,
+            Stability: 0.85);
+
+        // Assert
+        opts.VoiceId.Should().Be("voice-xyz");
+        opts.Model.Should().Be("eleven_multilingual_v2");
+        opts.Format.Should().Be(AudioFormat.Wav);
+        opts.SampleRate.Should().Be(44100);
+        opts.Stability.Should().Be(0.85);
+    }
+
+    [Theory]
+    [InlineData(AudioFormat.Mp3)]
+    [InlineData(AudioFormat.Wav)]
+    [InlineData(AudioFormat.Opus)]
+    [InlineData(AudioFormat.Flac)]
+    [InlineData(AudioFormat.Pcm16)]
+    public void SynthesisOptions_AcceptsEveryAudioFormat(AudioFormat format)
+    {
+        // Act
+        var opts = new SynthesisOptions("v", Format: format);
+
+        // Assert
+        opts.Format.Should().Be(format);
+    }
+
+    [Fact]
+    public void SynthesisOptions_RecordEquality_TwoIdentical_AreEqual()
+    {
+        // Arrange
+        var a = new SynthesisOptions("v", "m", AudioFormat.Wav, 16000, 0.4);
+        var b = new SynthesisOptions("v", "m", AudioFormat.Wav, 16000, 0.4);
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void SynthesisOptions_RecordEquality_DifferingVoiceId_AreNotEqual()
+    {
+        // Arrange
+        var a = new SynthesisOptions("voice-1");
+        var b = new SynthesisOptions("voice-2");
+
+        // Act / Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void SynthesisOptions_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new SynthesisOptions("voice-1");
+
+        // Act
+        var updated = original with { Format = AudioFormat.Opus, Stability = 0.9 };
+
+        // Assert
+        updated.VoiceId.Should().Be("voice-1");
+        updated.Format.Should().Be(AudioFormat.Opus);
+        updated.Stability.Should().Be(0.9);
+        original.Format.Should().Be(AudioFormat.Mp3);
+        original.Stability.Should().Be(0.5);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Speech.Tests/SpeechErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Speech.Tests/SpeechErrorsTests.cs
@@ -102,6 +102,94 @@ public class SpeechErrorsTests
     }
 
     [Fact]
+    public void InvalidVoiceId_WithVoiceId_ReturnsValidationError()
+    {
+        // Arrange
+        const string voiceId = "voice-unknown";
+
+        // Act
+        var error = SpeechErrors.InvalidVoiceId(voiceId);
+
+        // Assert
+        error.Code.Should().Be("Speech.InvalidVoiceId");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain($"'{voiceId}'");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("21m00Tcm4TlvDq8ikWAM")]
+    [InlineData("voice-123")]
+    public void InvalidVoiceId_WithVariousIds_EmbedsIdInMessage(string voiceId)
+    {
+        // Act
+        var error = SpeechErrors.InvalidVoiceId(voiceId);
+
+        // Assert
+        error.Code.Should().Be("Speech.InvalidVoiceId");
+        error.Message.Should().Contain($"'{voiceId}'");
+    }
+
+    [Fact]
+    public void TextTooLong_WithLengths_ReturnsValidationError()
+    {
+        // Arrange
+        const int length = 5000;
+        const int maximum = 2500;
+
+        // Act
+        var error = SpeechErrors.TextTooLong(length, maximum);
+
+        // Assert
+        error.Code.Should().Be("Speech.TextTooLong");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain("5000");
+        error.Message.Should().Contain("2500");
+    }
+
+    [Theory]
+    [InlineData(1, 0)]
+    [InlineData(10000, 9999)]
+    [InlineData(int.MaxValue, 1)]
+    public void TextTooLong_WithBoundaryValues_EmbedsBothInMessage(int length, int maximum)
+    {
+        // Act
+        var error = SpeechErrors.TextTooLong(length, maximum);
+
+        // Assert
+        error.Message.Should().Contain(length.ToString());
+        error.Message.Should().Contain(maximum.ToString());
+    }
+
+    [Fact]
+    public void UnsupportedLanguage_WithLanguage_ReturnsValidationError()
+    {
+        // Arrange
+        const string language = "xx-XX";
+
+        // Act
+        var error = SpeechErrors.UnsupportedLanguage(language);
+
+        // Assert
+        error.Code.Should().Be("Speech.UnsupportedLanguage");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain($"'{language}'");
+    }
+
+    [Theory]
+    [InlineData("fr-FR")]
+    [InlineData("de-DE")]
+    [InlineData("klingon")]
+    public void UnsupportedLanguage_WithVariousLanguages_EmbedsLanguageInMessage(string language)
+    {
+        // Act
+        var error = SpeechErrors.UnsupportedLanguage(language);
+
+        // Assert
+        error.Message.Should().Contain($"'{language}'");
+    }
+
+    [Fact]
     public void AllErrorFactories_ReturnNonNullErrorInstances()
     {
         // Act / Assert
@@ -109,6 +197,9 @@ public class SpeechErrorsTests
         SpeechErrors.AudioTooLong(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)).Should().NotBeNull();
         SpeechErrors.ProviderUnreachable("r").Should().NotBeNull();
         SpeechErrors.RateLimited("r").Should().NotBeNull();
+        SpeechErrors.InvalidVoiceId("v").Should().NotBeNull();
+        SpeechErrors.TextTooLong(1, 0).Should().NotBeNull();
+        SpeechErrors.UnsupportedLanguage("l").Should().NotBeNull();
     }
 
     [Fact]
@@ -121,6 +212,9 @@ public class SpeechErrorsTests
             SpeechErrors.AudioTooLong(TimeSpan.Zero, TimeSpan.Zero).Code,
             SpeechErrors.ProviderUnreachable("r").Code,
             SpeechErrors.RateLimited("r").Code,
+            SpeechErrors.InvalidVoiceId("v").Code,
+            SpeechErrors.TextTooLong(1, 0).Code,
+            SpeechErrors.UnsupportedLanguage("l").Code,
         };
 
         // Assert


### PR DESCRIPTION
## Summary
Defines ITextToSpeech port in existing Compendium.Abstractions.Speech assembly. Unblocks compendium-adapter-elevenlabs per ADR-0006.

## Surface
- ITextToSpeech (Synthesize / SynthesizeStream)
- SynthesisOptions, AudioOutput records
- AudioFormat enum
- SpeechErrors extended

Reuses AudioChunk from STT.

## Coverage >= 90 % line.

## Test plan
- [x] dotnet build green / dotnet test green / coverage >= 90 % / CI pending