### PR TITLE
feat(abstractions/translation): define ITranslator port

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -179,6 +179,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Crm
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Crm.Tests", "tests\Unit\Compendium.Abstractions.Crm.Tests\Compendium.Abstractions.Crm.Tests.csproj", "{B997F54F-8761-483F-A5AC-22C584F1C150}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Translation", "src\Abstractions\Compendium.Abstractions.Translation\Compendium.Abstractions.Translation.csproj", "{42808BFA-A912-43DB-8F22-CCEBC8D70ADC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Translation.Tests", "tests\Unit\Compendium.Abstractions.Translation.Tests\Compendium.Abstractions.Translation.Tests.csproj", "{69760A76-9186-410C-8FF2-220C5147D956}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -468,6 +472,14 @@ Global
 		{B997F54F-8761-483F-A5AC-22C584F1C150}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B997F54F-8761-483F-A5AC-22C584F1C150}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B997F54F-8761-483F-A5AC-22C584F1C150}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42808BFA-A912-43DB-8F22-CCEBC8D70ADC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42808BFA-A912-43DB-8F22-CCEBC8D70ADC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42808BFA-A912-43DB-8F22-CCEBC8D70ADC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42808BFA-A912-43DB-8F22-CCEBC8D70ADC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69760A76-9186-410C-8FF2-220C5147D956}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69760A76-9186-410C-8FF2-220C5147D956}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69760A76-9186-410C-8FF2-220C5147D956}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69760A76-9186-410C-8FF2-220C5147D956}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -553,5 +565,7 @@ Global
 		{E57CBF52-7F38-4CE4-B353-A769D6804DB0} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 		{F9134930-D6FF-4F9D-8A37-FA4AA9ED72BF} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
 		{B997F54F-8761-483F-A5AC-22C584F1C150} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{42808BFA-A912-43DB-8F22-CCEBC8D70ADC} = {25C6CE4F-1EE7-4448-AC41-F3C3584AF7BA}
+		{69760A76-9186-410C-8FF2-220C5147D956} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Translation/Compendium.Abstractions.Translation.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Translation/Compendium.Abstractions.Translation.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Translation</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Translation</RootNamespace>
+    <PackageId>Compendium.Abstractions.Translation</PackageId>
+    <Description>Translation abstractions for Compendium Framework: ITranslator. Provider-agnostic interface for text translation, batch translation, and language detection.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Translation.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Translation/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Translation/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.Translation/ITranslator.cs
+++ b/src/Abstractions/Compendium.Abstractions.Translation/ITranslator.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------
+// <copyright file="ITranslator.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Translation.Models;
+
+namespace Compendium.Abstractions.Translation;
+
+/// <summary>
+/// Provides text translation and language detection.
+/// This interface is provider-agnostic and can be implemented by providers such as
+/// DeepL, Google Cloud Translation, Azure Translator, or local models.
+/// </summary>
+public interface ITranslator
+{
+    /// <summary>
+    /// Translates a single piece of text.
+    /// </summary>
+    /// <param name="text">The text to translate.</param>
+    /// <param name="opts">Translation options including target language and formality.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The translation result, or a failure describing why translation could not be performed.</returns>
+    Task<Result<TranslationResult>> TranslateAsync(string text, TranslationOptions opts, CancellationToken ct);
+
+    /// <summary>
+    /// Translates a batch of texts in one call. Order of the result corresponds to the order of the inputs.
+    /// </summary>
+    /// <param name="texts">The texts to translate.</param>
+    /// <param name="opts">Translation options applied to every input.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A list of translation results, or a failure if the batch could not be processed.</returns>
+    Task<Result<IReadOnlyList<TranslationResult>>> TranslateBatchAsync(IReadOnlyList<string> texts, TranslationOptions opts, CancellationToken ct);
+
+    /// <summary>
+    /// Detects the BCP-47 language of the supplied text.
+    /// </summary>
+    /// <param name="text">The text to inspect.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The detected language code, or a failure describing why detection could not be performed.</returns>
+    Task<Result<string>> DetectLanguageAsync(string text, CancellationToken ct);
+}

