### PR TITLE
feat(abstractions/ai): define IReranker port

### DIFF
--- a/src/Abstractions/Compendium.Abstractions.AI/AIErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.AI/AIErrors.cs
@@ -116,4 +116,16 @@ public static class AIErrors
     /// </summary>
     public static Error InvalidRequest(string reason) =>
         Error.Validation($"{Prefix}.InvalidRequest", reason);
+
+    /// <summary>
+    /// The rerank operation failed.
+    /// </summary>
+    public static Error RerankFailed(string reason) =>
+        Error.Failure($"{Prefix}.RerankFailed", $"Rerank operation failed: {reason}.");
+
+    /// <summary>
+    /// The query supplied to a rerank or retrieval operation is invalid (e.g. empty or whitespace).
+    /// </summary>
+    public static Error InvalidQuery(string reason) =>
+        Error.Validation($"{Prefix}.InvalidQuery", reason);
 }

--- a/src/Abstractions/Compendium.Abstractions.AI/IReranker.cs
+++ b/src/Abstractions/Compendium.Abstractions.AI/IReranker.cs
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------
+// <copyright file="IReranker.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.AI.Models;
+
+namespace Compendium.Abstractions.AI;
+
+/// <summary>
+/// Provides relevance-based reranking of a set of documents against a query.
+/// Implementations may delegate to providers such as Cohere Rerank, Voyage,
+/// or local cross-encoder models. This port is consumed by RAG pipelines
+/// to improve retrieval quality after an initial vector search.
+/// </summary>
+public interface IReranker
+{
+    /// <summary>
+    /// Reranks the supplied documents against the query and returns them ordered by descending relevance.
+    /// </summary>
+    /// <param name="query">The query used to score document relevance.</param>
+    /// <param name="documents">The candidate documents to rerank.</param>
+    /// <param name="opts">Options controlling model selection, top-N truncation, and whether to echo documents back.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A result containing the reranked documents ordered by descending relevance, or an error.</returns>
+    Task<Result<IReadOnlyList<RerankedDocument>>> RerankAsync(
+        string query,
+        IReadOnlyList<string> documents,
+        RerankOptions opts,
+        CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.AI/Models/RerankOptions.cs
+++ b/src/Abstractions/Compendium.Abstractions.AI/Models/RerankOptions.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------
+// <copyright file="RerankOptions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.AI.Models;
+
+/// <summary>
+/// Represents options for a rerank request.
+/// </summary>
+public sealed record RerankOptions
+{
+    /// <summary>
+    /// Gets the optional model identifier to use for reranking.
+    /// </summary>
+    public string? Model { get; init; }
+
+    /// <summary>
+    /// Gets the optional maximum number of top documents to return.
+    /// </summary>
+    public int? TopN { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the reranked documents should be returned with their original text.
+    /// </summary>
+    public bool ReturnDocuments { get; init; }
+}

--- a/src/Abstractions/Compendium.Abstractions.AI/Models/RerankedDocument.cs
+++ b/src/Abstractions/Compendium.Abstractions.AI/Models/RerankedDocument.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------
+// <copyright file="RerankedDocument.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.AI.Models;
+
+/// <summary>
+/// Represents a single reranked document with its relevance score.
+/// </summary>
+public sealed record RerankedDocument
+{
+    /// <summary>
+    /// Gets the index of the document in the original input list.
+    /// </summary>
+    public required int Index { get; init; }
+
+    /// <summary>
+    /// Gets the relevance score for this document, where higher values indicate greater relevance.
+    /// </summary>
+    public required double RelevanceScore { get; init; }
+
+    /// <summary>
+    /// Gets the original document text, when requested via <see cref="RerankOptions.ReturnDocuments"/>.
+    /// </summary>
+    public string? Document { get; init; }
+}

--- a/tests/Unit/Compendium.Abstractions.AI.Tests/AIErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.AI.Tests/AIErrorsTests.cs
@@ -198,4 +198,28 @@ public class AIErrorsTests
         error.Message.Should().Be("Messages array cannot be empty");
         error.Type.Should().Be(ErrorType.Validation);
     }
+
+    [Fact]
+    public void RerankFailed_ShouldReturnFailureErrorWithReason()
+    {
+        // Act
+        var error = AIErrors.RerankFailed("upstream 503");
+
+        // Assert
+        error.Code.Should().Be("AI.RerankFailed");
+        error.Message.Should().Contain("upstream 503");
+        error.Type.Should().Be(ErrorType.Failure);
+    }
+
+    [Fact]
+    public void InvalidQuery_ShouldReturnValidationError()
+    {
+        // Act
+        var error = AIErrors.InvalidQuery("Query must not be empty");
+
+        // Assert
+        error.Code.Should().Be("AI.InvalidQuery");
+        error.Message.Should().Be("Query must not be empty");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
 }

--- a/tests/Unit/Compendium.Abstractions.AI.Tests/Models/RerankOptionsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.AI.Tests/Models/RerankOptionsTests.cs
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------
+// <copyright file="RerankOptionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.AI.Tests.Models;
+
+public sealed class RerankOptionsTests
+{
+    [Fact]
+    public void RerankOptions_Default_HasExpectedDefaults()
+    {
+        // Arrange & Act
+        var options = new RerankOptions();
+
+        // Assert
+        options.Model.Should().BeNull();
+        options.TopN.Should().BeNull();
+        options.ReturnDocuments.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RerankOptions_WithAllProperties_CreatesSuccessfully()
+    {
+        // Arrange & Act
+        var options = new RerankOptions
+        {
+            Model = "rerank-english-v3.0",
+            TopN = 5,
+            ReturnDocuments = true,
+        };
+
+        // Assert
+        options.Model.Should().Be("rerank-english-v3.0");
+        options.TopN.Should().Be(5);
+        options.ReturnDocuments.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RerankOptions_Equality_BasedOnValues()
+    {
+        // Arrange
+        var a = new RerankOptions { Model = "m", TopN = 3, ReturnDocuments = true };
+        var b = new RerankOptions { Model = "m", TopN = 3, ReturnDocuments = true };
+        var c = new RerankOptions { Model = "m", TopN = 4, ReturnDocuments = true };
+
+        // Act & Assert
+        a.Should().Be(b);
+        a.Should().NotBe(c);
+    }
+
+    [Fact]
+    public void RerankOptions_WithExpression_ReturnsModifiedCopy()
+    {
+        // Arrange
+        var original = new RerankOptions { Model = "m", TopN = 3 };
+
+        // Act
+        var copy = original with { TopN = 10 };
+
+        // Assert
+        copy.Model.Should().Be("m");
+        copy.TopN.Should().Be(10);
+        original.TopN.Should().Be(3);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.AI.Tests/Models/RerankedDocumentTests.cs
+++ b/tests/Unit/Compendium.Abstractions.AI.Tests/Models/RerankedDocumentTests.cs
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------
+// <copyright file="RerankedDocumentTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.AI.Tests.Models;
+
+public sealed class RerankedDocumentTests
+{
+    [Fact]
+    public void RerankedDocument_WithRequiredProperties_CreatesSuccessfully()
+    {
+        // Arrange & Act
+        var doc = new RerankedDocument
+        {
+            Index = 2,
+            RelevanceScore = 0.87,
+        };
+
+        // Assert
+        doc.Index.Should().Be(2);
+        doc.RelevanceScore.Should().Be(0.87);
+        doc.Document.Should().BeNull();
+    }
+
+    [Fact]
+    public void RerankedDocument_WithDocument_PopulatesText()
+    {
+        // Arrange & Act
+        var doc = new RerankedDocument
+        {
+            Index = 0,
+            RelevanceScore = 0.99,
+            Document = "The quick brown fox.",
+        };
+
+        // Assert
+        doc.Document.Should().Be("The quick brown fox.");
+    }
+
+    [Fact]
+    public void RerankedDocument_Equality_BasedOnValues()
+    {
+        // Arrange
+        var a = new RerankedDocument { Index = 1, RelevanceScore = 0.5, Document = "x" };
+        var b = new RerankedDocument { Index = 1, RelevanceScore = 0.5, Document = "x" };
+        var c = new RerankedDocument { Index = 1, RelevanceScore = 0.6, Document = "x" };
+
+        // Act & Assert
+        a.Should().Be(b);
+        a.Should().NotBe(c);
+    }
+
+    [Fact]
+    public void RerankedDocument_WithExpression_ReturnsModifiedCopy()
+    {
+        // Arrange
+        var original = new RerankedDocument { Index = 0, RelevanceScore = 0.1 };
+
+        // Act
+        var copy = original with { RelevanceScore = 0.95 };
+
+        // Assert
+        copy.Index.Should().Be(0);
+        copy.RelevanceScore.Should().Be(0.95);
+        original.RelevanceScore.Should().Be(0.1);
+    }
+}


### PR DESCRIPTION
## Summary
Defines IReranker port in existing Compendium.Abstractions.AI assembly. Unblocks compendium-adapter-cohere (rerank) per ADR-0006. Improves RAG quality across all AI adapters.

## Surface
- IReranker (Rerank)
- RerankOptions, RerankedDocument records
- AIErrors extended

## Coverage ≥ 90 % project-wide.

## Test plan
- [x] dotnet build green / dotnet test green / coverage ≥ 90 % / CI pending