### PR TITLE
refactor(integration): 3 more E2E classes on InMemory + GetStatistics tenant fix

### DIFF
--- a/src/Infrastructure/Compendium.Infrastructure/EventSourcing/InMemoryStreamingEventStore.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/EventSourcing/InMemoryStreamingEventStore.cs
@@ -247,11 +247,18 @@ public sealed class InMemoryStreamingEventStore : IStreamingEventStore, IDisposa
         _lock.EnterReadLock();
         try
         {
-            var totalEvents = _streams.Values.Sum(s => s.Count);
+            var tenantId = _tenantContext?.TenantId;
+            var snapshot = string.IsNullOrEmpty(tenantId)
+                ? _streams.Values.ToList()
+                : _streams
+                    .Where(kvp => kvp.Key.StartsWith($"{tenantId}:", StringComparison.Ordinal))
+                    .Select(kvp => kvp.Value)
+                    .ToList();
+
             var stats = new EventStoreStatistics
             {
-                TotalEvents = totalEvents,
-                TotalAggregates = _streams.Count,
+                TotalEvents = snapshot.Sum(s => s.Count),
+                TotalAggregates = snapshot.Count,
             };
             return Task.FromResult(Result.Success(stats));
         }

--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ConcurrencyE2ETests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ConcurrencyE2ETests.cs
@@ -5,19 +5,11 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using Compendium.Adapters.PostgreSQL.Configuration;
-using Compendium.Adapters.PostgreSQL.EventStore;
 using Compendium.Core.Results;
-using Compendium.IntegrationTests.EndToEnd.Infrastructure;
+using Compendium.Infrastructure.EventSourcing;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates.ValueObjects;
-using Dapper;
 using FluentAssertions;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using NSubstitute;
-using Testcontainers.PostgreSql;
-using Compendium.IntegrationTests.Fixtures;
 using Xunit;
 
 namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
@@ -26,78 +18,30 @@ namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
 /// E2E Test Scenario 5: Concurrent Commands with Optimistic Concurrency.
 /// Tests optimistic concurrency control prevents lost updates under concurrent load.
 /// </summary>