--- a/src/Abstractions/Compendium.Abstractions.Translation/Models/Formality.cs
+++ b/src/Abstractions/Compendium.Abstractions.Translation/Models/Formality.cs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------
+// <copyright file="Formality.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Translation.Models;
+
+/// <summary>
+/// Specifies how formal the translated text should sound.
+/// Providers that don't support formality should treat all values as <see cref="Default"/>.
+/// </summary>
+public enum Formality
+{
+    /// <summary>
+    /// Use the provider's default formality (no explicit preference).
+    /// </summary>
+    Default = 0,
+
+    /// <summary>
+    /// Require a more formal tone. Fail if the target language does not support it.
+    /// </summary>
+    More = 1,
+
+    /// <summary>
+    /// Require a less formal tone. Fail if the target language does not support it.
+    /// </summary>
+    Less = 2,
+
+    /// <summary>
+    /// Prefer a more formal tone, but fall back silently if unsupported.
+    /// </summary>
+    PreferMore = 3,
+
+    /// <summary>
+    /// Prefer a less formal tone, but fall back silently if unsupported.
+    /// </summary>
+    PreferLess = 4,
+}

--- a/src/Abstractions/Compendium.Abstractions.Translation/Models/TranslationOptions.cs
+++ b/src/Abstractions/Compendium.Abstractions.Translation/Models/TranslationOptions.cs
@@ -1,0 +1,26 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranslationOptions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Translation.Models;
+
+/// <summary>
+/// Options controlling a translation request.
+/// </summary>
+/// <param name="SourceLanguage">
+/// Optional BCP-47 source language code (e.g. "en", "fr-CA"). When <c>null</c>, the provider
+/// will auto-detect the source language.
+/// </param>
+/// <param name="TargetLanguage">
+/// Required BCP-47 target language code (e.g. "de", "pt-BR").
+/// </param>
+/// <param name="Formality">
+/// Desired formality of the translation. Defaults to <see cref="Formality.Default"/>.
+/// </param>
+public sealed record TranslationOptions(
+    string? SourceLanguage,
+    string TargetLanguage,
+    Formality Formality = Formality.Default);

--- a/src/Abstractions/Compendium.Abstractions.Translation/Models/TranslationResult.cs
+++ b/src/Abstractions/Compendium.Abstractions.Translation/Models/TranslationResult.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranslationResult.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Translation.Models;
+
+/// <summary>
+/// Outcome of a successful translation.
+/// </summary>
+/// <param name="TranslatedText">The translated text.</param>
+/// <param name="DetectedSourceLanguage">
+/// The BCP-47 source language code reported by the provider — either echoed from the request
+/// or auto-detected when <see cref="TranslationOptions.SourceLanguage"/> was <c>null</c>.
+/// </param>
+/// <param name="Confidence">
+/// Optional confidence score in the range [0.0, 1.0]. <c>null</c> when the provider does not
+/// expose a confidence value.
+/// </param>
+public sealed record TranslationResult(
+    string TranslatedText,
+    string DetectedSourceLanguage,
+    double? Confidence);

--- a/src/Abstractions/Compendium.Abstractions.Translation/TranslationErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Translation/TranslationErrors.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranslationErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Translation;
+
+/// <summary>
+/// Standardized error definitions for translation operations.
+/// </summary>
+public static class TranslationErrors
+{
+    /// <summary>
+    /// Gets the error code prefix for translation errors.
+    /// </summary>
+    public const string Prefix = "Translation";
+
+    /// <summary>
+    /// The requested source or target language is not supported by the provider.
+    /// </summary>
+    public static Error UnsupportedLanguage(string language) =>
+        Error.Validation(
+            $"{Prefix}.UnsupportedLanguage",
+            $"Language '{language}' is not supported by this translation provider.");
+
+    /// <summary>
+    /// The input text exceeds the provider's per-request size limit.
+    /// </summary>
+    public static Error TextTooLong(int length, int maximum) =>
+        Error.Validation(
+            $"{Prefix}.TextTooLong",
+            $"Text length {length} exceeds the maximum of {maximum} characters.");
+
+    /// <summary>
+    /// The translation provider could not be reached.
+    /// </summary>
+    public static Error ProviderUnreachable(string provider, string? reason = null) =>
+        Error.Unavailable(
+            $"{Prefix}.ProviderUnreachable",
+            reason is null
+                ? $"Translation provider '{provider}' is unreachable."
+                : $"Translation provider '{provider}' is unreachable: {reason}.");
+
+    /// <summary>
+    /// The provider rejected the request because the caller exceeded the rate limit.
+    /// </summary>
+    public static Error RateLimited(TimeSpan? retryAfter = null) =>
+        Error.TooManyRequests(
+            $"{Prefix}.RateLimited",
+            retryAfter.HasValue
+                ? $"Translation provider rate limit exceeded. Retry after {retryAfter.Value.TotalSeconds} seconds."
+                : "Translation provider rate limit exceeded. Please try again later.");
+}

