### PR TITLE
ci: switch to self-hosted ARC runners (runs-on: dotnet)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    runs-on: dotnet
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: dotnet
     timeout-minutes: 20
     outputs:
       version_path: ${{ steps.version.outputs.path }}
@@ -99,7 +99,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: dotnet
     timeout-minutes: 10
     steps:
       - name: Download site artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   pack-publish:
-    runs-on: ubuntu-latest
+    runs-on: dotnet
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Migre tous les workflows GH Actions de Compendium vers les runners self-hosted ARC qui tournent sur le cluster k8s `sassy-solutions-main-live`.

- `ci.yml` : `runs-on: ubuntu-latest` → `runs-on: dotnet`
- `docs-deploy.yml` : 2 jobs (build + deploy) → `dotnet`
- `release.yml` : `pack-publish` → `dotnet`

## Pourquoi

Minutes GitHub Actions épuisées sur l'org `sassy-solutions`. Les runners ARC tournent sur le cluster k8s existant via la GitHub App `nxs-runner` (cf. [github-actions-runners](https://github.com/sassy-solutions/github-actions-runners)).

## Variante `dotnet`

- Ubuntu 24.04 + .NET 8 SDK pré-installé
- Docker CLI + Buildx + Compose
- runner GH binaire 2.334.0
- `actions/setup-dotnet@v4` continue de marcher (override la version si besoin, e.g. 9.0.x pour docfx)
- dind sidecar pour les jobs qui font `docker build`

## Validation

Smoke test end-to-end (`smoke-deploy` + `smoke-dotnet`) PASS sur le cluster — le runner pull l'image privée depuis GHCR via `ghcr-pull`, mint un installation token via `nxs-runner` (App ID 3676514, installation 131410088), s'enregistre en JIT, exécute le job, le pod meurt.

## Test plan

- [ ] Merger ce PR
- [ ] Vérifier que le 1er run du CI sur main démarre bien (Actions tab)
- [ ] Confirmer qu'un pod éphémère spawn dans `arc-runners` ns du cluster
- [ ] `dotnet restore` / `dotnet test` passent