### PR TITLE
refactor(integration): 3 projection E2Es run on InMemory

### DIFF
--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/LiveProjectionE2ETests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/LiveProjectionE2ETests.cs
@@ -5,23 +5,15 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System.Diagnostics;
-using Compendium.Adapters.PostgreSQL.Configuration;
-using Compendium.Adapters.PostgreSQL.EventStore;
-using Compendium.Adapters.PostgreSQL.Projections;
-using Compendium.Core.EventSourcing;
+using Compendium.Infrastructure.EventSourcing;
 using Compendium.Infrastructure.Projections;
-using Compendium.IntegrationTests.EndToEnd.Infrastructure;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates.ValueObjects;
 using Compendium.IntegrationTests.EndToEnd.TestProjections;
-using Dapper;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Testcontainers.PostgreSql;
-using Compendium.IntegrationTests.Fixtures;
 using Xunit;
 
 namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
@@ -34,102 +26,45 @@ namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
 [Trait("Category", "LiveProjection")]
 public sealed class LiveProjectionE2ETests : IAsyncLifetime
 {
-    private PostgreSqlContainer? _postgres;
-    private PostgreSqlEventStore? _eventStore;
-    private PostgreSqlStreamingEventStore? _streamingEventStore;
-    private PostgreSqlProjectionStore? _projectionStore;
+    private InMemoryStreamingEventStore? _eventStore;
+    private InMemoryProjectionStore? _projectionStore;
     private LiveProjectionProcessor? _liveProcessor;
-    private string _connectionString = null!;
+    private ServiceProvider? _provider;
 
-    public async Task InitializeAsync()
+    public Task InitializeAsync()
     {
-        // Use EnvironmentConfigurationHelper for connection string fallback
-        var externalConnectionString = Compendium.IntegrationTests.Infrastructure.EnvironmentConfigurationHelper.GetPostgreSqlConnectionString();
-
-        if (!string.IsNullOrEmpty(externalConnectionString))
-        {
-            _connectionString = externalConnectionString;
-        }
-        else
-        {
-            // Fallback to TestContainers
-            Console.WriteLine("⚠️ Starting TestContainer for PostgreSQL (Live Projection E2E)...");
-            _postgres = new PostgreSqlBuilder()
-                .WithImage("postgres:15-alpine")
-                .WithDatabase("compendium_live_projection_e2e")
-                .WithUsername("test_user")
-                .WithPassword("test_password")
-                .WithCleanUp(true)
-                .Build();
-
-            await _postgres.StartAsync();
-            _connectionString = _postgres.GetConnectionString();
-        }
-
-        // Set up dependency injection
         var services = new ServiceCollection();
-        services.AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Information));
+        services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning));
 
-        // Configure PostgreSQL options
-        services.Configure<PostgreSqlOptions>(options =>
-        {
-            options.ConnectionString = _connectionString;
-            options.TableName = "live_projection_events_e2e";
-            options.AutoCreateSchema = true;
-            options.BatchSize = 1000;
-        });
-
-        // Configure projection options
         services.Configure<ProjectionOptions>(options =>
         {
             options.RebuildBatchSize = 100;
             options.MaxConcurrentRebuilds = 2;
             options.ProgressReportInterval = 50;
-            options.EnableSnapshots = false; // Disable for clearer testing
+            options.EnableSnapshots = false;
             options.SnapshotInterval = TimeSpan.FromHours(1);
         });
 
-        // Register services
-        var eventDeserializer = new E2EEventDeserializer();
-        services.AddSingleton<IEventDeserializer>(eventDeserializer);
-        services.AddSingleton<PostgreSqlEventStore>();
-        services.AddSingleton<IStreamingEventStore, PostgreSqlStreamingEventStore>();
-        services.AddSingleton<IProjectionStore, PostgreSqlProjectionStore>();
+        _eventStore = new InMemoryStreamingEventStore();
+        _projectionStore = new InMemoryProjectionStore();
 
-        // Projections must be DI-registered so the manager can resolve them
+        services.AddSingleton(_eventStore);
+        services.AddSingleton<IStreamingEventStore>(_eventStore);
+        services.AddSingleton<IProjectionStore>(_projectionStore);
         services.AddSingleton<OrderSummaryProjection>();
 
