### PR TITLE
feat(infrastructure): InMemoryProjectionStore

### DIFF
--- a/src/Infrastructure/Compendium.Infrastructure/Projections/InMemoryProjectionStore.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/Projections/InMemoryProjectionStore.cs
@@ -1,0 +1,114 @@
+// -----------------------------------------------------------------------
+// <copyright file="InMemoryProjectionStore.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace Compendium.Infrastructure.Projections;
+
+/// <summary>
+/// In-memory implementation of <see cref="IProjectionStore"/> for testing and
+/// InMemory-backed framework E2E scenarios.
+/// </summary>
+/// <remarks>
+/// Matches <c>PostgreSqlProjectionStore</c> semantics for checkpoint persistence,
+/// snapshot storage, and projection state. Snapshots are round-tripped through
+/// <see cref="JsonSerializer"/> so projection types that already serialize for
+/// PG keep the same shape contract.
+/// </remarks>
+public sealed class InMemoryProjectionStore : IProjectionStore
+{
+    private readonly ConcurrentDictionary<string, long> _checkpoints = new();
+    private readonly ConcurrentDictionary<string, string> _snapshots = new();
+    private readonly ConcurrentDictionary<string, ProjectionState> _states = new();
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+
+    /// <inheritdoc />
+    public Task SaveCheckpointAsync(string projectionName, long position, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectionName);
+        _checkpoints[projectionName] = position;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<long?> GetCheckpointAsync(string projectionName, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectionName);
+        return Task.FromResult(_checkpoints.TryGetValue(projectionName, out var pos) ? pos : (long?)null);
+    }
+
+    /// <inheritdoc />
+    public Task SaveSnapshotAsync<TProjection>(TProjection projection, CancellationToken cancellationToken = default)
+        where TProjection : IProjection
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projection.ProjectionName);
+
+        var json = JsonSerializer.Serialize(projection, projection.GetType(), _jsonOptions);
+        _snapshots[projection.ProjectionName] = json;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<TProjection?> LoadSnapshotAsync<TProjection>(
+        string projectionName,
+        CancellationToken cancellationToken = default)
+        where TProjection : IProjection
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectionName);
+
+        if (!_snapshots.TryGetValue(projectionName, out var json))
+        {
+            return Task.FromResult<TProjection?>(default);
+        }
+
+        var snapshot = JsonSerializer.Deserialize<TProjection>(json, _jsonOptions);
+        return Task.FromResult(snapshot);
+    }
+
+    /// <inheritdoc />
+    public Task DeleteProjectionDataAsync(string projectionName, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectionName);
+
+        _checkpoints.TryRemove(projectionName, out _);
+        _snapshots.TryRemove(projectionName, out _);
+        _states.TryRemove(projectionName, out _);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<ProjectionState?> GetProjectionStateAsync(
+        string projectionName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectionName);
+        return Task.FromResult(_states.TryGetValue(projectionName, out var state) ? state : null);
+    }
+
+    /// <inheritdoc />
+    public Task SaveProjectionStateAsync(ProjectionState state, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(state.ProjectionName);
+
+        _states[state.ProjectionName] = state;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Clears all stored projection data. Test-only helper.</summary>
+    public void Clear()
+    {
+        _checkpoints.Clear();
+        _snapshots.Clear();
+        _states.Clear();
+    }
+}