--- a/tests/Unit/Compendium.Abstractions.Translation.Tests/Compendium.Abstractions.Translation.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Translation.Tests/Compendium.Abstractions.Translation.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Translation.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Translation.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Translation\Compendium.Abstractions.Translation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Translation.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Translation.Tests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using Xunit;
+global using FluentAssertions;
+global using NSubstitute;
+global using Compendium.Abstractions.Translation;
+global using Compendium.Abstractions.Translation.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Translation.Tests/ITranslatorContractTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Translation.Tests/ITranslatorContractTests.cs
@@ -1,0 +1,90 @@
+// -----------------------------------------------------------------------
+// <copyright file="ITranslatorContractTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Translation.Tests;
+
+public class ITranslatorContractTests
+{
+    [Fact]
+    public async Task TranslateAsync_OnSubstitute_ReturnsConfiguredResult()
+    {
+        // Arrange
+        var translator = Substitute.For<ITranslator>();
+        var options = new TranslationOptions("en", "fr", Formality.Default);
+        var expected = new TranslationResult("Bonjour", "en", 0.9);
+        translator
+            .TranslateAsync("Hello", options, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(expected));
+
+        // Act
+        var result = await translator.TranslateAsync("Hello", options, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task TranslateBatchAsync_OnSubstitute_ReturnsConfiguredList()
+    {
+        // Arrange
+        var translator = Substitute.For<ITranslator>();
+        var options = new TranslationOptions(null, "de", Formality.More);
+        IReadOnlyList<string> inputs = new[] { "Hello", "World" };
+        IReadOnlyList<TranslationResult> expected = new[]
+        {
+            new TranslationResult("Hallo", "en", 0.99),
+            new TranslationResult("Welt", "en", 0.97),
+        };
+        translator
+            .TranslateBatchAsync(inputs, options, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(expected));
+
+        // Act
+        var result = await translator.TranslateBatchAsync(inputs, options, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public async Task DetectLanguageAsync_OnSubstitute_ReturnsConfiguredLanguage()
+    {
+        // Arrange
+        var translator = Substitute.For<ITranslator>();
+        translator
+            .DetectLanguageAsync("こんにちは", Arg.Any<CancellationToken>())
+            .Returns(Result.Success("ja"));
+
+        // Act
+        var result = await translator.DetectLanguageAsync("こんにちは", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("ja");
+    }
+
+    [Fact]
+    public async Task TranslateAsync_WhenProviderFails_PropagatesFailureResult()
+    {
+        // Arrange
+        var translator = Substitute.For<ITranslator>();
+        var options = new TranslationOptions("en", "xx", Formality.Default);
+        var expectedError = TranslationErrors.UnsupportedLanguage("xx");
+        translator
+            .TranslateAsync(Arg.Any<string>(), options, Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<TranslationResult>(expectedError));
+
+        // Act
+        var result = await translator.TranslateAsync("Hello", options, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be(expectedError.Code);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Translation.Tests/Models/FormalityTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Translation.Tests/Models/FormalityTests.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="FormalityTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Translation.Tests.Models;
+
+public class FormalityTests
+{
+    [Fact]
+    public void Formality_Default_HasValueZero()
+    {
+        // Act / Assert
+        ((int)Formality.Default).Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(Formality.Default, 0)]
+    [InlineData(Formality.More, 1)]
+    [InlineData(Formality.Less, 2)]
+    [InlineData(Formality.PreferMore, 3)]
+    [InlineData(Formality.PreferLess, 4)]
+    public void Formality_AllMembers_HaveStableOrdinals(Formality value, int expected)
+    {
+        // Act / Assert
+        ((int)value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Formality_ExposesExpectedMembers()
+    {
+        // Act
+        var names = Enum.GetNames<Formality>();
+
+        // Assert
+        names.Should().BeEquivalentTo(new[]
+        {
+            nameof(Formality.Default),
+            nameof(Formality.More),
+            nameof(Formality.Less),
+            nameof(Formality.PreferMore),
+            nameof(Formality.PreferLess),
+        });
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Translation.Tests/Models/TranslationOptionsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Translation.Tests/Models/TranslationOptionsTests.cs
@@ -1,0 +1,84 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranslationOptionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Translation.Tests.Models;
+
+public class TranslationOptionsTests
+{
+    [Fact]
+    public void TranslationOptions_Constructor_AssignsAllProperties()
+    {
+        // Act
+        var opts = new TranslationOptions("en", "fr", Formality.More);
+
+        // Assert
+        opts.SourceLanguage.Should().Be("en");
+        opts.TargetLanguage.Should().Be("fr");
+        opts.Formality.Should().Be(Formality.More);
+    }
+
+    [Fact]
+    public void TranslationOptions_OmittedFormality_DefaultsToDefault()
+    {
+        // Act
+        var opts = new TranslationOptions("en", "de");
+
+        // Assert
+        opts.Formality.Should().Be(Formality.Default);
+    }
+
+    [Fact]
+    public void TranslationOptions_NullSourceLanguage_IsAllowed()
+    {
+        // Act
+        var opts = new TranslationOptions(null, "es", Formality.PreferLess);
+
+        // Assert
+        opts.SourceLanguage.Should().BeNull();
+        opts.TargetLanguage.Should().Be("es");
+        opts.Formality.Should().Be(Formality.PreferLess);
+    }
+
+    [Fact]
+    public void TranslationOptions_EquatableByValue_ReturnsTrueForIdenticalContent()
+    {
+        // Arrange
+        var a = new TranslationOptions("en", "fr", Formality.More);
+        var b = new TranslationOptions("en", "fr", Formality.More);
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void TranslationOptions_EquatableByValue_ReturnsFalseWhenAnyFieldDiffers()
+    {
+        // Arrange
+        var baseline = new TranslationOptions("en", "fr", Formality.More);
+
+        // Act / Assert
+        baseline.Should().NotBe(baseline with { SourceLanguage = "de" });
+        baseline.Should().NotBe(baseline with { TargetLanguage = "es" });
+        baseline.Should().NotBe(baseline with { Formality = Formality.Less });
+    }
+
+    [Fact]
+    public void TranslationOptions_WithExpression_ReplacesSingleField()
+    {
+        // Arrange
+        var opts = new TranslationOptions("en", "fr", Formality.Default);
+
+        // Act
+        var updated = opts with { TargetLanguage = "it" };
+
+        // Assert
+        updated.SourceLanguage.Should().Be("en");
+        updated.TargetLanguage.Should().Be("it");
+        updated.Formality.Should().Be(Formality.Default);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Translation.Tests/Models/TranslationResultTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Translation.Tests/Models/TranslationResultTests.cs
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranslationResultTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Translation.Tests.Models;
+
+public class TranslationResultTests
+{
+    [Fact]
+    public void TranslationResult_Constructor_AssignsAllProperties()
+    {
+        // Act
+        var result = new TranslationResult("Bonjour", "en", 0.95);
+
+        // Assert
+        result.TranslatedText.Should().Be("Bonjour");
+        result.DetectedSourceLanguage.Should().Be("en");
+        result.Confidence.Should().Be(0.95);
+    }
+
+    [Fact]
+    public void TranslationResult_NullConfidence_IsAllowed()
+    {
+        // Act
+        var result = new TranslationResult("Hola", "en", null);
+
+        // Assert
+        result.Confidence.Should().BeNull();
+    }
+
+    [Fact]
+    public void TranslationResult_EquatableByValue_ReturnsTrueForIdenticalContent()
+    {
+        // Arrange
+        var a = new TranslationResult("Hallo", "en", 0.8);
+        var b = new TranslationResult("Hallo", "en", 0.8);
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void TranslationResult_EquatableByValue_ReturnsFalseWhenAnyFieldDiffers()
+    {
+        // Arrange
+        var baseline = new TranslationResult("Hallo", "en", 0.8);
+
+        // Act / Assert
+        baseline.Should().NotBe(baseline with { TranslatedText = "Salut" });
+        baseline.Should().NotBe(baseline with { DetectedSourceLanguage = "fr" });
+        baseline.Should().NotBe(baseline with { Confidence = 0.5 });
+        baseline.Should().NotBe(baseline with { Confidence = null });
+    }
+
+    [Fact]
+    public void TranslationResult_WithExpression_ReplacesSingleField()
+    {
+        // Arrange
+        var result = new TranslationResult("Ciao", "it", null);
+
+        // Act
+        var updated = result with { Confidence = 0.75 };
+
+        // Assert
+        updated.TranslatedText.Should().Be("Ciao");
+        updated.DetectedSourceLanguage.Should().Be("it");
+        updated.Confidence.Should().Be(0.75);
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Translation.Tests/TranslationErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Translation.Tests/TranslationErrorsTests.cs
@@ -1,0 +1,95 @@
+// -----------------------------------------------------------------------
+// <copyright file="TranslationErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Translation.Tests;
+
+public class TranslationErrorsTests
+{
+    [Fact]
+    public void Prefix_HasExpectedValue()
+    {
+        // Act / Assert
+        TranslationErrors.Prefix.Should().Be("Translation");
+    }
+
+    [Fact]
+    public void UnsupportedLanguage_ReturnsValidationError()
+    {
+        // Act
+        var error = TranslationErrors.UnsupportedLanguage("klingon");
+
+        // Assert
+        error.Code.Should().Be("Translation.UnsupportedLanguage");
+        error.Message.Should().Contain("klingon");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
+
+    [Fact]
+    public void TextTooLong_ReturnsValidationErrorMentioningLengthAndMaximum()
+    {
+        // Act
+        var error = TranslationErrors.TextTooLong(length: 12_000, maximum: 5_000);
+
+        // Assert
+        error.Code.Should().Be("Translation.TextTooLong");
+        error.Message.Should().Contain("12000");
+        error.Message.Should().Contain("5000");
+        error.Type.Should().Be(ErrorType.Validation);
+    }
+
+    [Fact]
+    public void ProviderUnreachable_WithoutReason_ReturnsUnavailableErrorWithProviderName()
+    {
+        // Act
+        var error = TranslationErrors.ProviderUnreachable("deepl");
+
+        // Assert
+        error.Code.Should().Be("Translation.ProviderUnreachable");
+        error.Message.Should().Contain("deepl");
+        error.Type.Should().Be(ErrorType.Unavailable);
+    }
+
+    [Fact]
+    public void ProviderUnreachable_WithReason_IncludesReasonInMessage()
+    {
+        // Act
+        var error = TranslationErrors.ProviderUnreachable("deepl", "DNS lookup failed");
+
+        // Assert
+        error.Code.Should().Be("Translation.ProviderUnreachable");
+        error.Message.Should().Contain("deepl");
+        error.Message.Should().Contain("DNS lookup failed");
+        error.Type.Should().Be(ErrorType.Unavailable);
+    }
+
+    [Fact]
+    public void RateLimited_WithoutRetryAfter_ReturnsTooManyRequestsErrorWithGenericMessage()
+    {
+        // Act
+        var error = TranslationErrors.RateLimited();
+
+        // Assert
+        error.Code.Should().Be("Translation.RateLimited");
+        error.Message.Should().Contain("rate limit");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+    }
+
+    [Fact]
+    public void RateLimited_WithRetryAfter_IncludesRetryWindowInMessage()
+    {
+        // Arrange
+        var retryAfter = TimeSpan.FromSeconds(45);
+
+        // Act
+        var error = TranslationErrors.RateLimited(retryAfter);
+
+        // Assert
+        error.Code.Should().Be("Translation.RateLimited");
+        error.Message.Should().Contain("45");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+    }
+}


### PR DESCRIPTION
## Summary
Defines ITranslator port in new Compendium.Abstractions.Translation assembly. Unblocks compendium-adapter-deepl per ADR-0006.

## Surface
- ITranslator (Translate / TranslateBatch / DetectLanguage)
- TranslationOptions, TranslationResult records
- Formality enum, TranslationErrors factories

## Coverage ≥ 90 % line.

## Test plan
- [x] dotnet build green / dotnet test green / coverage ≥ 90 % / CI pending