### PR TITLE
refactor(integration): saga retry + snapshot E2Es run on InMemory

### DIFF
--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/SagaRetryExhaustionE2ETests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/SagaRetryExhaustionE2ETests.cs
@@ -7,13 +7,9 @@
 
 using Compendium.Abstractions.Sagas.Common;
 using Compendium.Abstractions.Sagas.ProcessManagers;
-using Compendium.Adapters.PostgreSQL.Configuration;
-using Compendium.Adapters.PostgreSQL.Sagas;
 using Compendium.Application.Sagas.ProcessManagers;
 using Compendium.Core.Results;
-using Compendium.IntegrationTests.Fixtures;
 using FluentAssertions;
-using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
@@ -36,46 +32,26 @@ namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
 /// </summary>
 [Trait("Category", "E2E")]
 [Trait("Category", "Saga")]
-public sealed class SagaRetryExhaustionE2ETests : IClassFixture<PostgreSqlFixture>, IAsyncLifetime
+public sealed class SagaRetryExhaustionE2ETests : IAsyncLifetime
 {
-    private readonly PostgreSqlFixture _pg;
-    private PostgresProcessManagerRepository _repository = null!;
+    private InMemoryProcessManagerRepository _repository = null!;
     private CountingStepExecutor _executor = null!;
     private ProcessManagerOrchestrator _orchestrator = null!;
 
-    public SagaRetryExhaustionE2ETests(PostgreSqlFixture pg)
+    public Task InitializeAsync()
     {
-        _pg = pg;
-    }
-
-    public async Task InitializeAsync()
-    {
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
-
-        var options = Options.Create(new PostgreSqlOptions { ConnectionString = _pg.ConnectionString });
-        _repository = new PostgresProcessManagerRepository(options);
-        await _repository.InitializeAsync();
-        await _pg.CleanTableAsync("process_manager_steps");
-        await _pg.CleanTableAsync("process_managers");
-
+        _repository = new InMemoryProcessManagerRepository();
         _executor = new CountingStepExecutor();
         _orchestrator = new ProcessManagerOrchestrator(_repository, _executor);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task ExecuteStep_AfterTransientFailure_RetrySucceedsAndStateAdvances()
     {
         // Arrange
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
-
         var pm = ProvisioningProcessManager.Create("acme");
         var startResult = await _orchestrator.StartAsync(pm);
         startResult.IsSuccess.Should().BeTrue();
@@ -113,16 +89,11 @@ public sealed class SagaRetryExhaustionE2ETests : IClassFixture<PostgreSqlFixtur
         step.ErrorMessage.Should().BeNull("the successful retry must clear the failure message");
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task ExecuteStep_AcrossManyRetries_AllAttemptsAreObservableViaErrorMessage()
     {
         // Arrange — a step that needs three resets to eventually succeed. Each failed attempt
         // must persist its error message so an operator dashboard can show retry history.
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
-
         var pm = ProvisioningProcessManager.Create("widget");
         await _orchestrator.StartAsync(pm);
 
@@ -164,17 +135,12 @@ public sealed class SagaRetryExhaustionE2ETests : IClassFixture<PostgreSqlFixtur
         _executor.ExecuteCallCount.Should().Be(maxAttempts + 1, "three failures plus the final success");
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task ExecuteStep_RetryExhaustion_TriggersCompensationAndOnlyCompensatesPriorCompletedSteps()
     {
         // Arrange — first step completes, second step fails permanently. Compensation must
         // roll back ONLY the first step (the one that actually executed external work).
         // This guards against the "compensate-everything" anti-pattern that double-undoes.
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
-
         var pm = ProvisioningProcessManager.Create("foo");
         await _orchestrator.StartAsync(pm);
 
@@ -205,7 +171,7 @@ public sealed class SagaRetryExhaustionE2ETests : IClassFixture<PostgreSqlFixtur
             "compensation must invoke the executor exactly once per previously-completed step");
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task Compensate_CalledTwice_IsIdempotentAndDoesNotReinvokeExecutor()
     {
         // Arrange — the orchestrator's compensation iterates "steps with status Completed".
@@ -213,11 +179,6 @@ public sealed class SagaRetryExhaustionE2ETests : IClassFixture<PostgreSqlFixtur
         // second invocation must not re-issue executor.CompensateAsync calls. This test pins
         // that contract because process-manager hosts may retry compensation on transient
         // persistence errors and we MUST NOT double-undo external work.
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
-
         var pm = ProvisioningProcessManager.Create("idempotent-org");
         await _orchestrator.StartAsync(pm);
 

--- a/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/SnapshotMidStreamE2ETests.cs
+++ b/tests/Integration/Compendium.IntegrationTests/EndToEnd/Scenarios/SnapshotMidStreamE2ETests.cs
@@ -6,18 +6,11 @@
 // -----------------------------------------------------------------------
 
 using Compendium.Abstractions.EventSourcing;
-using Compendium.Adapters.PostgreSQL.Configuration;
-using Compendium.Adapters.PostgreSQL.EventStore;
 using Compendium.Core.Domain.Events;
 using Compendium.Infrastructure.EventSourcing;
-using Compendium.IntegrationTests.EndToEnd.Infrastructure;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates;
 using Compendium.IntegrationTests.EndToEnd.TestAggregates.ValueObjects;
-using Compendium.IntegrationTests.Fixtures;
 using FluentAssertions;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using NSubstitute;
 using Xunit;
 
 namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
@@ -40,61 +33,30 @@ namespace Compendium.IntegrationTests.EndToEnd.Scenarios;
 /// </summary>
 [Trait("Category", "E2E")]
 [Trait("Category", "EventSourcing")]
-public sealed class SnapshotMidStreamE2ETests : IClassFixture<PostgreSqlFixture>, IAsyncLifetime
+public sealed class SnapshotMidStreamE2ETests : IAsyncLifetime
 {
-    private readonly PostgreSqlFixture _pg;
-    private PostgreSqlEventStore _eventStore = null!;
+    private InMemoryStreamingEventStore _eventStore = null!;
     private InMemorySnapshotStore _snapshots = null!;
-    private const string TableName = "snapshot_midstream_events";
 
-    public SnapshotMidStreamE2ETests(PostgreSqlFixture pg)
+    public Task InitializeAsync()
     {
-        _pg = pg;
-    }
-
-    public async Task InitializeAsync()
-    {
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
-
-        var options = Options.Create(new PostgreSqlOptions
-        {
-            ConnectionString = _pg.ConnectionString,
-            AutoCreateSchema = true,
-            TableName = TableName,
-            CommandTimeout = 30,
-            BatchSize = 1000,
-        });
-
-        var deserializer = new E2EEventDeserializer();
-        var logger = Substitute.For<ILogger<PostgreSqlEventStore>>();
-        _eventStore = new PostgreSqlEventStore(options, deserializer, logger);
-
-        var initResult = await _eventStore.InitializeSchemaAsync();
-        initResult.IsSuccess.Should().BeTrue();
-        await _pg.CleanTableAsync(TableName);
-
+        _eventStore = new InMemoryStreamingEventStore();
         _snapshots = new InMemorySnapshotStore();
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()
     {
+        _eventStore?.Dispose();
         _snapshots?.Dispose();
         return Task.CompletedTask;
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task LoadFromMidStreamSnapshot_PlusDeltaEvents_ProducesIdenticalStateAsFullReplay()
     {
         // Arrange — append 4 events, snapshot at version 2, append 3 more events.
         // Loading via "snapshot + events from version 3 onward" must equal "replay all 7".
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
-
         var orderId = OrderId.New();
         var customerId = "snapshot-customer";
 
@@ -158,17 +120,12 @@ public sealed class SnapshotMidStreamE2ETests : IClassFixture<PostgreSqlFixture>
             "loading from a snapshot at v2 must skip the first 2 events and only re-apply the post-snapshot delta");
     }
 
-    [RequiresDockerFact]
+    [Fact]
     public async Task SaveSnapshot_OlderVersionAfterNewer_DoesNotRegressStoredState()
     {
         // Arrange — write a v5 snapshot, then attempt to write a v3 snapshot. The store
         // must keep v5. Without this guard, an out-of-order save (e.g. a delayed background
         // snapshotter racing the live writer) would corrupt the rehydration path.
-        if (!_pg.IsAvailable)
-        {
-            return;
-        }
-
         var aggregateId = $"aggregate-{Guid.NewGuid():N}";
         var newerState = new OrderSnapshotState
         {


### PR DESCRIPTION
ADR-0007 step 3, batch 4 — `_pg` fixture lift.

## What

| File | Tests |
|---|---|
| SagaRetryExhaustionE2ETests | 4/4 ✓ |
| SnapshotMidStreamE2ETests | 2/2 ✓ |

Both used `IClassFixture<PostgreSqlFixture>` + shared `_pg` field but tested framework behaviour (saga retry semantics, snapshot mid-stream rehydration) — none of the assertions depended on PG-specific behaviour.

Replaced with:
- `InMemoryProcessManagerRepository` for SagaRetry (already exists in framework)
- `InMemoryStreamingEventStore` + `InMemorySnapshotStore` for SnapshotMidStream

## Test plan

- [x] Build green
- [x] 6/6 tests pass without Docker
- [ ] CI green

After this PR `PostgreSqlFixture` is used only by `PostgresProcessManagerStateReloadTests` which moves to the PG adapter repo in B5.

Part of the ADR-0007 closeout. Blocker 3 of 7.