-        var provider = services.BuildServiceProvider();
+        _provider = services.BuildServiceProvider();
 
-        _eventStore = provider.GetRequiredService<PostgreSqlEventStore>();
-        _streamingEventStore = (PostgreSqlStreamingEventStore)provider.GetRequiredService<IStreamingEventStore>();
-        _projectionStore = (PostgreSqlProjectionStore)provider.GetRequiredService<IProjectionStore>();
-
-        // Drop and recreate tables to ensure clean state with proper constraints
-        using var connection = new Npgsql.NpgsqlConnection(_connectionString);
-        await connection.OpenAsync();
-        await connection.ExecuteAsync($"DROP TABLE IF EXISTS live_projection_events_e2e");
-        await connection.ExecuteAsync($"DROP TABLE IF EXISTS projection_checkpoints");
-        await connection.CloseAsync();
-
-        // Initialize schemas
-        var initResult = await _eventStore.InitializeSchemaAsync();
-        initResult.IsSuccess.Should().BeTrue();
-
-        var streamInitResult = await _streamingEventStore.InitializeSchemaAsync();
-        streamInitResult.IsSuccess.Should().BeTrue();
-
-        await _projectionStore.InitializeAsync();
-
-        // Create LiveProjectionProcessor manually (not as a hosted service)
-        var logger = provider.GetRequiredService<ILogger<LiveProjectionProcessor>>();
-        var projectionOptions = provider.GetRequiredService<IOptions<ProjectionOptions>>();
+        var logger = _provider.GetRequiredService<ILogger<LiveProjectionProcessor>>();
+        var projectionOptions = _provider.GetRequiredService<IOptions<ProjectionOptions>>();
         _liveProcessor = new LiveProjectionProcessor(
-            _streamingEventStore,
+            _eventStore,
             _projectionStore,
-            provider,
+            _provider,
             logger,
             projectionOptions);
+
+        return Task.CompletedTask;
     }
 
     public async Task DisposeAsync()
@@ -139,13 +74,11 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
             await _liveProcessor.StopAsync(CancellationToken.None);
         }
 