--- a/tests/Unit/Compendium.Infrastructure.Tests/Projections/InMemoryProjectionStoreTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Projections/InMemoryProjectionStoreTests.cs
@@ -1,0 +1,132 @@
+// -----------------------------------------------------------------------
+// <copyright file="InMemoryProjectionStoreTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Infrastructure.Projections;
+using FluentAssertions;
+
+namespace Compendium.Infrastructure.Tests.Projections;
+
+public sealed class InMemoryProjectionStoreTests
+{
+    private readonly InMemoryProjectionStore _sut = new();
+
+    [Fact]
+    public async Task GetCheckpoint_WhenMissing_ReturnsNull()
+    {
+        var result = await _sut.GetCheckpointAsync("p-1");
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SaveCheckpoint_ThenGet_ReturnsValue()
+    {
+        await _sut.SaveCheckpointAsync("p-1", 42);
+        var result = await _sut.GetCheckpointAsync("p-1");
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task SaveCheckpoint_Overwrites()
+    {
+        await _sut.SaveCheckpointAsync("p-1", 10);
+        await _sut.SaveCheckpointAsync("p-1", 99);
+        var result = await _sut.GetCheckpointAsync("p-1");
+        result.Should().Be(99);
+    }
+
+    [Fact]
+    public async Task GetProjectionState_WhenMissing_ReturnsNull()
+    {
+        var result = await _sut.GetProjectionStateAsync("p-1");
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SaveProjectionState_ThenGet_ReturnsSameInstance()
+    {
+        var state = new ProjectionState
+        {
+            ProjectionName = "p-1",
+            Version = 2,
+            LastProcessedPosition = 17,
+            LastProcessedAt = DateTime.UtcNow,
+        };
+
+        await _sut.SaveProjectionStateAsync(state);
+        var result = await _sut.GetProjectionStateAsync("p-1");
+
+        result.Should().NotBeNull();
+        result!.ProjectionName.Should().Be("p-1");
+        result.Version.Should().Be(2);
+        result.LastProcessedPosition.Should().Be(17);
+    }
+
+    [Fact]
+    public async Task SaveSnapshot_ThenLoad_RoundtripsThroughJson()
+    {
+        var projection = new TestProjection { ProjectionName = "p-snap", Version = 1, Counter = 42 };
+        await _sut.SaveSnapshotAsync(projection);
+
+        var loaded = await _sut.LoadSnapshotAsync<TestProjection>("p-snap");
+
+        loaded.Should().NotBeNull();
+        loaded!.ProjectionName.Should().Be("p-snap");
+        loaded.Counter.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task LoadSnapshot_WhenMissing_ReturnsDefault()
+    {
+        var loaded = await _sut.LoadSnapshotAsync<TestProjection>("missing");
+        loaded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteProjectionData_RemovesAllArtifacts()
+    {
+        await _sut.SaveCheckpointAsync("p-1", 10);
+        await _sut.SaveSnapshotAsync(new TestProjection { ProjectionName = "p-1", Counter = 5 });
+        await _sut.SaveProjectionStateAsync(new ProjectionState { ProjectionName = "p-1" });
+
+        await _sut.DeleteProjectionDataAsync("p-1");
+
+        (await _sut.GetCheckpointAsync("p-1")).Should().BeNull();
+        (await _sut.LoadSnapshotAsync<TestProjection>("p-1")).Should().BeNull();
+        (await _sut.GetProjectionStateAsync("p-1")).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ProjectionName_NullOrWhitespace_Throws(string? name)
+    {
+        var act1 = () => _sut.GetCheckpointAsync(name!);
+        var act2 = () => _sut.SaveCheckpointAsync(name!, 0);
+        var act3 = () => _sut.LoadSnapshotAsync<TestProjection>(name!);
+        var act4 = () => _sut.DeleteProjectionDataAsync(name!);
+
+        await act1.Should().ThrowAsync<ArgumentException>();
+        await act2.Should().ThrowAsync<ArgumentException>();
+        await act3.Should().ThrowAsync<ArgumentException>();
+        await act4.Should().ThrowAsync<ArgumentException>();
+    }
+
+    public sealed class TestProjection : Compendium.Infrastructure.Projections.IProjection
+    {
+        public string ProjectionName { get; set; } = "test";
+
+        public int Version { get; set; } = 1;
+
+        public int Counter { get; set; }
+
+        public Task ResetAsync(CancellationToken cancellationToken = default)
+        {
+            Counter = 0;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
ADR-0007 prep step. Adds InMemoryProjectionStore so projection-based E2E tests can run without Postgres.

## What

- `InMemoryProjectionStore.cs` (~110 LOC): implements `IProjectionStore` (checkpoint + snapshot + state)
- 11 unit tests covering all 6 contract methods + key validation

## Why deferred refactor of LiveProjection E2Es

First attempt at refactoring `LiveProjectionE2ETests` to use this new store surfaced a behaviour gap: the projection sees more events than expected (e.g. LineCount=5 vs expected 1). This points to either a checkpoint-read interaction in `LiveProjectionProcessor` or a stream-position semantic difference in `InMemoryStreamingEventStore.StreamEventsAsync`. Needs deeper investigation — not in scope for this PR.

The 2 LiveProjection tests that DID pass on the InMem stack: `LiveProcessor_GracefulShutdown_SavesCheckpoint`, `LiveProcessor_StartStop_CanRestart`. So basic lifecycle works — it's the event-replay positioning that needs the investigation.

## Test plan

- [x] Build green
- [x] 11/11 unit tests pass
- [ ] CI green