### PR TITLE
feat(abstractions/crm): define ICrmSync port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -175,6 +175,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Web
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Webhooks.Tests", "tests\Unit\Compendium.Abstractions.Webhooks.Tests\Compendium.Abstractions.Webhooks.Tests.csproj", "{E57CBF52-7F38-4CE4-B353-A769D6804DB0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Crm", "src\Abstractions\Compendium.Abstractions.Crm\Compendium.Abstractions.Crm.csproj", "{F9134930-D6FF-4F9D-8A37-FA4AA9ED72BF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Crm.Tests", "tests\Unit\Compendium.Abstractions.Crm.Tests\Compendium.Abstractions.Crm.Tests.csproj", "{B997F54F-8761-483F-A5AC-22C584F1C150}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -456,6 +460,14 @@ Global
 		{E57CBF52-7F38-4CE4-B353-A769D6804DB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E57CBF52-7F38-4CE4-B353-A769D6804DB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E57CBF52-7F38-4CE4-B353-A769D6804DB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9134930-D6FF-4F9D-8A37-FA4AA9ED72BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9134930-D6FF-4F9D-8A37-FA4AA9ED72BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9134930-D6FF-4F9D-8A37-FA4AA9ED72BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9134930-D6FF-4F9D-8A37-FA4AA9ED72BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B997F54F-8761-483F-A5AC-22C584F1C150}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B997F54F-8761-483F-A5AC-22C584F1C150}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B997F54F-8761-483F-A5AC-22C584F1C150}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B997F54F-8761-483F-A5AC-22C584F1C150}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -539,5 +551,7 @@ Global
 		{57A7F68F-6CCA-4544-8AEE-D66D90DE5197} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{EA61F4B0-0D9A-4B7D-BD9B-A35FFA2C393F} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
 		{E57CBF52-7F38-4CE4-B353-A769D6804DB0} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{F9134930-D6FF-4F9D-8A37-FA4AA9ED72BF} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
+		{B997F54F-8761-483F-A5AC-22C584F1C150} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Crm/Compendium.Abstractions.Crm.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Crm/Compendium.Abstractions.Crm.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Crm</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Crm</RootNamespace>
+    <PackageId>Compendium.Abstractions.Crm</PackageId>
+    <Description>CRM abstractions for Compendium Framework: ICrmSync port and contact/company/event/association models. Provider-agnostic interface for CRM synchronization across HubSpot, Attio, Salesforce, and similar platforms.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Crm.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Crm/CrmErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Crm/CrmErrors.cs
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="CrmErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Crm;
+
+/// <summary>
+/// Provides standardized error definitions for CRM synchronization operations.
+/// </summary>
+public static class CrmErrors
+{
+    /// <summary>
+    /// Gets the error code prefix for CRM errors.
+    /// </summary>
+    public const string Prefix = "Crm";
+
+    /// <summary>
+    /// The requested contact was not found in the CRM provider.
+    /// </summary>
+    public static Error ContactNotFound(string externalId) =>
+        Error.NotFound($"{Prefix}.ContactNotFound", $"Contact '{externalId}' was not found.");
+
+    /// <summary>
+    /// A contact with the same identifying field already exists.
+    /// </summary>
+    public static Error DuplicateContact(string identifier) =>
+        Error.Conflict($"{Prefix}.DuplicateContact", $"A contact already exists for '{identifier}'.");
+
+    /// <summary>
+    /// The supplied email address is invalid.
+    /// </summary>
+    public static Error InvalidEmail(string email) =>
+        Error.Validation($"{Prefix}.InvalidEmail", $"Email address '{email}' is invalid.");
+
+    /// <summary>
+    /// The CRM provider could not be reached.
+    /// </summary>
+    public static Error ProviderUnreachable(string provider) =>
+        Error.Failure($"{Prefix}.ProviderUnreachable", $"CRM provider '{provider}' is unreachable.");
+
+    /// <summary>
+    /// The CRM provider rejected the request because the rate limit was exceeded.
+    /// </summary>
+    public static Error RateLimited(TimeSpan? retryAfter = null) =>
+        Error.Failure(
+            $"{Prefix}.RateLimited",
+            retryAfter.HasValue
+                ? $"Rate limit exceeded. Retry after {retryAfter.Value.TotalSeconds} seconds."
+                : "Rate limit exceeded. Please try again later.");
+}