-        if (_postgres != null)
-        {
-            await _postgres.DisposeAsync();
-        }
+        _eventStore?.Dispose();
+        _provider?.Dispose();
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task LiveProcessor_UpdatesProjectionInRealTime_WithinLatencyTarget()
     {
         // Arrange
@@ -163,14 +96,10 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
         var order = OrderAggregate.PlaceOrder(orderId, customerId, DateTimeOffset.UtcNow);
         var placeEvents = order.DomainEvents.ToList();
         order.ClearDomainEvents();
-
-        var sw1 = Stopwatch.StartNew();
         await _eventStore!.AppendEventsAsync(orderId.ToString(), placeEvents, 0);
 
         // Wait for live processor to pick up event (polling interval + processing time)
         await Task.Delay(300); // 100ms poll + 200ms buffer
-        sw1.Stop();
-
         // Query projection state
         var projection1 = GetProjectionInstance();
         var summary1 = projection1.GetOrderSummary(orderId.ToString());
@@ -180,10 +109,6 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
         summary1.CustomerId.Should().Be(customerId);
         summary1.Status.Should().Be("Created");
         summary1.LineCount.Should().Be(0);
-
-        Console.WriteLine($"Event 1 latency: {sw1.ElapsedMilliseconds}ms");
-        sw1.ElapsedMilliseconds.Should().BeLessThan(500, "OrderPlaced event should be processed within 500ms");
-
         // **Step 2: Add order lines and verify real-time updates**
         order.AddOrderLine("line-1", "product-A", 2, 25.00m);
         order.AddOrderLine("line-2", "product-B", 1, 50.00m);
@@ -191,14 +116,10 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
 
         var lineEvents = order.DomainEvents.ToList();
         order.ClearDomainEvents();
-
-        var sw2 = Stopwatch.StartNew();
         await _eventStore.AppendEventsAsync(orderId.ToString(), lineEvents, 1);
 
         // Wait for live processor
         await Task.Delay(300);
-        sw2.Stop();
-
         // Query updated projection
         var projection2 = GetProjectionInstance();
         var summary2 = projection2.GetOrderSummary(orderId.ToString());
@@ -206,24 +127,16 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
         summary2.Should().NotBeNull();
         summary2!.LineCount.Should().Be(3, "All 3 order lines should be reflected");
         summary2.TotalAmount.Should().Be((2 * 25.00m) + (1 * 50.00m) + (3 * 10.00m));
-
-        Console.WriteLine($"Events 2-4 latency: {sw2.ElapsedMilliseconds}ms");
-        sw2.ElapsedMilliseconds.Should().BeLessThan(500, "OrderLineAdded events should be processed within 500ms");
-
         // **Step 3: Complete order and verify final state**
         var completeResult = order.Complete(DateTimeOffset.UtcNow);
         completeResult.IsSuccess.Should().BeTrue();
 
         var completeEvents = order.DomainEvents.ToList();
         order.ClearDomainEvents();
-
-        var sw3 = Stopwatch.StartNew();
         await _eventStore.AppendEventsAsync(orderId.ToString(), completeEvents, 4);
 
         // Wait for live processor
         await Task.Delay(300);
-        sw3.Stop();
-
         // Query final projection state
         var projection3 = GetProjectionInstance();
         var summary3 = projection3.GetOrderSummary(orderId.ToString());
@@ -231,10 +144,6 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
         summary3.Should().NotBeNull();
         summary3!.Status.Should().Be("Completed");
         summary3.CompletedAt.Should().NotBeNull();
-
-        Console.WriteLine($"Event 5 latency: {sw3.ElapsedMilliseconds}ms");
-        sw3.ElapsedMilliseconds.Should().BeLessThan(500, "OrderCompleted event should be processed within 500ms");
-
         // **Step 4: Verify processor status**
         var status = _liveProcessor.GetStatus();
         status.IsRunning.Should().BeTrue();
@@ -248,7 +157,7 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
         // ✅ Final state matches expectations
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task LiveProcessor_ProcessesMultipleOrders_Concurrently()
     {
         // Arrange
@@ -274,14 +183,10 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
 
             appendTasks.Add(_eventStore!.AppendEventsAsync(orderId.ToString(), events, 0));
         }
-
-        var sw = Stopwatch.StartNew();
         await Task.WhenAll(appendTasks);
 
         // Wait for live processor to catch up
         await Task.Delay(500);
-        sw.Stop();
-
         // **Step 2: Verify all orders processed**
         var projection = GetProjectionInstance();
 
@@ -291,9 +196,6 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
             summary.Should().NotBeNull($"Order {orderId} should be processed");
             summary!.LineCount.Should().Be(1);
         }
-
-        Console.WriteLine($"5 concurrent orders processed in {sw.ElapsedMilliseconds}ms");
-
         // **Step 3: Verify processor statistics**
         var status = _liveProcessor.GetStatus();
         status.TotalEventsProcessed.Should().BeGreaterOrEqualTo(10, "At least 10 events (5 orders x 2 events each)");
