### PR TITLE
feat(abstractions/webhooks): define IWebhookSender port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -171,6 +171,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Spe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Speech.Tests", "tests\Unit\Compendium.Abstractions.Speech.Tests\Compendium.Abstractions.Speech.Tests.csproj", "{57A7F68F-6CCA-4544-8AEE-D66D90DE5197}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Webhooks", "src\Abstractions\Compendium.Abstractions.Webhooks\Compendium.Abstractions.Webhooks.csproj", "{EA61F4B0-0D9A-4B7D-BD9B-A35FFA2C393F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Webhooks.Tests", "tests\Unit\Compendium.Abstractions.Webhooks.Tests\Compendium.Abstractions.Webhooks.Tests.csproj", "{E57CBF52-7F38-4CE4-B353-A769D6804DB0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -444,6 +448,14 @@ Global
 		{57A7F68F-6CCA-4544-8AEE-D66D90DE5197}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{57A7F68F-6CCA-4544-8AEE-D66D90DE5197}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{57A7F68F-6CCA-4544-8AEE-D66D90DE5197}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA61F4B0-0D9A-4B7D-BD9B-A35FFA2C393F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA61F4B0-0D9A-4B7D-BD9B-A35FFA2C393F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA61F4B0-0D9A-4B7D-BD9B-A35FFA2C393F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA61F4B0-0D9A-4B7D-BD9B-A35FFA2C393F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E57CBF52-7F38-4CE4-B353-A769D6804DB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E57CBF52-7F38-4CE4-B353-A769D6804DB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E57CBF52-7F38-4CE4-B353-A769D6804DB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E57CBF52-7F38-4CE4-B353-A769D6804DB0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -525,5 +537,7 @@ Global
 		{FB420FBA-5109-4AEC-B006-6C1F12608F5B} = {0048DED2-AA2D-4CA2-A7CF-088F26F6D7A7}
 		{A19F2183-2233-4E83-8E81-600F1C5DE505} = {25C6CE4F-1EE7-4448-AC41-F3C3584AF7BA}
 		{57A7F68F-6CCA-4544-8AEE-D66D90DE5197} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{EA61F4B0-0D9A-4B7D-BD9B-A35FFA2C393F} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
+		{E57CBF52-7F38-4CE4-B353-A769D6804DB0} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Webhooks/Compendium.Abstractions.Webhooks.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Webhooks/Compendium.Abstractions.Webhooks.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Webhooks</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Webhooks</RootNamespace>
+    <PackageId>Compendium.Abstractions.Webhooks</PackageId>
+    <Description>Webhook abstractions for Compendium Framework: IWebhookSender. Provider-agnostic interface for fan-out of integration events to external consumer endpoints with signatures and retries (e.g. Svix, raw HTTP).</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Webhooks.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Webhooks/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Webhooks/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.Webhooks/IWebhookSender.cs
+++ b/src/Abstractions/Compendium.Abstractions.Webhooks/IWebhookSender.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// <copyright file="IWebhookSender.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Webhooks.Models;
+
+namespace Compendium.Abstractions.Webhooks;
+
+/// <summary>
+/// Provides operations for fan-out of integration events to external consumer endpoints.
+/// This port complements the in-process outbox: where the outbox publishes integration
+/// events inside the application, an <see cref="IWebhookSender"/> adapter dispatches them
+/// over HTTP to subscribed external endpoints with provider-managed retries and signatures.
+/// Implementations may target managed services such as Svix or implement raw HTTP fan-out.
+/// </summary>
+public interface IWebhookSender
+{
+    /// <summary>
+    /// Dispatches a webhook message to all endpoints subscribed to its event name within
+    /// the message's tenant. Adapters MUST honour the message's <see cref="WebhookMessage.Id"/>
+    /// as an idempotency key so that repeated calls produce a single logical delivery.
+    /// </summary>
+    /// <param name="message">The message to dispatch.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A successful result on accepted-for-delivery, or an error describing the failure.</returns>
+    Task<Result> SendAsync(WebhookMessage message, CancellationToken ct);
+
+    /// <summary>
+    /// Registers a new consumer endpoint for the supplied tenant.
+    /// </summary>
+    /// <param name="endpoint">The endpoint to register.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the provider-assigned endpoint identifier on success.</returns>
+    Task<Result<string>> RegisterEndpointAsync(WebhookEndpoint endpoint, CancellationToken ct);
+
+    /// <summary>
+    /// Deletes the endpoint identified by <paramref name="endpointId"/> for the supplied tenant.
+    /// </summary>
+    /// <param name="endpointId">The endpoint identifier to delete.</param>
+    /// <param name="tenantId">The tenant the endpoint belongs to. Adapters MUST refuse to
+    /// delete endpoints owned by a different tenant.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A successful result on deletion, or <see cref="WebhookErrors.EndpointNotFound"/>
+    /// if no matching endpoint exists for the tenant.</returns>
+    Task<Result> DeleteEndpointAsync(string endpointId, string tenantId, CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Webhooks/Models/WebhookEndpoint.cs
+++ b/src/Abstractions/Compendium.Abstractions.Webhooks/Models/WebhookEndpoint.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="WebhookEndpoint.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Webhooks.Models;
+
+/// <summary>
+/// Represents a registered consumer endpoint that subscribes to a set of webhook events
+/// for a single tenant.
+/// </summary>
+public sealed record WebhookEndpoint
+{
+    /// <summary>
+    /// Gets the unique endpoint identifier (typically issued by the adapter on registration).
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Gets the destination URL the adapter will <c>POST</c> webhook deliveries to.
+    /// </summary>
+    public required Uri Url { get; init; }
+
+    /// <summary>
+    /// Gets the tenant identifier owning this endpoint.
+    /// </summary>
+    public required string TenantId { get; init; }
+
+    /// <summary>
+    /// Gets the list of event names this endpoint subscribes to. An empty list means
+    /// "no subscriptions" — the endpoint will not receive any deliveries.
+    /// </summary>
+    public required IReadOnlyList<string> EventFilters { get; init; }
+
+    /// <summary>
+    /// Gets the optional shared secret used by the adapter to sign outbound deliveries.
+    /// Adapters that require signatures should fail fast if this is missing.
+    /// </summary>
+    public string? SigningSecret { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this endpoint is active and should receive deliveries.
+    /// </summary>
+    public bool Active { get; init; } = true;
+}

--- a/src/Abstractions/Compendium.Abstractions.Webhooks/Models/WebhookMessage.cs
+++ b/src/Abstractions/Compendium.Abstractions.Webhooks/Models/WebhookMessage.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="WebhookMessage.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Webhooks.Models;
+
+/// <summary>
+/// Represents a webhook message to be fanned out to subscribed consumer endpoints.
+/// </summary>
+public sealed record WebhookMessage
+{
+    /// <summary>
+    /// Gets the idempotency key for this message. Adapters MUST treat repeated sends
+    /// with the same <see cref="Id"/> as a single delivery.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Gets the logical event name (e.g. <c>order.created</c>) used by consumers
+    /// to filter subscriptions.
+    /// </summary>
+    public required string EventName { get; init; }
+
+    /// <summary>
+    /// Gets the event payload to be serialized and delivered to consumers.
+    /// </summary>
+    public required object Payload { get; init; }
+
+    /// <summary>
+    /// Gets the tenant identifier owning this message.
+    /// </summary>
+    public required string TenantId { get; init; }
+
+    /// <summary>
+    /// Gets the optional source domain event identifier (e.g. the event-store event id)
+    /// for traceability between integration events and outbound webhooks.
+    /// </summary>
+    public string? EventId { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp at which the message was produced.
+    /// </summary>
+    public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
+}

--- a/src/Abstractions/Compendium.Abstractions.Webhooks/WebhookErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Webhooks/WebhookErrors.cs
@@ -1,0 +1,59 @@
+// -----------------------------------------------------------------------
+// <copyright file="WebhookErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Webhooks;
+
+/// <summary>
+/// Provides standard error definitions for webhook fan-out operations.
+/// </summary>
+public static class WebhookErrors
+{
+    /// <summary>
+    /// Gets the error code prefix for webhook errors.
+    /// </summary>
+    public const string Prefix = "Webhook";
+
+    /// <summary>
+    /// Error returned when the requested endpoint cannot be located for the supplied tenant.
+    /// </summary>
+    public static Error EndpointNotFound(string endpointId) =>
+        Error.NotFound(
+            $"{Prefix}.EndpointNotFound",
+            $"Webhook endpoint '{endpointId}' was not found.");
+
+    /// <summary>
+    /// Error returned when the endpoint URL is missing, malformed, or uses an unsupported scheme.
+    /// </summary>
+    public static Error InvalidUrl(string url) =>
+        Error.Validation(
+            $"{Prefix}.InvalidUrl",
+            $"The webhook URL '{url}' is invalid or uses an unsupported scheme.");
+
+    /// <summary>
+    /// Error returned when an endpoint requires a signing secret but none was supplied.
+    /// </summary>
+    public static Error SigningSecretMissing(string endpointId) =>
+        Error.Validation(
+            $"{Prefix}.SigningSecretMissing",
+            $"Webhook endpoint '{endpointId}' requires a signing secret but none was supplied.");
+
+    /// <summary>
+    /// Error returned when the underlying webhook provider cannot be reached.
+    /// </summary>
+    public static Error ProviderUnreachable(string reason) =>
+        Error.Unavailable(
+            $"{Prefix}.ProviderUnreachable",
+            $"The webhook provider is unreachable: {reason}");
+
+    /// <summary>
+    /// Error returned when the request rate limit imposed by the provider has been exceeded.
+    /// </summary>
+    public static Error RateLimited(string reason) =>
+        Error.TooManyRequests(
+            $"{Prefix}.RateLimited",
+            $"Webhook rate limit exceeded: {reason}");
+}

--- a/tests/Unit/Compendium.Abstractions.Webhooks.Tests/Compendium.Abstractions.Webhooks.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Webhooks.Tests/Compendium.Abstractions.Webhooks.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Webhooks.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Webhooks.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Core\Compendium.Core\Compendium.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Webhooks\Compendium.Abstractions.Webhooks.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Webhooks.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Webhooks.Tests/GlobalUsings.cs
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Xunit;
+global using FluentAssertions;
+global using Compendium.Abstractions.Webhooks;
+global using Compendium.Abstractions.Webhooks.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Webhooks.Tests/Models/WebhookEndpointTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Webhooks.Tests/Models/WebhookEndpointTests.cs
@@ -1,0 +1,137 @@
+// -----------------------------------------------------------------------
+// <copyright file="WebhookEndpointTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Webhooks.Tests.Models;
+
+public class WebhookEndpointTests
+{
+    [Fact]
+    public void WebhookEndpoint_WithRequiredOnly_DefaultsActiveTrueAndSecretNull()
+    {
+        // Arrange / Act
+        var endpoint = new WebhookEndpoint
+        {
+            Id = "ep-1",
+            Url = new Uri("https://example.com/hook"),
+            TenantId = "tenant-1",
+            EventFilters = new[] { "order.created" },
+        };
+
+        // Assert
+        endpoint.Id.Should().Be("ep-1");
+        endpoint.Url.Should().Be(new Uri("https://example.com/hook"));
+        endpoint.TenantId.Should().Be("tenant-1");
+        endpoint.EventFilters.Should().ContainSingle().Which.Should().Be("order.created");
+        endpoint.SigningSecret.Should().BeNull();
+        endpoint.Active.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WebhookEndpoint_WithExplicitSecretAndInactive_PreservesValues()
+    {
+        // Arrange / Act
+        var endpoint = new WebhookEndpoint
+        {
+            Id = "ep-2",
+            Url = new Uri("https://hooks.example.com/x"),
+            TenantId = "t",
+            EventFilters = Array.Empty<string>(),
+            SigningSecret = "shhh",
+            Active = false,
+        };
+
+        // Assert
+        endpoint.SigningSecret.Should().Be("shhh");
+        endpoint.Active.Should().BeFalse();
+        endpoint.EventFilters.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WebhookEndpoint_RecordEquality_IdenticalEndpoints_AreEqual()
+    {
+        // Arrange
+        var filters = new[] { "a", "b" };
+        var first = new WebhookEndpoint
+        {
+            Id = "id",
+            Url = new Uri("https://e/"),
+            TenantId = "t",
+            EventFilters = filters,
+            SigningSecret = "s",
+            Active = true,
+        };
+        var second = new WebhookEndpoint
+        {
+            Id = "id",
+            Url = new Uri("https://e/"),
+            TenantId = "t",
+            EventFilters = filters,
+            SigningSecret = "s",
+            Active = true,
+        };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void WebhookEndpoint_RecordEquality_DifferingTenant_AreNotEqual()
+    {
+        // Arrange
+        var filters = new[] { "a" };
+        var first = new WebhookEndpoint
+        {
+            Id = "id",
+            Url = new Uri("https://e/"),
+            TenantId = "tenant-a",
+            EventFilters = filters,
+        };
+        var second = first with { TenantId = "tenant-b" };
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void WebhookEndpoint_With_FlippingActive_ProducesModifiedCopy()
+    {
+        // Arrange
+        var endpoint = new WebhookEndpoint
+        {
+            Id = "id",
+            Url = new Uri("https://e/"),
+            TenantId = "t",
+            EventFilters = Array.Empty<string>(),
+        };
+
+        // Act
+        var disabled = endpoint with { Active = false };
+
+        // Assert
+        disabled.Active.Should().BeFalse();
+        endpoint.Active.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("https://example.com/hook")]
+    [InlineData("http://localhost:9000/in")]
+    public void WebhookEndpoint_AcceptsHttpAndHttpsUrls(string url)
+    {
+        // Arrange / Act
+        var endpoint = new WebhookEndpoint
+        {
+            Id = "id",
+            Url = new Uri(url),
+            TenantId = "t",
+            EventFilters = Array.Empty<string>(),
+        };
+
+        // Assert
+        endpoint.Url.OriginalString.Should().Be(url);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Webhooks.Tests/Models/WebhookMessageTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Webhooks.Tests/Models/WebhookMessageTests.cs
@@ -1,0 +1,129 @@
+// -----------------------------------------------------------------------
+// <copyright file="WebhookMessageTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Webhooks.Tests.Models;
+
+public class WebhookMessageTests
+{
+    [Fact]
+    public void WebhookMessage_WithRequiredOnly_DefaultsTimestampToUtcNowAndLeavesEventIdNull()
+    {
+        // Arrange
+        var before = DateTimeOffset.UtcNow;
+
+        // Act
+        var message = new WebhookMessage
+        {
+            Id = "msg-1",
+            EventName = "order.created",
+            Payload = new { orderId = "o-1" },
+            TenantId = "tenant-1",
+        };
+        var after = DateTimeOffset.UtcNow;
+
+        // Assert
+        message.Id.Should().Be("msg-1");
+        message.EventName.Should().Be("order.created");
+        message.Payload.Should().NotBeNull();
+        message.TenantId.Should().Be("tenant-1");
+        message.EventId.Should().BeNull();
+        message.Timestamp.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    [Fact]
+    public void WebhookMessage_WithExplicitTimestampAndEventId_PreservesValues()
+    {
+        // Arrange
+        var ts = new DateTimeOffset(2026, 5, 11, 12, 0, 0, TimeSpan.Zero);
+
+        // Act
+        var message = new WebhookMessage
+        {
+            Id = "msg-2",
+            EventName = "user.invited",
+            Payload = "raw-string-payload",
+            TenantId = "tenant-9",
+            EventId = "evt-42",
+            Timestamp = ts,
+        };
+
+        // Assert
+        message.EventId.Should().Be("evt-42");
+        message.Timestamp.Should().Be(ts);
+        message.Payload.Should().Be("raw-string-payload");
+    }
+
+    [Fact]
+    public void WebhookMessage_RecordEquality_IdenticalMessages_AreEqual()
+    {
+        // Arrange
+        var payload = new { foo = "bar" };
+        var ts = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var first = new WebhookMessage
+        {
+            Id = "id",
+            EventName = "evt",
+            Payload = payload,
+            TenantId = "t",
+            EventId = "e",
+            Timestamp = ts,
+        };
+        var second = new WebhookMessage
+        {
+            Id = "id",
+            EventName = "evt",
+            Payload = payload,
+            TenantId = "t",
+            EventId = "e",
+            Timestamp = ts,
+        };
+
+        // Act / Assert
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void WebhookMessage_RecordEquality_DifferingTenant_AreNotEqual()
+    {
+        // Arrange
+        var ts = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var payload = new { x = 1 };
+        var first = new WebhookMessage
+        {
+            Id = "id",
+            EventName = "evt",
+            Payload = payload,
+            TenantId = "a",
+            Timestamp = ts,
+        };
+        var second = first with { TenantId = "b" };
+
+        // Act / Assert
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void WebhookMessage_With_ProducesModifiedCopyAndLeavesOriginalUnchanged()
+    {
+        // Arrange
+        var original = new WebhookMessage
+        {
+            Id = "id",
+            EventName = "evt",
+            Payload = new { a = 1 },
+            TenantId = "t",
+        };
+
+        // Act
+        var copy = original with { EventId = "e-99" };
+
+        // Assert
+        copy.EventId.Should().Be("e-99");
+        original.EventId.Should().BeNull();
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Webhooks.Tests/WebhookErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Webhooks.Tests/WebhookErrorsTests.cs
@@ -1,0 +1,121 @@
+// -----------------------------------------------------------------------
+// <copyright file="WebhookErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Webhooks.Tests;
+
+public class WebhookErrorsTests
+{
+    [Fact]
+    public void Prefix_Is_Webhook()
+    {
+        // Act / Assert
+        WebhookErrors.Prefix.Should().Be("Webhook");
+    }
+
+    [Theory]
+    [InlineData("ep-1")]
+    [InlineData("")]
+    [InlineData("very-long-endpoint-id-aaaaaaaaaaaaaaaaa")]
+    public void EndpointNotFound_WithVariousIds_ReturnsNotFoundErrorEmbeddingId(string endpointId)
+    {
+        // Act
+        var error = WebhookErrors.EndpointNotFound(endpointId);
+
+        // Assert
+        error.Code.Should().Be("Webhook.EndpointNotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain($"'{endpointId}'");
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://example.com/x")]
+    [InlineData("")]
+    public void InvalidUrl_WithVariousInputs_ReturnsValidationErrorEmbeddingUrl(string url)
+    {
+        // Act
+        var error = WebhookErrors.InvalidUrl(url);
+
+        // Assert
+        error.Code.Should().Be("Webhook.InvalidUrl");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain($"'{url}'");
+    }
+
+    [Fact]
+    public void SigningSecretMissing_WithEndpointId_ReturnsValidationErrorEmbeddingId()
+    {
+        // Arrange
+        const string endpointId = "ep-7";
+
+        // Act
+        var error = WebhookErrors.SigningSecretMissing(endpointId);
+
+        // Assert
+        error.Code.Should().Be("Webhook.SigningSecretMissing");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain($"'{endpointId}'");
+    }
+
+    [Fact]
+    public void ProviderUnreachable_WithReason_ReturnsUnavailableErrorEmbeddingReason()
+    {
+        // Arrange
+        const string reason = "DNS lookup failed";
+
+        // Act
+        var error = WebhookErrors.ProviderUnreachable(reason);
+
+        // Assert
+        error.Code.Should().Be("Webhook.ProviderUnreachable");
+        error.Type.Should().Be(ErrorType.Unavailable);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Fact]
+    public void RateLimited_WithReason_ReturnsTooManyRequestsErrorEmbeddingReason()
+    {
+        // Arrange
+        const string reason = "100 req/sec exceeded";
+
+        // Act
+        var error = WebhookErrors.RateLimited(reason);
+
+        // Assert
+        error.Code.Should().Be("Webhook.RateLimited");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().Contain(reason);
+    }
+
+    [Fact]
+    public void AllErrorFactories_ReturnNonNullErrorInstances()
+    {
+        // Act / Assert
+        WebhookErrors.EndpointNotFound("ep").Should().NotBeNull();
+        WebhookErrors.InvalidUrl("u").Should().NotBeNull();
+        WebhookErrors.SigningSecretMissing("ep").Should().NotBeNull();
+        WebhookErrors.ProviderUnreachable("r").Should().NotBeNull();
+        WebhookErrors.RateLimited("r").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AllErrorCodes_StartWithWebhookPrefix()
+    {
+        // Act
+        var codes = new[]
+        {
+            WebhookErrors.EndpointNotFound("ep").Code,
+            WebhookErrors.InvalidUrl("u").Code,
+            WebhookErrors.SigningSecretMissing("ep").Code,
+            WebhookErrors.ProviderUnreachable("r").Code,
+            WebhookErrors.RateLimited("r").Code,
+        };
+
+        // Assert
+        codes.Should().OnlyContain(c => c.StartsWith("Webhook.", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary
Defines IWebhookSender port in new Compendium.Abstractions.Webhooks assembly. Unblocks compendium-adapter-svix per ADR-0006.

Complement to the existing outbox (Adapters.PostgreSQL) — outbox handles in-process integration events ; IWebhookSender adapters fan out to external consumer endpoints with signatures + retries.

## Surface
- IWebhookSender (Send / RegisterEndpoint / DeleteEndpoint)
- WebhookMessage, WebhookEndpoint records (tenant-aware)
- WebhookErrors factories

## Coverage ≥ 90 % line.

## Test plan
- [x] dotnet build green / dotnet test green / coverage ≥ 90 % / CI pending