--- a/src/Abstractions/Compendium.Abstractions.Crm/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Crm/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.Crm/ICrmSync.cs
+++ b/src/Abstractions/Compendium.Abstractions.Crm/ICrmSync.cs
@@ -1,0 +1,50 @@
+// -----------------------------------------------------------------------
+// <copyright file="ICrmSync.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Crm.Models;
+
+namespace Compendium.Abstractions.Crm;
+
+/// <summary>
+/// Provides synchronization of contacts, companies, events and associations with an external CRM.
+/// This interface is provider-agnostic and can be implemented by adapters for HubSpot, Attio,
+/// Salesforce, or similar platforms.
+/// </summary>
+public interface ICrmSync
+{
+    /// <summary>
+    /// Inserts or updates a contact in the target CRM.
+    /// </summary>
+    /// <param name="contact">The contact to upsert.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the provider's identifier for the contact or an error.</returns>
+    Task<Result<string>> UpsertContactAsync(CrmContact contact, CancellationToken ct);
+
+    /// <summary>
+    /// Inserts or updates a company in the target CRM.
+    /// </summary>
+    /// <param name="company">The company to upsert.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the provider's identifier for the company or an error.</returns>
+    Task<Result<string>> UpsertCompanyAsync(CrmCompany company, CancellationToken ct);
+
+    /// <summary>
+    /// Tracks a behavioural / lifecycle event against a CRM contact.
+    /// </summary>
+    /// <param name="evt">The event to record.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A successful result or an error.</returns>
+    Task<Result> TrackEventAsync(CrmEvent evt, CancellationToken ct);
+
+    /// <summary>
+    /// Creates an association between two CRM entities.
+    /// </summary>
+    /// <param name="association">The association to record.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A successful result or an error.</returns>
+    Task<Result> AssociateAsync(CrmAssociation association, CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Crm/Models/CrmAssociation.cs
+++ b/src/Abstractions/Compendium.Abstractions.Crm/Models/CrmAssociation.cs
@@ -1,0 +1,23 @@
+// -----------------------------------------------------------------------
+// <copyright file="CrmAssociation.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Crm.Models;
+
+/// <summary>
+/// Represents a directional association between two CRM entities (e.g. contact -> company).
+/// </summary>
+/// <param name="FromType">The type of the source entity (e.g. "contact", "company").</param>
+/// <param name="FromId">The external identifier of the source entity.</param>
+/// <param name="ToType">The type of the target entity.</param>
+/// <param name="ToId">The external identifier of the target entity.</param>
+/// <param name="Role">Optional role / label describing the relationship (e.g. "primary_contact").</param>
+public sealed record CrmAssociation(
+    string FromType,
+    string FromId,
+    string ToType,
+    string ToId,
+    string? Role);

--- a/src/Abstractions/Compendium.Abstractions.Crm/Models/CrmCompany.cs
+++ b/src/Abstractions/Compendium.Abstractions.Crm/Models/CrmCompany.cs
@@ -1,0 +1,23 @@
+// -----------------------------------------------------------------------
+// <copyright file="CrmCompany.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Crm.Models;
+
+/// <summary>
+/// Represents a CRM company / organization to be synchronized with an external CRM provider.
+/// </summary>
+/// <param name="ExternalId">The stable identifier of the company in the source system.</param>
+/// <param name="Name">The display name of the company.</param>
+/// <param name="Domain">The company's primary web domain, if known.</param>
+/// <param name="Properties">Additional provider-specific properties to attach to the company.</param>
+/// <param name="TenantId">The tenant that owns this company (for multi-tenant isolation).</param>
+public sealed record CrmCompany(
+    string ExternalId,
+    string Name,
+    string? Domain,
+    IReadOnlyDictionary<string, object>? Properties,
+    string TenantId);

--- a/src/Abstractions/Compendium.Abstractions.Crm/Models/CrmContact.cs
+++ b/src/Abstractions/Compendium.Abstractions.Crm/Models/CrmContact.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------
+// <copyright file="CrmContact.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Crm.Models;
+
+/// <summary>
+/// Represents a CRM contact to be synchronized with an external CRM provider.
+/// </summary>
+/// <param name="ExternalId">The stable identifier of the contact in the source system.</param>
+/// <param name="Email">The contact's primary email address.</param>
+/// <param name="FirstName">The contact's first name, if known.</param>
+/// <param name="LastName">The contact's last name, if known.</param>
+/// <param name="Properties">Additional provider-specific properties to attach to the contact.</param>
+/// <param name="TenantId">The tenant that owns this contact (for multi-tenant isolation).</param>
+public sealed record CrmContact(
+    string ExternalId,
+    string Email,
+    string? FirstName,
+    string? LastName,
+    IReadOnlyDictionary<string, object>? Properties,
+    string TenantId);

--- a/src/Abstractions/Compendium.Abstractions.Crm/Models/CrmEvent.cs
+++ b/src/Abstractions/Compendium.Abstractions.Crm/Models/CrmEvent.cs
@@ -1,0 +1,23 @@
+// -----------------------------------------------------------------------
+// <copyright file="CrmEvent.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Crm.Models;
+
+/// <summary>
+/// Represents a behavioural / lifecycle event to be tracked against a CRM contact.
+/// </summary>
+/// <param name="Name">The event name (e.g. "checkout_completed", "trial_started").</param>
+/// <param name="ContactExternalId">The external identifier of the contact the event is associated with.</param>
+/// <param name="Properties">Additional provider-specific event properties.</param>
+/// <param name="Timestamp">The moment the event occurred.</param>
+/// <param name="TenantId">The tenant that owns this event (for multi-tenant isolation).</param>
+public sealed record CrmEvent(
+    string Name,
+    string ContactExternalId,
+    IReadOnlyDictionary<string, object>? Properties,
+    DateTimeOffset Timestamp,
+    string TenantId);

--- a/tests/Unit/Compendium.Abstractions.Crm.Tests/Compendium.Abstractions.Crm.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Crm.Tests/Compendium.Abstractions.Crm.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Crm.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Crm.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Crm\Compendium.Abstractions.Crm.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Crm.Tests/CrmErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Crm.Tests/CrmErrorsTests.cs
@@ -1,0 +1,92 @@
+// -----------------------------------------------------------------------
+// <copyright file="CrmErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Crm.Tests;
+
+public class CrmErrorsTests
+{
+    [Fact]
+    public void Prefix_IsCrm()
+    {
+        // Act / Assert
+        CrmErrors.Prefix.Should().Be("Crm");
+    }
+
+    [Fact]
+    public void ContactNotFound_ShouldReturnNotFoundError()
+    {
+        // Act
+        var error = CrmErrors.ContactNotFound("ext-1");
+
+        // Assert
+        error.Code.Should().Be("Crm.ContactNotFound");
+        error.Message.Should().Contain("ext-1");
+        error.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public void DuplicateContact_ShouldReturnConflictError()
+    {
+        // Act
+        var error = CrmErrors.DuplicateContact("user@example.com");
+
+        // Assert
+        error.Code.Should().Be("Crm.DuplicateContact");
+        error.Message.Should().Contain("user@example.com");
+        error.Type.Should().Be(ErrorType.Conflict);
+    }
+
+    [Fact]
+    public void InvalidEmail_ShouldReturnValidationError()
+    {
+        // Act
+        var error = CrmErrors.InvalidEmail("not-an-email");
+
+        // Assert
+        error.Code.Should().Be("Crm.InvalidEmail");
+        error.Message.Should().Contain("not-an-email");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
+
+    [Fact]
+    public void ProviderUnreachable_ShouldReturnFailureError()
+    {
+        // Act
+        var error = CrmErrors.ProviderUnreachable("hubspot");
+
+        // Assert
+        error.Code.Should().Be("Crm.ProviderUnreachable");
+        error.Message.Should().Contain("hubspot");
+        error.Type.Should().Be(ErrorType.Failure);
+    }
+
+    [Fact]
+    public void RateLimited_WithoutRetryAfter_ShouldReturnGenericMessage()
+    {
+        // Act
+        var error = CrmErrors.RateLimited();
+
+        // Assert
+        error.Code.Should().Be("Crm.RateLimited");
+        error.Message.Should().Contain("Rate limit exceeded");
+        error.Type.Should().Be(ErrorType.Failure);
+    }
+
+    [Fact]
+    public void RateLimited_WithRetryAfter_ShouldIncludeRetryTime()
+    {
+        // Arrange
+        var retryAfter = TimeSpan.FromSeconds(45);
+
+        // Act
+        var error = CrmErrors.RateLimited(retryAfter);
+
+        // Assert
+        error.Code.Should().Be("Crm.RateLimited");
+        error.Message.Should().Contain("45");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Crm.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Crm.Tests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using Xunit;
+global using FluentAssertions;
+global using NSubstitute;
+global using Compendium.Abstractions.Crm;
+global using Compendium.Abstractions.Crm.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Crm.Tests/ICrmSyncTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Crm.Tests/ICrmSyncTests.cs
@@ -1,0 +1,79 @@
+// -----------------------------------------------------------------------
+// <copyright file="ICrmSyncTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Crm.Tests;
+
+public class ICrmSyncTests
+{
+    [Fact]
+    public async Task UpsertContactAsync_CanBeSubstituted_AndReturnsConfiguredResult()
+    {
+        // Arrange
+        var sync = Substitute.For<ICrmSync>();
+        var contact = new CrmContact("ext-1", "user@example.com", "Ada", "L", null, "tenant-1");
+        sync.UpsertContactAsync(contact, Arg.Any<CancellationToken>())
+            .Returns(Result.Success("provider-id-1"));
+
+        // Act
+        var result = await sync.UpsertContactAsync(contact, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("provider-id-1");
+    }
+
+    [Fact]
+    public async Task UpsertCompanyAsync_CanBeSubstituted_AndReturnsConfiguredResult()
+    {
+        // Arrange
+        var sync = Substitute.For<ICrmSync>();
+        var company = new CrmCompany("co-1", "Acme", null, null, "tenant-1");
+        sync.UpsertCompanyAsync(company, Arg.Any<CancellationToken>())
+            .Returns(Result.Success("provider-co-1"));
+
+        // Act
+        var result = await sync.UpsertCompanyAsync(company, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("provider-co-1");
+    }
+
+    [Fact]
+    public async Task TrackEventAsync_CanBeSubstituted_AndReturnsConfiguredResult()
+    {
+        // Arrange
+        var sync = Substitute.For<ICrmSync>();
+        var evt = new CrmEvent("trial_started", "ext-1", null, DateTimeOffset.UtcNow, "tenant-1");
+        sync.TrackEventAsync(evt, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+
+        // Act
+        var result = await sync.TrackEventAsync(evt, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AssociateAsync_CanBeSubstituted_AndPropagatesFailure()
+    {
+        // Arrange
+        var sync = Substitute.For<ICrmSync>();
+        var association = new CrmAssociation("contact", "ext-1", "company", "co-1", null);
+        var error = CrmErrors.ProviderUnreachable("hubspot");
+        sync.AssociateAsync(association, Arg.Any<CancellationToken>())
+            .Returns(Result.Failure(error));
+
+        // Act
+        var result = await sync.AssociateAsync(association, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Crm.ProviderUnreachable");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Crm.Tests/Models/CrmAssociationTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Crm.Tests/Models/CrmAssociationTests.cs
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="CrmAssociationTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Crm.Tests.Models;
+
+public class CrmAssociationTests
+{
+    [Fact]
+    public void CrmAssociation_Construct_AssignsAllProperties()
+    {
+        // Act
+        var assoc = new CrmAssociation(
+            FromType: "contact",
+            FromId: "ext-1",
+            ToType: "company",
+            ToId: "co-1",
+            Role: "primary_contact");
+
+        // Assert
+        assoc.FromType.Should().Be("contact");
+        assoc.FromId.Should().Be("ext-1");
+        assoc.ToType.Should().Be("company");
+        assoc.ToId.Should().Be("co-1");
+        assoc.Role.Should().Be("primary_contact");
+    }
+
+    [Fact]
+    public void CrmAssociation_Construct_AllowsNullRole()
+    {
+        // Act
+        var assoc = new CrmAssociation("contact", "ext-1", "company", "co-1", null);
+
+        // Assert
+        assoc.Role.Should().BeNull();
+    }
+
+    [Fact]
+    public void CrmAssociation_Equality_IsValueBased()
+    {
+        // Arrange
+        var a = new CrmAssociation("contact", "ext-1", "company", "co-1", "primary_contact");
+        var b = new CrmAssociation("contact", "ext-1", "company", "co-1", "primary_contact");
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void CrmAssociation_Inequality_WhenRoleDiffers()
+    {
+        // Arrange
+        var a = new CrmAssociation("contact", "ext-1", "company", "co-1", "primary_contact");
+        var b = a with { Role = "decision_maker" };
+
+        // Act / Assert
+        a.Should().NotBe(b);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Crm.Tests/Models/CrmCompanyTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Crm.Tests/Models/CrmCompanyTests.cs
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------
+// <copyright file="CrmCompanyTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Crm.Tests.Models;
+
+public class CrmCompanyTests
+{
+    [Fact]
+    public void CrmCompany_Construct_AssignsAllProperties()
+    {
+        // Arrange
+        var props = new Dictionary<string, object> { ["industry"] = "saas" };
+
+        // Act
+        var company = new CrmCompany(
+            ExternalId: "co-1",
+            Name: "Acme",
+            Domain: "acme.example",
+            Properties: props,
+            TenantId: "tenant-1");
+
+        // Assert
+        company.ExternalId.Should().Be("co-1");
+        company.Name.Should().Be("Acme");
+        company.Domain.Should().Be("acme.example");
+        company.Properties.Should().BeSameAs(props);
+        company.TenantId.Should().Be("tenant-1");
+    }
+
+    [Fact]
+    public void CrmCompany_Construct_AllowsNullOptionalFields()
+    {
+        // Act
+        var company = new CrmCompany("co-2", "Acme", null, null, "tenant-1");
+
+        // Assert
+        company.Domain.Should().BeNull();
+        company.Properties.Should().BeNull();
+    }
+
+    [Fact]
+    public void CrmCompany_Equality_IsValueBased()
+    {
+        // Arrange
+        var a = new CrmCompany("co-1", "Acme", "acme.example", null, "tenant-1");
+        var b = new CrmCompany("co-1", "Acme", "acme.example", null, "tenant-1");
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void CrmCompany_With_ProducesModifiedCopy()
+    {
+        // Arrange
+        var original = new CrmCompany("co-1", "Acme", null, null, "tenant-1");
+
+        // Act
+        var modified = original with { Name = "Acme Corp" };
+
+        // Assert
+        modified.Should().NotBe(original);
+        modified.Name.Should().Be("Acme Corp");
+        modified.ExternalId.Should().Be("co-1");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Crm.Tests/Models/CrmContactTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Crm.Tests/Models/CrmContactTests.cs
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------
+// <copyright file="CrmContactTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Crm.Tests.Models;
+
+public class CrmContactTests
+{
+    [Fact]
+    public void CrmContact_Construct_AssignsAllProperties()
+    {
+        // Arrange
+        var props = new Dictionary<string, object> { ["plan"] = "pro" };
+
+        // Act
+        var contact = new CrmContact(
+            ExternalId: "ext-1",
+            Email: "user@example.com",
+            FirstName: "Ada",
+            LastName: "Lovelace",
+            Properties: props,
+            TenantId: "tenant-1");
+
+        // Assert
+        contact.ExternalId.Should().Be("ext-1");
+        contact.Email.Should().Be("user@example.com");
+        contact.FirstName.Should().Be("Ada");
+        contact.LastName.Should().Be("Lovelace");
+        contact.Properties.Should().BeSameAs(props);
+        contact.TenantId.Should().Be("tenant-1");
+    }
+
+    [Fact]
+    public void CrmContact_Construct_AllowsNullOptionalFields()
+    {
+        // Act
+        var contact = new CrmContact("ext-2", "user@example.com", null, null, null, "tenant-1");
+
+        // Assert
+        contact.FirstName.Should().BeNull();
+        contact.LastName.Should().BeNull();
+        contact.Properties.Should().BeNull();
+    }
+
+    [Fact]
+    public void CrmContact_Equality_IsValueBased()
+    {
+        // Arrange
+        var a = new CrmContact("ext-1", "user@example.com", "Ada", "L", null, "tenant-1");
+        var b = new CrmContact("ext-1", "user@example.com", "Ada", "L", null, "tenant-1");
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void CrmContact_Inequality_DiffersWhenAnyFieldDiffers()
+    {
+        // Arrange
+        var a = new CrmContact("ext-1", "user@example.com", "Ada", "L", null, "tenant-1");
+        var b = a with { TenantId = "tenant-2" };
+
+        // Act / Assert
+        a.Should().NotBe(b);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Crm.Tests/Models/CrmEventTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Crm.Tests/Models/CrmEventTests.cs
@@ -1,0 +1,76 @@
+// -----------------------------------------------------------------------
+// <copyright file="CrmEventTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Crm.Tests.Models;
+
+public class CrmEventTests
+{
+    [Fact]
+    public void CrmEvent_Construct_AssignsAllProperties()
+    {
+        // Arrange
+        var when = new DateTimeOffset(2026, 5, 11, 10, 0, 0, TimeSpan.Zero);
+        var props = new Dictionary<string, object> { ["plan"] = "pro" };
+
+        // Act
+        var evt = new CrmEvent(
+            Name: "trial_started",
+            ContactExternalId: "ext-1",
+            Properties: props,
+            Timestamp: when,
+            TenantId: "tenant-1");
+
+        // Assert
+        evt.Name.Should().Be("trial_started");
+        evt.ContactExternalId.Should().Be("ext-1");
+        evt.Properties.Should().BeSameAs(props);
+        evt.Timestamp.Should().Be(when);
+        evt.TenantId.Should().Be("tenant-1");
+    }
+
+    [Fact]
+    public void CrmEvent_Construct_AllowsNullProperties()
+    {
+        // Arrange
+        var when = DateTimeOffset.UtcNow;
+
+        // Act
+        var evt = new CrmEvent("event", "ext-1", null, when, "tenant-1");
+
+        // Assert
+        evt.Properties.Should().BeNull();
+    }
+
+    [Fact]
+    public void CrmEvent_Equality_IsValueBased()
+    {
+        // Arrange
+        var when = new DateTimeOffset(2026, 5, 11, 10, 0, 0, TimeSpan.Zero);
+        var a = new CrmEvent("ev", "ext-1", null, when, "tenant-1");
+        var b = new CrmEvent("ev", "ext-1", null, when, "tenant-1");
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void CrmEvent_With_ChangesTimestampWithoutMutating()
+    {
+        // Arrange
+        var when = DateTimeOffset.UtcNow;
+        var evt = new CrmEvent("ev", "ext-1", null, when, "tenant-1");
+        var later = when.AddMinutes(5);
+
+        // Act
+        var copy = evt with { Timestamp = later };
+
+        // Assert
+        evt.Timestamp.Should().Be(when);
+        copy.Timestamp.Should().Be(later);
+    }
+}


### PR DESCRIPTION
## Summary
Defines ICrmSync port in new Compendium.Abstractions.Crm assembly. Unblocks compendium-adapter-hubspot / attio per ADR-0006.

## Surface
- ICrmSync (UpsertContact / UpsertCompany / TrackEvent / Associate)
- CrmContact, CrmCompany, CrmEvent, CrmAssociation records
- CrmErrors factories

## Coverage
- Line coverage: **100 %** (Compendium.Abstractions.Crm)
- Branch coverage: **100 %**
- 27 tests passing.

## Test plan
- [x] dotnet build green
- [x] dotnet test green
- [x] coverage >= 90 %
- [ ] CI pending