@@ -304,7 +206,7 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
         // ✅ No events missed
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task LiveProcessor_GracefulShutdown_SavesCheckpoint()
     {
         // Arrange
@@ -349,7 +251,7 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
         // ✅ Processor stopped gracefully
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task LiveProcessor_StartStop_CanRestart()
     {
         // Arrange
@@ -406,7 +308,7 @@ public sealed class LiveProjectionE2ETests : IAsyncLifetime
             .GetField("_liveProjections", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
         var liveProjections = liveProjectionsField!.GetValue(_liveProcessor)
-            as System.Collections.Concurrent.ConcurrentDictionary<string, IProjection>;
+            as System.Collections.Concurrent.ConcurrentDictionary<string, Compendium.Infrastructure.Projections.IProjection>;
 
         if (liveProjections!.TryGetValue("E2E_OrderSummary", out var projection))
         {

--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ProjectionRebuildE2ETests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ProjectionRebuildE2ETests.cs
@@ -5,23 +5,15 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System.Diagnostics;
-using Compendium.Adapters.PostgreSQL.Configuration;
-using Compendium.Adapters.PostgreSQL.EventStore;
-using Compendium.Adapters.PostgreSQL.Projections;
 using Compendium.Core.Domain.Events;
-using Compendium.Core.EventSourcing;
+using Compendium.Infrastructure.EventSourcing;
 using Compendium.Infrastructure.Projections;
-using Compendium.IntegrationTests.EndToEnd.Infrastructure;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates.ValueObjects;
 using Compendium.IntegrationTests.EndToEnd.TestProjections;
-using Dapper;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Testcontainers.PostgreSql;
-using Compendium.IntegrationTests.Fixtures;
 using Xunit;
 
 namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
@@ -31,108 +23,50 @@ namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
 /// Tests projection rebuild from large event streams with performance monitoring.
 /// </summary>
 [Trait("Category", "E2E")]
-[Trait("Category", "Performance")]
 public sealed class ProjectionRebuildE2ETests : IAsyncLifetime
 {
-    private PostgreSqlContainer? _postgres;
-    private PostgreSqlEventStore? _eventStore;
-    private PostgreSqlStreamingEventStore? _streamingEventStore;
-    private PostgreSqlProjectionStore? _projectionStore;
-    private IProjectionManager? _projectionManager;
-    private string _connectionString = null!;
+    private InMemoryStreamingEventStore? _eventStore;
+    private InMemoryProjectionStore? _projectionStore;
+    private Compendium.Infrastructure.Projections.IProjectionManager? _projectionManager;
+    private ServiceProvider? _provider;
 
-    public async Task InitializeAsync()
+    public Task InitializeAsync()
     {
-        // Use EnvironmentConfigurationHelper for connection string fallback
-        var externalConnectionString = Compendium.IntegrationTests.Infrastructure.EnvironmentConfigurationHelper.GetPostgreSqlConnectionString();
-
-        if (!string.IsNullOrEmpty(externalConnectionString))
-        {
-            _connectionString = externalConnectionString;
-        }
-        else
-        {
-            // Fallback to TestContainers
-            Console.WriteLine("⚠️ Starting TestContainer for PostgreSQL (Projection E2E)...");
-            _postgres = new PostgreSqlBuilder()
-                .WithImage("postgres:15-alpine")
-                .WithDatabase("compendium_projection_e2e")
-                .WithUsername("test_user")
-                .WithPassword("test_password")
-                .WithCleanUp(true)
-                .Build();
-
-            await _postgres.StartAsync();
-            _connectionString = _postgres.GetConnectionString();
-        }
-
-        // Set up dependency injection
         var services = new ServiceCollection();
-        services.AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Information));
+        services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning));
 
-        // Configure PostgreSQL options
-        services.Configure<PostgreSqlOptions>(options =>
-        {
-            options.ConnectionString = _connectionString;
-            options.TableName = "projection_events_e2e";
-            options.AutoCreateSchema = true;
-            options.BatchSize = 1000;
-        });
-
-        // Configure projection options
         services.Configure<ProjectionOptions>(options =>
         {
             options.RebuildBatchSize = 100;
             options.MaxConcurrentRebuilds = 2;
-            options.ProgressReportInterval = 10; // Report every 10 events for testing
-            options.EnableSnapshots = false; // Disable for clearer testing
+            options.ProgressReportInterval = 10;
+            options.EnableSnapshots = false;
             options.SnapshotInterval = TimeSpan.FromHours(1);
         });
 
-        // Register services
-        var eventDeserializer = new E2EEventDeserializer();
-        services.AddSingleton<IEventDeserializer>(eventDeserializer);
-        services.AddSingleton<PostgreSqlEventStore>();
-        services.AddSingleton<IStreamingEventStore, PostgreSqlStreamingEventStore>();
-        services.AddSingleton<IProjectionStore, PostgreSqlProjectionStore>();
-        services.AddSingleton<IProjectionManager, EnhancedProjectionManager>();
+        _eventStore = new InMemoryStreamingEventStore();
+        _projectionStore = new InMemoryProjectionStore();
 
-        // Projections must be DI-registered so the manager can resolve them
+        services.AddSingleton(_eventStore);
+        services.AddSingleton<IStreamingEventStore>(_eventStore);
+        services.AddSingleton<IProjectionStore>(_projectionStore);
+        services.AddSingleton<Compendium.Infrastructure.Projections.IProjectionManager, EnhancedProjectionManager>();
         services.AddSingleton<OrderSummaryProjection>();
 
-        var provider = services.BuildServiceProvider();
+        _provider = services.BuildServiceProvider();
+        _projectionManager = _provider.GetRequiredService<Compendium.Infrastructure.Projections.IProjectionManager>();
 
-        _eventStore = provider.GetRequiredService<PostgreSqlEventStore>();
-        _streamingEventStore = (PostgreSqlStreamingEventStore)provider.GetRequiredService<IStreamingEventStore>();
-        _projectionStore = (PostgreSqlProjectionStore)provider.GetRequiredService<IProjectionStore>();
-        _projectionManager = provider.GetRequiredService<IProjectionManager>();
-
-        // Drop and recreate tables to ensure clean state with proper constraints
-        using var connection = new Npgsql.NpgsqlConnection(_connectionString);
-        await connection.OpenAsync();
-        await connection.ExecuteAsync($"DROP TABLE IF EXISTS projection_events_e2e");
-        await connection.ExecuteAsync($"DROP TABLE IF EXISTS projection_checkpoints");
-        await connection.CloseAsync();
-
-        // Initialize schemas
-        var initResult = await _eventStore.InitializeSchemaAsync();
-        initResult.IsSuccess.Should().BeTrue();
-
-        var streamInitResult = await _streamingEventStore.InitializeSchemaAsync();
-        streamInitResult.IsSuccess.Should().BeTrue();
-
-        await _projectionStore.InitializeAsync();
+        return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
-        if (_postgres != null)
-        {
-            await _postgres.DisposeAsync();
-        }
+        _eventStore?.Dispose();
+        _provider?.Dispose();
+        return Task.CompletedTask;
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task RebuildProjection_From1000Events_CompletesSuccessfully()
     {
         // Arrange
@@ -184,11 +118,9 @@ public sealed class ProjectionRebuildE2ETests : IAsyncLifetime
         var progress = new Progress<RebuildProgress>(report => progressReports.Add(report));
 
         // Act
-        var stopwatch = Stopwatch.StartNew();
         await _projectionManager.RebuildProjectionAsync<OrderSummaryProjection>(
             streamId: orderId.ToString(),
             progress: progress);
-        stopwatch.Stop();
 
         // Assert - Verify projection state
         var projectionState = await _projectionManager.GetProjectionStateAsync("E2E_OrderSummary");
@@ -201,12 +133,7 @@ public sealed class ProjectionRebuildE2ETests : IAsyncLifetime
         lastReport.ProcessedEvents.Should().Be(1000);
         lastReport.PercentComplete.Should().BeApproximately(100, 0.1);
 
-        // Performance: Should meet 10k events/minute target
-        var eventsPerMinute = eventCount * 60.0 / stopwatch.Elapsed.TotalSeconds;
-        Console.WriteLine($"Rebuilt projection from {eventCount} events in {stopwatch.Elapsed.TotalSeconds:F2}s ({eventsPerMinute:F0} events/min)");
-
-        eventsPerMinute.Should().BeGreaterThan(10000,
-            "Projection rebuild should process at least 10,000 events/minute");
+        // Performance benchmarks live in tests/Perf/Compendium.Infrastructure.PerfTests.
 
         // **Expected Results:**
         // ✅ Projection rebuilt from 1000 events
@@ -215,7 +142,7 @@ public sealed class ProjectionRebuildE2ETests : IAsyncLifetime
         // ✅ Final projection state correct
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task RebuildProjection_WithMultipleOrders_AggregatesCorrectly()
     {
         // Arrange
@@ -263,7 +190,7 @@ public sealed class ProjectionRebuildE2ETests : IAsyncLifetime
         // ✅ Statistics show all events processed
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task ProjectionWithCheckpoint_ResumesFromLastPosition()
     {
         // Arrange
@@ -311,7 +238,7 @@ public sealed class ProjectionRebuildE2ETests : IAsyncLifetime
         // ✅ Final state shows completed
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task CompleteOrderLifecycle_WithProjectionRebuild_QueriesSucceed()
     {
         // Arrange

--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ProjectionRebuildEdgeCasesE2ETests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/ProjectionRebuildEdgeCasesE2ETests.cs
@@ -5,21 +5,14 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using Compendium.Adapters.PostgreSQL.Configuration;
-using Compendium.Adapters.PostgreSQL.EventStore;
-using Compendium.Adapters.PostgreSQL.Projections;
-using Compendium.Core.EventSourcing;
+using Compendium.Infrastructure.EventSourcing;
 using Compendium.Infrastructure.Projections;
-using Compendium.IntegrationTests.EndToEnd.Infrastructure;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates.ValueObjects;
 using Compendium.IntegrationTests.EndToEnd.TestProjections;
-using Compendium.IntegrationTests.Fixtures;
-using Dapper;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Npgsql;
 using Xunit;
 
 namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
@@ -43,38 +36,17 @@ namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
 /// </list>
 /// </summary>
 [Trait("Category", "E2E")]
-[Trait("Category", "Performance")]
-public sealed class ProjectionRebuildEdgeCasesE2ETests : IClassFixture<PostgreSqlFixture>, IAsyncLifetime
+public sealed class ProjectionRebuildEdgeCasesE2ETests : IAsyncLifetime
 {
-    private readonly PostgreSqlFixture _pg;
-    private PostgreSqlEventStore _eventStore = null!;
-    private PostgreSqlStreamingEventStore _streamingEventStore = null!;
-    private PostgreSqlProjectionStore _projectionStore = null!;
-    private IProjectionManager _projectionManager = null!;
-    private const string TableName = "rebuild_edges_events";
+    private InMemoryStreamingEventStore _eventStore = null!;
+    private InMemoryProjectionStore _projectionStore = null!;
+    private Compendium.Infrastructure.Projections.IProjectionManager _projectionManager = null!;
+    private ServiceProvider _provider = null!;
 
-    public ProjectionRebuildEdgeCasesE2ETests(PostgreSqlFixture pg)
+    public Task InitializeAsync()
     {
-        _pg = pg;
-    }
-
-    public async Task InitializeAsync()
-    {
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
-
         var services = new ServiceCollection();
-        services.AddLogging(builder => builder.AddDebug().SetMinimumLevel(LogLevel.Warning));
-
-        services.Configure<PostgreSqlOptions>(o =>
-        {
-            o.ConnectionString = _pg.ConnectionString;
-            o.TableName = TableName;
-            o.AutoCreateSchema = true;
-            o.BatchSize = 1000;
-        });
+        services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning));
 
         services.Configure<ProjectionOptions>(o =>
         {
@@ -84,46 +56,32 @@ public sealed class ProjectionRebuildEdgeCasesE2ETests : IClassFixture<PostgreSq
             o.EnableSnapshots = false;
         });
 
-        services.AddSingleton<IEventDeserializer>(new E2EEventDeserializer());
-        services.AddSingleton<PostgreSqlEventStore>();
-        services.AddSingleton<IStreamingEventStore, PostgreSqlStreamingEventStore>();
-        services.AddSingleton<IProjectionStore, PostgreSqlProjectionStore>();
-        services.AddSingleton<IProjectionManager, EnhancedProjectionManager>();
+        _eventStore = new InMemoryStreamingEventStore();
+        _projectionStore = new InMemoryProjectionStore();
+
+        services.AddSingleton(_eventStore);
+        services.AddSingleton<IStreamingEventStore>(_eventStore);
+        services.AddSingleton<IProjectionStore>(_projectionStore);
+        services.AddSingleton<Compendium.Infrastructure.Projections.IProjectionManager, EnhancedProjectionManager>();
         services.AddSingleton<OrderSummaryProjection>();
 
-        var provider = services.BuildServiceProvider();
-        _eventStore = provider.GetRequiredService<PostgreSqlEventStore>();
-        _streamingEventStore = (PostgreSqlStreamingEventStore)provider.GetRequiredService<IStreamingEventStore>();
-        _projectionStore = (PostgreSqlProjectionStore)provider.GetRequiredService<IProjectionStore>();
-        _projectionManager = provider.GetRequiredService<IProjectionManager>();
+        _provider = services.BuildServiceProvider();
+        _projectionManager = _provider.GetRequiredService<Compendium.Infrastructure.Projections.IProjectionManager>();
 
-        // Drop projection metadata so each test starts from a clean slate. We keep the
-        // event-store table because the per-test orderIds are unique guids, so a shared
-        // table is safe and faster than DDL on every run.
-        await using var connection = new NpgsqlConnection(_pg.ConnectionString);
-        await connection.OpenAsync();
-        await connection.ExecuteAsync($"DROP TABLE IF EXISTS {TableName}");
-        await connection.ExecuteAsync("DROP TABLE IF EXISTS projection_checkpoints");
-        await connection.ExecuteAsync("DROP TABLE IF EXISTS projection_states");
-        await connection.ExecuteAsync("DROP TABLE IF EXISTS projection_snapshots");
-
-        var initEvents = await _eventStore.InitializeSchemaAsync();
-        initEvents.IsSuccess.Should().BeTrue();
-        var initStream = await _streamingEventStore.InitializeSchemaAsync();
-        initStream.IsSuccess.Should().BeTrue();
-        await _projectionStore.InitializeAsync();
+        return Task.CompletedTask;
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public Task DisposeAsync()
+    {
+        _eventStore?.Dispose();
+        _provider?.Dispose();
+        return Task.CompletedTask;
+    }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task RebuildProjection_TwoPhaseAppend_CheckpointAdvancesMonotonically()
     {
         // Arrange — phase 1: append 5 events, rebuild, capture checkpoint.
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
 
         var orderId = OrderId.New();
         var order = OrderAggregate.PlaceOrder(orderId, "customer-multi-phase", DateTimeOffset.UtcNow);
@@ -168,14 +126,10 @@ public sealed class ProjectionRebuildEdgeCasesE2ETests : IClassFixture<PostgreSq
         state.Status.Should().Be(ProjectionStatus.Completed);
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task RebuildProjection_CalledTwiceWithNoNewEvents_CheckpointStaysStableAndStateIsCompleted()
     {
         // Arrange — single stream, rebuild once.
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
 
         var orderId = OrderId.New();
         var order = OrderAggregate.PlaceOrder(orderId, "customer-idempotent", DateTimeOffset.UtcNow);
@@ -204,16 +158,12 @@ public sealed class ProjectionRebuildEdgeCasesE2ETests : IClassFixture<PostgreSq
         state.Status.Should().Be(ProjectionStatus.Completed);
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task RebuildProjection_WithCheckpointAlreadyAtMaxPosition_CompletesWithoutReprocessing()
     {
         // Arrange — append events, rebuild, capture max checkpoint. Then call rebuild again
         // and assert no events are re-applied below the existing checkpoint. We measure
         // re-application via a counting projection wrapper that tracks ApplyAsync calls.
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
 
         var orderId = OrderId.New();
         var order = OrderAggregate.PlaceOrder(orderId, "customer-max-checkpoint", DateTimeOffset.UtcNow);
@@ -229,7 +179,7 @@ public sealed class ProjectionRebuildEdgeCasesE2ETests : IClassFixture<PostgreSq
         await _projectionManager.RebuildProjectionAsync<OrderSummaryProjection>(streamId: orderId.ToString());
         var initialCheckpoint = await _projectionStore.GetCheckpointAsync("E2E_OrderSummary");
         initialCheckpoint.Should().NotBeNull();
-        var maxPosition = await _streamingEventStore.GetMaxGlobalPositionAsync();
+        var maxPosition = await _eventStore.GetMaxGlobalPositionAsync();
         initialCheckpoint!.Value.Should().BeGreaterOrEqualTo(events.Count - 1,
             "the checkpoint must reach at least the count of applied events");
 


### PR DESCRIPTION
ADR-0007 step 3, batch 3. Unblocked by #94's exclusive fromPosition fix.

## What

3 framework-behaviour E2E classes refactored to InMemory:

| File | Tests |
|---|---|
| LiveProjectionE2ETests | 4/4 ✓ |
| ProjectionRebuildE2ETests | 4/4 ✓ |
| ProjectionRebuildEdgeCasesE2ETests | 3/3 ✓ |

Same mechanical pattern as #91, #92: drop `PostgreSqlContainer` / `PostgreSqlFixture`, replace PG event store + streaming + projection store with `InMemoryStreamingEventStore` + `InMemoryProjectionStore` (one instance each). `[RequiresDockerFact]` → `[Fact]`. Stopwatch wall-clock assertions dropped (perf measured in BenchmarkDotNet per #88).

## Net change

~330 LOC removed.

## Test plan

- [x] Build green
- [x] 11/11 tests pass without Docker
- [ ] CI green

Remaining E2E refactor work: `_pg` fixture lift (B3), Idempotency+TenantIsolation split (B4).