### PR TITLE
fix(infrastructure): StreamEventsAsync.fromPosition is exclusive

### DIFF
--- a/src/Infrastructure/Compendium.Infrastructure/EventSourcing/InMemoryStreamingEventStore.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/EventSourcing/InMemoryStreamingEventStore.cs
@@ -281,7 +281,7 @@ public sealed class InMemoryStreamingEventStore : IStreamingEventStore, IDisposa
         _lock.EnterReadLock();
         try
         {
-            snapshot = _globalLog.Where(e => e.GlobalPosition >= fromPosition).ToList();
+            snapshot = _globalLog.Where(e => e.GlobalPosition > fromPosition).ToList();
         }
         finally
         {

--- a/src/Infrastructure/Compendium.Infrastructure/Projections/IStreamingEventStore.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/Projections/IStreamingEventStore.cs
@@ -19,7 +19,7 @@ public interface IStreamingEventStore : IEventStore
     /// Used for projection rebuilds and live processing.
     /// </summary>
     /// <param name="streamId">Optional stream identifier to filter by specific stream.</param>
-    /// <param name="fromPosition">The global position to start from (inclusive).</param>
+    /// <param name="fromPosition">The global position to start from (exclusive — events with positions <c>&gt; fromPosition</c> are yielded).</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>An async enumerable of event data with metadata.</returns>
     IAsyncEnumerable<EventData> StreamEventsAsync(

--- a/tests/Unit/Compendium.Infrastructure.Tests/EventSourcing/InMemoryStreamingEventStoreTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/EventSourcing/InMemoryStreamingEventStoreTests.cs
@@ -75,8 +75,9 @@ public sealed class InMemoryStreamingEventStoreTests
     }
 
     [Fact]
-    public async Task StreamEvents_FromPosition_SkipsEarlierEvents()
+    public async Task StreamEvents_FromPosition_IsExclusive()
     {
+        // Append events at global positions 1, 2, 3.
         await _sut.AppendEventsAsync("agg-1", new[] { NewEvent("agg-1", "Order", 1) }, 0);
         await _sut.AppendEventsAsync("agg-1", new[] { NewEvent("agg-1", "Order", 2) }, 1);
         await _sut.AppendEventsAsync("agg-1", new[] { NewEvent("agg-1", "Order", 3) }, 2);
@@ -87,8 +88,12 @@ public sealed class InMemoryStreamingEventStoreTests
             streamed.Add(ed);
         }
 
-        streamed.Should().HaveCount(2);  // Global positions 2 and 3.
-        streamed.Select(e => e.GlobalPosition).Should().BeEquivalentTo(new long[] { 2, 3 });
+        // Exclusive on fromPosition: only events with GlobalPosition > 2 are yielded.
+        // This matches the SQL `WHERE global_position > @FromPosition` in
+        // PostgreSqlStreamingEventStore — without exclusive semantics,
+        // LiveProjectionProcessor would re-process the checkpoint event on every poll.
+        streamed.Should().HaveCount(1);
+        streamed.Select(e => e.GlobalPosition).Should().BeEquivalentTo(new long[] { 3 });
     }
 
     [Fact]


### PR DESCRIPTION
Surgical fix discovered when wiring \`LiveProjectionProcessor\` through \`InMemoryStreamingEventStore\` in #93's follow-up.

## What

\`InMemoryStreamingEventStore.StreamEventsAsync\` was using \`>= fromPosition\` (inclusive). The actual contract — honoured by \`PostgreSqlStreamingEventStore\` (SQL \`WHERE global_position > @FromPosition\`) — is exclusive. Result: every poll cycle of \`LiveProjectionProcessor\` re-yielded the last-processed event, projections double-counted.

This was the root cause of two failing tests in the WIP refactor of LiveProjectionE2ETests:
- \`LiveProcessor_UpdatesProjectionInRealTime_WithinLatencyTarget\` — expected LineCount=3, got 4
- \`LiveProcessor_ProcessesMultipleOrders_Concurrently\` — expected LineCount=1, got 5

## Changes

- \`InMemoryStreamingEventStore.cs\`: \`>=\` → \`>\` (1-char fix)
- \`IStreamingEventStore.cs\`: docstring corrected from "inclusive" to "exclusive" (matching the actual PG behaviour and what consumers depend on)
- \`InMemoryStreamingEventStoreTests.cs\`: existing test renamed to \`StreamEvents_FromPosition_IsExclusive\` with self-documenting assertion + rationale comment

## Test plan

- [x] All 11 InMemoryStreamingEventStore unit tests pass
- [x] Framework build clean
- [ ] CI green
- [ ] Followup PR (Blocker 2) will refactor LiveProjection E2Es and verify they now pass with this fix

Part of the ADR-0007 closeout. Blocker 1 of 7.