+/// <remarks>
+/// Per ADR-0007, this framework-behaviour test runs against
+/// <see cref="InMemoryStreamingEventStore"/>. Postgres-specific concurrency
+/// tests live in compendium-adapter-postgresql.
+/// </remarks>
 [Trait("Category", "E2E")]
 [Trait("Category", "Concurrency")]
 public sealed class ConcurrencyE2ETests : IAsyncLifetime
 {
-    private PostgreSqlContainer? _postgres;
-    private PostgreSqlEventStore? _eventStore;
-    private string _connectionString = null!;
+    private InMemoryStreamingEventStore? _eventStore;
 
-    public async Task InitializeAsync()
+    public Task InitializeAsync()
     {
-        // Use EnvironmentConfigurationHelper for connection string fallback
-        var externalConnectionString = Compendium.IntegrationTests.Infrastructure.EnvironmentConfigurationHelper.GetPostgreSqlConnectionString();
-
-        if (!string.IsNullOrEmpty(externalConnectionString))
-        {
-            _connectionString = externalConnectionString;
-        }
-        else
-        {
-            // Fallback to TestContainers
-            Console.WriteLine("⚠️ Starting TestContainer for PostgreSQL (Concurrency E2E)...");
-            _postgres = new PostgreSqlBuilder()
-                .WithImage("postgres:15-alpine")
-                .WithDatabase("compendium_concurrency_e2e")
-                .WithUsername("test_user")
-                .WithPassword("test_password")
-                .WithCleanUp(true)
-                .Build();
-
-            await _postgres.StartAsync();
-            _connectionString = _postgres.GetConnectionString();
-        }
-
-        // Initialize event store
-        var options = Options.Create(new PostgreSqlOptions
-        {
-            ConnectionString = _connectionString,
-            AutoCreateSchema = true,
-            TableName = "concurrency_events_e2e",
-            CommandTimeout = 30,
-            BatchSize = 1000
-        });
-
-        var eventDeserializer = new E2EEventDeserializer();
-        var logger = Substitute.For<ILogger<PostgreSqlEventStore>>();
-        _eventStore = new PostgreSqlEventStore(options, eventDeserializer, logger);
-
-        // Drop and recreate table to ensure clean state with proper constraints
-        using var connection = new Npgsql.NpgsqlConnection(_connectionString);
-        await connection.OpenAsync();
-        await connection.ExecuteAsync($"DROP TABLE IF EXISTS concurrency_events_e2e");
-        await connection.CloseAsync();
-
-        // Initialize schema with proper unique constraints
-        var initResult = await _eventStore.InitializeSchemaAsync();
-        initResult.IsSuccess.Should().BeTrue();
+        _eventStore = new InMemoryStreamingEventStore();
+        return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
-        if (_eventStore != null)
-        {
-            await _eventStore.DisposeAsync();
-        }
-
-        if (_postgres != null)
-        {
-            await _postgres.DisposeAsync();
-        }
+        _eventStore?.Dispose();
+        return Task.CompletedTask;
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task ConcurrentAppends_WithSameExpectedVersion_OnlyOneSucceeds()
     {
         // Arrange
@@ -157,7 +101,7 @@ public sealed class ConcurrencyE2ETests : IAsyncLifetime
         // ✅ Final aggregate version = 2 (no lost updates)
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task ConcurrentAppends_WithRetry_AllEventuallySucceed()
     {
         // Arrange
@@ -239,7 +183,7 @@ public sealed class ConcurrencyE2ETests : IAsyncLifetime
         // ✅ No lost updates
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task HighConcurrency_50ParallelAppends_MaintainsConsistency()
     {
         // Arrange
@@ -315,7 +259,7 @@ public sealed class ConcurrencyE2ETests : IAsyncLifetime
         // ✅ All events present in correct order
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task SequentialAppends_NoConflicts_AllSucceed()
     {
         // Arrange
@@ -353,7 +297,7 @@ public sealed class ConcurrencyE2ETests : IAsyncLifetime
         // ✅ Final version = 11
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task ConcurrentReads_WithConcurrentWrites_ReadsRemainConsistent()
     {
         // Arrange

--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ErrorHandlingE2ETests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ErrorHandlingE2ETests.cs
@@ -5,18 +5,11 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using Compendium.Adapters.PostgreSQL.Configuration;
-using Compendium.Adapters.PostgreSQL.EventStore;
 using Compendium.Core.Results;
-using Compendium.IntegrationTests.EndToEnd.Infrastructure;
+using Compendium.Infrastructure.EventSourcing;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates.ValueObjects;
 using FluentAssertions;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using NSubstitute;
-using Testcontainers.PostgreSql;
-using Compendium.IntegrationTests.Fixtures;
 using Xunit;
 
 namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
@@ -25,72 +18,29 @@ namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
 /// E2E Test Scenario 7: Error Handling and Recovery.
 /// Tests graceful error handling and Result pattern usage across framework components.
 /// </summary>
+/// <remarks>
+/// Per ADR-0007, this framework-behaviour test runs against
+/// <see cref="InMemoryStreamingEventStore"/>.
+/// </remarks>
 [Trait("Category", "E2E")]
 [Trait("Category", "ErrorHandling")]
 public sealed class ErrorHandlingE2ETests : IAsyncLifetime
 {
-    private PostgreSqlContainer? _postgres;
-    private PostgreSqlEventStore? _eventStore;
-    private string _connectionString = null!;
+    private InMemoryStreamingEventStore? _eventStore;
 
-    public async Task InitializeAsync()
+    public Task InitializeAsync()
     {
-        // Use EnvironmentConfigurationHelper for connection string fallback
-        var externalConnectionString = Compendium.IntegrationTests.Infrastructure.EnvironmentConfigurationHelper.GetPostgreSqlConnectionString();
-
-        if (!string.IsNullOrEmpty(externalConnectionString))
-        {
-            _connectionString = externalConnectionString;
-        }
-        else
-        {
-            // Fallback to TestContainers
-            Console.WriteLine("⚠️ Starting TestContainer for PostgreSQL (Error Handling E2E)...");
-            _postgres = new PostgreSqlBuilder()
-                .WithImage("postgres:15-alpine")
-                .WithDatabase("compendium_error_e2e")
-                .WithUsername("test_user")
-                .WithPassword("test_password")
-                .WithCleanUp(true)
-                .Build();
-
-            await _postgres.StartAsync();
-            _connectionString = _postgres.GetConnectionString();
-        }
-
-        // Initialize event store
-        var options = Options.Create(new PostgreSqlOptions
-        {
-            ConnectionString = _connectionString,
-            AutoCreateSchema = true,
-            TableName = "error_handling_events_e2e",
-            CommandTimeout = 30,
-            BatchSize = 1000
-        });
-
-        var eventDeserializer = new E2EEventDeserializer();
-        var logger = Substitute.For<ILogger<PostgreSqlEventStore>>();
-        _eventStore = new PostgreSqlEventStore(options, eventDeserializer, logger);
-
-        // Initialize schema
-        var initResult = await _eventStore.InitializeSchemaAsync();
-        initResult.IsSuccess.Should().BeTrue();
+        _eventStore = new InMemoryStreamingEventStore();
+        return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
-        if (_eventStore != null)
-        {
-            await _eventStore.DisposeAsync();
-        }
-
-        if (_postgres != null)
-        {
-            await _postgres.DisposeAsync();
-        }
+        _eventStore?.Dispose();
+        return Task.CompletedTask;
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task InvalidAggregateCommand_ShouldReturnValidationError()
     {
         // Arrange
@@ -132,7 +82,7 @@ public sealed class ErrorHandlingE2ETests : IAsyncLifetime
         // ✅ Aggregate state unchanged
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task BusinessRuleViolation_ShouldReturnBusinessError()
     {
         // Arrange
@@ -188,7 +138,7 @@ public sealed class ErrorHandlingE2ETests : IAsyncLifetime
         // ✅ System maintains consistency
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task OptimisticConcurrencyViolation_ShouldReturnConflictError()
     {
         // Arrange
@@ -234,7 +184,7 @@ public sealed class ErrorHandlingE2ETests : IAsyncLifetime
         // ✅ Retry with correct version succeeds
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task NonExistentAggregate_ShouldReturnNotFoundError()
     {
         // Arrange

--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/MultiTenancyE2ETests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/MultiTenancyE2ETests.cs
@@ -5,19 +5,11 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using Compendium.Adapters.PostgreSQL.Configuration;
-using Compendium.Adapters.PostgreSQL.EventStore;
-using Compendium.IntegrationTests.EndToEnd.Infrastructure;
+using Compendium.Infrastructure.EventSourcing;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates.ValueObjects;
 using Compendium.Multitenancy;
-using Dapper;
 using FluentAssertions;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using NSubstitute;
-using Testcontainers.PostgreSql;
-using Compendium.IntegrationTests.Fixtures;
 using Xunit;
 
 namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
@@ -26,82 +18,33 @@ namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
 /// E2E Test Scenario 3: Multi-Tenancy Isolation.
 /// Tests complete data isolation between tenants at all layers (event store, projections, queries).
 /// </summary>
+/// <remarks>
+/// Per ADR-0007, this framework-behaviour test runs against
+/// <see cref="InMemoryStreamingEventStore"/>. The tenant-aware stream key
+/// is constructed in the event store itself; this test verifies that
+/// behaviour identically against InMemory.
+/// </remarks>
 [Trait("Category", "E2E")]
 [Trait("Category", "MultiTenancy")]
 public sealed class MultiTenancyE2ETests : IAsyncLifetime
 {
-    private PostgreSqlContainer? _postgres;
-    private PostgreSqlEventStore? _eventStore;
+    private InMemoryStreamingEventStore? _eventStore;
     private TenantContext? _tenantContext;
-    private string _connectionString = null!;
 
-    public async Task InitializeAsync()
+    public Task InitializeAsync()
     {
-        // Use EnvironmentConfigurationHelper for connection string fallback
-        var externalConnectionString = Compendium.IntegrationTests.Infrastructure.EnvironmentConfigurationHelper.GetPostgreSqlConnectionString();
-
-        if (!string.IsNullOrEmpty(externalConnectionString))
-        {
-            _connectionString = externalConnectionString;
-        }
-        else
-        {
-            // Fallback to TestContainers
-            Console.WriteLine("⚠️ Starting TestContainer for PostgreSQL (Multi-Tenancy E2E)...");
-            _postgres = new PostgreSqlBuilder()
-                .WithImage("postgres:15-alpine")
-                .WithDatabase("compendium_multitenant_e2e")
-                .WithUsername("test_user")
-                .WithPassword("test_password")
-                .WithCleanUp(true)
-                .Build();
-
-            await _postgres.StartAsync();
-            _connectionString = _postgres.GetConnectionString();
-        }
-
-        // Initialize tenant context
         _tenantContext = new TenantContext();
-
-        // Initialize event store with multi-tenancy support
-        var options = Options.Create(new PostgreSqlOptions
-        {
-            ConnectionString = _connectionString,
-            AutoCreateSchema = true,
-            TableName = "multitenant_events_e2e",
-            CommandTimeout = 30,
-            BatchSize = 1000
-        });
-
-        var eventDeserializer = new E2EEventDeserializer();
-        var logger = Substitute.For<ILogger<PostgreSqlEventStore>>();
-        _eventStore = new PostgreSqlEventStore(options, eventDeserializer, logger, _tenantContext);
-
-        // Drop and recreate table to ensure clean state with proper constraints
-        using var connection = new Npgsql.NpgsqlConnection(_connectionString);
-        await connection.OpenAsync();
-        await connection.ExecuteAsync($"DROP TABLE IF EXISTS multitenant_events_e2e");
-        await connection.CloseAsync();
-
-        // Initialize schema
-        var initResult = await _eventStore.InitializeSchemaAsync();
-        initResult.IsSuccess.Should().BeTrue();
+        _eventStore = new InMemoryStreamingEventStore(_tenantContext);
+        return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
-        if (_eventStore != null)
-        {
-            await _eventStore.DisposeAsync();
-        }
-
-        if (_postgres != null)
-        {
-            await _postgres.DisposeAsync();
-        }
+        _eventStore?.Dispose();
+        return Task.CompletedTask;
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task TenantIsolation_OrdersCreatedForDifferentTenants_ShouldBeCompletelyIsolated()
     {
         // Arrange
@@ -186,7 +129,7 @@ public sealed class MultiTenancyE2ETests : IAsyncLifetime
         // ✅ Cross-tenant access prevented
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task TenantIsolation_StreamExistsCheck_ShouldRespectTenantBoundaries()
     {
         // Arrange
@@ -223,7 +166,7 @@ public sealed class MultiTenancyE2ETests : IAsyncLifetime
         // ✅ Tenant B cannot see Tenant A's stream
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task TenantIsolation_GetCurrentVersion_ShouldReturnZeroForOtherTenants()
     {
         // Arrange
@@ -260,7 +203,7 @@ public sealed class MultiTenancyE2ETests : IAsyncLifetime
         // ✅ Tenant B sees version 0 for Tenant A's stream
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task TenantIsolation_GetStatistics_ShouldOnlyReturnTenantData()
     {
         // Arrange
@@ -307,7 +250,7 @@ public sealed class MultiTenancyE2ETests : IAsyncLifetime
         // ✅ Each tenant only sees their own data
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task TenantIsolation_OptimisticConcurrency_ShouldWorkWithinTenantContext()
     {
         // Arrange
@@ -350,24 +293,11 @@ public sealed class MultiTenancyE2ETests : IAsyncLifetime
         // ✅ Version conflicts detected correctly
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task TenantIsolation_WithoutTenantContext_ShouldStillWork()
     {
-        // Arrange - Create event store WITHOUT tenant context
-        var options = Options.Create(new PostgreSqlOptions
-        {
-            ConnectionString = _connectionString,
-            AutoCreateSchema = true,
-            TableName = "no_tenant_events_e2e",
-            CommandTimeout = 30,
-            BatchSize = 1000
-        });
-
-        var eventDeserializer = new E2EEventDeserializer();
-        var logger = Substitute.For<ILogger<PostgreSqlEventStore>>();
-        var noTenantEventStore = new PostgreSqlEventStore(options, eventDeserializer, logger, tenantContext: null);
-
-        await noTenantEventStore.InitializeSchemaAsync();
+        // Arrange — create a separate event store WITHOUT tenant context.
+        using var noTenantEventStore = new InMemoryStreamingEventStore(tenantContext: null);
 
         // **Step 1: Create order without tenant context**
         var orderId = OrderId.New();
@@ -386,8 +316,6 @@ public sealed class MultiTenancyE2ETests : IAsyncLifetime
         var statsResult = await noTenantEventStore.GetStatisticsAsync();
         statsResult.IsSuccess.Should().BeTrue();
         statsResult.Value.TotalAggregates.Should().BeGreaterThan(0);
-
-        await noTenantEventStore.DisposeAsync();
 
         // **Expected Results:**
         // ✅ Event store works without tenant context (multi-tenancy is optional)


### PR DESCRIPTION
ADR-0007 plan step 3, batch 2.

Follows the same pattern as #91 (OrderLifecycle). Three more framework-behaviour E2E classes refactored to InMemoryStreamingEventStore:

| File | Tests | Local result |
|---|---|---|
| ConcurrencyE2ETests | 5 | 5/5 ✓ |
| ErrorHandlingE2ETests | 4 | 4/4 ✓ |
| MultiTenancyE2ETests | 6 | 6/6 ✓ |

## Framework fix included

`InMemoryStreamingEventStore.GetStatisticsAsync` now filters by tenant to match `PostgreSqlEventStore` behaviour. Tenant-isolated stats were the one semantic gap caught by the refactor (the PG store already filtered correctly; InMemory was returning globals). This is the kind of gap ADR-0007 expected — surfaced by making the InMemory tests run.

## Remaining E2E refactor work

| File | Status |
|---|---|
| OrderLifecycleE2ETests | done in #91 |
| ConcurrencyE2ETests | **done here** |
| ErrorHandlingE2ETests | **done here** |
| MultiTenancyE2ETests | **done here** |
| LiveProjectionE2ETests | needs InMemoryProjectionStore |
| ProjectionRebuildE2ETests | needs InMemoryProjectionStore |
| ProjectionRebuildEdgeCasesE2ETests | needs InMemoryProjectionStore |
| SagaRetryExhaustionE2ETests | uses shared `_pg` fixture |
| SnapshotMidStreamE2ETests | uses shared `_pg` fixture |
| IdempotencyE2ETests | uses PG + Redis |
| Security/TenantIsolationIntegrationTests | mixed framework + PG-specific |

## Test plan

- [x] `dotnet build` green
- [x] All three E2E suites pass without Docker (15/15)
- [x] InMemoryStreamingEventStore unit tests still pass (11/11)
- [ ] CI green