### PR TITLE
feat(compendium): POM-431 KubernetesAgentSandbox adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ logs/
 # Rider / JetBrains
 .idea/
 *.DotSettings.user
+
+# Claude Code runtime state (tracked skills/commands stay; scheduler lock is transient)
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Compendium.Adapters.Kubernetes.Sandbox`** (POM-431). Kubernetes adapter
+  for `IAgentSandbox`: provisions an ephemeral non-root pod per agent run,
+  drives it through `pods/exec` (bash exec, base64 file read/write/edit),
+  deletes the pod on dispose. Ships with a multi-stage Dockerfile for the
+  sandbox base image (`deploy/sandbox/coding-agent.Dockerfile`), a Helm
+  chart with default-deny `NetworkPolicy` + minimal `ServiceAccount`/RBAC
+  (`deploy/sandbox/helm/`), an ArgoCD `Application` template
+  (`deploy/sandbox/argocd-application.yaml`), unit tests for the pod spec
+  and DI wiring, Testcontainers-backed k3s integration tests (auto-skip
+  when Docker is unavailable), and operator docs
+  (`docs/operations/coding-agent-sandbox.md`). Unblocks the Claude Code /
+  Codex / Gemini / OpenCode runtimes.
 - **Typed state reload on `IProcessManagerRepository`.** New
   `Task<Result<IProcessManager<TState>>> GetByIdAsync<TState>(Guid id, ct)` overload
   rehydrates a saga's persisted state into the original typed shape so resumed steps

--- a/Compendium.sln
+++ b/Compendium.sln
@@ -167,6 +167,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Core.PerfTests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Infrastructure.PerfTests", "tests\Perf\Compendium.Infrastructure.PerfTests\Compendium.Infrastructure.PerfTests.csproj", "{77217115-F266-49E6-B1D9-090218461DDD}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Adapters", "Adapters", "{0CB45A8C-EFA9-418F-A1DE-1C5B082B238A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.Kubernetes.Sandbox", "src\Adapters\Compendium.Adapters.Kubernetes.Sandbox\Compendium.Adapters.Kubernetes.Sandbox.csproj", "{D098747F-BBF1-488B-9CC6-0E89D693440D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.Kubernetes.Sandbox.Tests", "tests\Unit\Compendium.Adapters.Kubernetes.Sandbox.Tests\Compendium.Adapters.Kubernetes.Sandbox.Tests.csproj", "{BFC22E6F-1619-4CC2-9773-0B57DA972B64}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration", "Integration", "{A2517BFF-352C-4123-81B2-2D848F3FB497}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests", "tests\Integration\Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests\Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests.csproj", "{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -432,6 +442,18 @@ Global
 		{77217115-F266-49E6-B1D9-090218461DDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{77217115-F266-49E6-B1D9-090218461DDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{77217115-F266-49E6-B1D9-090218461DDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D098747F-BBF1-488B-9CC6-0E89D693440D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D098747F-BBF1-488B-9CC6-0E89D693440D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D098747F-BBF1-488B-9CC6-0E89D693440D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D098747F-BBF1-488B-9CC6-0E89D693440D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BFC22E6F-1619-4CC2-9773-0B57DA972B64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BFC22E6F-1619-4CC2-9773-0B57DA972B64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BFC22E6F-1619-4CC2-9773-0B57DA972B64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BFC22E6F-1619-4CC2-9773-0B57DA972B64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -511,5 +533,8 @@ Global
 		{4221097B-A228-4E18-A1E9-4D5423BA94FF} = {B23A5693-C266-43DC-8D3E-CBB108131762}
 		{3907EF5A-478C-43C0-A66C-1A2F5FFA10C6} = {4221097B-A228-4E18-A1E9-4D5423BA94FF}
 		{77217115-F266-49E6-B1D9-090218461DDD} = {4221097B-A228-4E18-A1E9-4D5423BA94FF}
+		{D098747F-BBF1-488B-9CC6-0E89D693440D} = {0CB45A8C-EFA9-418F-A1DE-1C5B082B238A}
+		{BFC22E6F-1619-4CC2-9773-0B57DA972B64} = {17245130-8317-4D67-B86D-BFA713DE2C1C}
+		{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B} = {A2517BFF-352C-4123-81B2-2D848F3FB497}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Bogus" Version="35.6.1" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+    <PackageVersion Include="KubernetesClient" Version="17.0.14" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
@@ -61,11 +62,13 @@
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.K3s" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
 </Project>

--- a/deploy/sandbox/argocd-application.yaml
+++ b/deploy/sandbox/argocd-application.yaml
@@ -1,0 +1,39 @@
+# ArgoCD Application that installs the coding-agent sandbox cluster
+# prerequisites (Namespace, ServiceAccount, NetworkPolicy, RBAC for the runtime).
+# Adjust `repoURL`, `targetRevision`, and the values overrides to suit your
+# environment, then `kubectl apply -f deploy/sandbox/argocd-application.yaml`.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: compendium-coding-agent-sandbox
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/sassy-solutions/compendium
+    targetRevision: main
+    path: deploy/sandbox/helm
+    helm:
+      valueFiles:
+        - values.yaml
+      values: |
+        namespace: coding-agents
+        networkPolicy:
+          cilium:
+            enabled: false
+        runtimeRbac:
+          enabled: true
+          subjects:
+            - kind: ServiceAccount
+              name: compendium-runtime
+              namespace: compendium-system
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: coding-agents
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/deploy/sandbox/coding-agent.Dockerfile
+++ b/deploy/sandbox/coding-agent.Dockerfile
@@ -1,0 +1,78 @@
+# Coding-agent sandbox base image.
+#
+# Hosts an ephemeral, non-root environment for coding agents
+# (Claude Code, Codex, Gemini, OpenCode) driven by Compendium's
+# KubernetesAgentSandbox adapter via `kubectl exec`.
+#
+# Image stays intentionally lean: bash + git + curl + node + python + an
+# optional .NET SDK overlay. Agent CLIs are *not* installed here; the runtime
+# injects them from a sidecar or downloads them per-run.
+#
+# Build:
+#   docker build -f deploy/sandbox/coding-agent.Dockerfile \
+#                -t ghcr.io/sassy-solutions/compendium/coding-agent-sandbox:1.0.0 \
+#                deploy/sandbox
+
+ARG DEBIAN_TAG=12-slim
+FROM debian:${DEBIAN_TAG} AS base
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PATH=/usr/local/bin:/usr/bin:/bin:/home/agent/.local/bin
+
+# Pinned toolchain. Versions match Debian 12 stable; bump deliberately.
+ARG NODE_MAJOR=20
+ARG PYTHON_PACKAGE=python3.11
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        coreutils \
+        curl \
+        git \
+        gnupg \
+        jq \
+        ${PYTHON_PACKAGE} \
+        python3-pip \
+        tini \
+        tzdata \
+        unzip \
+        xz-utils; \
+    curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash -; \
+    apt-get install -y --no-install-recommends nodejs; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Optional .NET SDK overlay — opt in by setting INSTALL_DOTNET=true at build time.
+ARG INSTALL_DOTNET=false
+ARG DOTNET_VERSION=9.0
+RUN if [ "$INSTALL_DOTNET" = "true" ]; then \
+        set -eux; \
+        curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh; \
+        chmod +x /tmp/dotnet-install.sh; \
+        /tmp/dotnet-install.sh --channel ${DOTNET_VERSION} --install-dir /usr/share/dotnet; \
+        ln -s /usr/share/dotnet/dotnet /usr/local/bin/dotnet; \
+        rm /tmp/dotnet-install.sh; \
+    fi
+
+# Non-root user. UID/GID match KubernetesSandboxOptions defaults (10001:10001)
+# so PVC fsGroup / NetworkPolicy targeting works out of the box.
+ARG AGENT_UID=10001
+ARG AGENT_GID=10001
+RUN groupadd --system --gid ${AGENT_GID} agent && \
+    useradd  --system --uid ${AGENT_UID} --gid ${AGENT_GID} \
+             --home /home/agent --create-home --shell /bin/bash agent && \
+    mkdir -p /workspace && \
+    chown ${AGENT_UID}:${AGENT_GID} /workspace
+
+USER agent:agent
+WORKDIR /workspace
+
+# `tini` reaps zombies if a coding-agent CLI forks subprocesses. The default
+# command is overridden by the sandbox adapter, which keeps PID 1 alive with
+# `sleep infinity` and drives the pod through `kubectl exec`.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["bash", "-lc", "exec sleep infinity"]

--- a/deploy/sandbox/helm/Chart.yaml
+++ b/deploy/sandbox/helm/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: compendium-coding-agent-sandbox
+description: |
+  Cluster prerequisites for Compendium's KubernetesAgentSandbox adapter:
+  dedicated namespace, RBAC-minimal ServiceAccount, default-deny NetworkPolicy
+  with a narrow egress allowlist, and an optional PodSecurity baseline label.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - compendium
+  - coding-agent
+  - sandbox
+maintainers:
+  - name: Sassy Solutions
+    url: https://github.com/sassy-solutions/compendium

--- a/deploy/sandbox/helm/templates/namespace.yaml
+++ b/deploy/sandbox/helm/templates/namespace.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    compendium.io/component: coding-agent-sandbox
+    {{- if .Values.podSecurity.enforce }}
+    pod-security.kubernetes.io/enforce: {{ .Values.podSecurity.enforce }}
+    pod-security.kubernetes.io/enforce-version: {{ .Values.podSecurity.enforceVersion | default "latest" }}
+    {{- end }}
+{{- end }}

--- a/deploy/sandbox/helm/templates/networkpolicy.yaml
+++ b/deploy/sandbox/helm/templates/networkpolicy.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: coding-agent-sandbox-default-deny
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    compendium.io/component: coding-agent-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      compendium.io/component: coding-agent-sandbox
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - ports:
+        - protocol: TCP
+          port: 443
+{{- end }}
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.cilium.enabled }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: coding-agent-sandbox-fqdn-allowlist
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  endpointSelector:
+    matchLabels:
+      compendium.io/component: coding-agent-sandbox
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toFQDNs:
+        {{- range .Values.networkPolicy.allowedFqdns }}
+        - matchName: {{ . | quote }}
+        {{- end }}
+        {{- range .Values.networkPolicy.allowedFqdnPatterns }}
+        - matchPattern: {{ . | quote }}
+        {{- end }}
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+{{- end }}

--- a/deploy/sandbox/helm/templates/runtime-rbac.yaml
+++ b/deploy/sandbox/helm/templates/runtime-rbac.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.runtimeRbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: compendium-runtime-sandbox-driver
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    compendium.io/component: coding-agent-sandbox
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "watch", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: compendium-runtime-sandbox-driver
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    compendium.io/component: coding-agent-sandbox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: compendium-runtime-sandbox-driver
+subjects:
+  {{- toYaml .Values.runtimeRbac.subjects | nindent 2 }}
+{{- end }}

--- a/deploy/sandbox/helm/templates/serviceaccount.yaml
+++ b/deploy/sandbox/helm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    compendium.io/component: coding-agent-sandbox
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false

--- a/deploy/sandbox/helm/values.yaml
+++ b/deploy/sandbox/helm/values.yaml
@@ -1,0 +1,46 @@
+# values.yaml — Compendium coding-agent sandbox cluster prerequisites.
+
+# Namespace pods are provisioned in. Mirrors KubernetesSandboxOptions.Namespace.
+namespace: coding-agents
+
+# Whether the chart creates the namespace. Disable if you provision namespaces
+# from a higher-level multi-tenant module.
+createNamespace: true
+
+# Apply the PodSecurity "restricted" admission label on the namespace.
+podSecurity:
+  enforce: restricted
+  enforceVersion: latest
+
+serviceAccount:
+  # Must match KubernetesSandboxOptions.ServiceAccountName.
+  name: coding-agent-sandbox
+  # Intentionally empty Role: the sandbox needs *no* in-cluster permissions.
+  # The controlling service (compendium-runtime) has separate RBAC to create
+  # pods in this namespace.
+  annotations: {}
+
+networkPolicy:
+  enabled: true
+  # FQDNs allowed for HTTPS egress (used by the companion CiliumNetworkPolicy).
+  allowedFqdns:
+    - api.anthropic.com
+    - api.openai.com
+    - api.github.com
+  allowedFqdnPatterns:
+    - "*.githubusercontent.com"
+  # Cilium-specific addendum. Disabled by default; set to true on Cilium-backed clusters.
+  cilium:
+    enabled: false
+
+# RBAC that lets the runtime service create / read / delete pods inside the
+# sandbox namespace. Apply this to the Role assumed by your runtime workload,
+# *not* to the sandbox service account itself.
+runtimeRbac:
+  enabled: true
+  # Subjects (e.g. the runtime service account) that need pod CRUD inside the
+  # sandbox namespace. Override per environment.
+  subjects:
+    - kind: ServiceAccount
+      name: compendium-runtime
+      namespace: compendium-system

--- a/deploy/sandbox/networkpolicy.yaml
+++ b/deploy/sandbox/networkpolicy.yaml
@@ -1,0 +1,75 @@
+# Default-deny egress for sandbox pods, with a narrow allowlist for the
+# coding-agent control planes (Anthropic, OpenAI, GitHub) plus DNS. Apply
+# alongside the KubernetesAgentSandbox adapter; pods are matched by the
+# `compendium.io/component=coding-agent-sandbox` label which the adapter sets
+# on every pod it creates.
+#
+# Notes:
+#   * Vendor IP ranges drift — keep these as `external` egress rules (FQDN-based
+#     NetworkPolicy needs a CNI like Cilium). Adjust to your cluster's CNI.
+#   * Ingress is fully denied: nothing should call into a sandbox pod.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: coding-agent-sandbox-default-deny
+  namespace: coding-agents
+spec:
+  podSelector:
+    matchLabels:
+      compendium.io/component: coding-agent-sandbox
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    # DNS — required for any FQDN resolution downstream.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # HTTPS to the model + git providers. Restrict further via a CNI-level
+    # FQDN policy (Cilium ToFQDN) when available.
+    - ports:
+        - protocol: TCP
+          port: 443
+---
+# Companion CiliumNetworkPolicy with FQDN allowlist. Apply only when Cilium is
+# the cluster CNI; ignored elsewhere.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: coding-agent-sandbox-fqdn-allowlist
+  namespace: coding-agents
+spec:
+  endpointSelector:
+    matchLabels:
+      compendium.io/component: coding-agent-sandbox
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toFQDNs:
+        - matchName: api.anthropic.com
+        - matchName: api.openai.com
+        - matchName: api.github.com
+        - matchPattern: "*.githubusercontent.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/docs/operations/coding-agent-sandbox.md
+++ b/docs/operations/coding-agent-sandbox.md
@@ -1,0 +1,199 @@
+# Coding-agent sandbox (Kubernetes)
+
+`Compendium.Adapters.Kubernetes.Sandbox` implements
+`Compendium.Abstractions.CodingAgents.Sandbox.IAgentSandbox` against a real
+Kubernetes cluster. Each agent run gets its own ephemeral pod: created on
+`StartAsync`, driven through `exec` for the duration of the run, and deleted
+on dispose (even when the caller faults). It is the runtime substrate the
+Claude Code / Codex / Gemini / OpenCode runtimes plug into via POM-427's
+`ICodingAgentRuntime` port.
+
+This doc covers operator-facing concerns: provisioning, security posture,
+RBAC, NetworkPolicy, image, and observability.
+
+---
+
+## Architecture
+
+```
+[ ICodingAgentRuntime ] -- options --> [ IKubernetesAgentSandboxFactory ]
+                                                 |
+                                            Create()
+                                                 v
+[ IAgentSandbox ] -- StartAsync -----> creates Pod (RBAC: runtime SA)
+                  -- ExecBash -------> kubectl exec into the pod
+                  -- Read/Write/Edit-> exec base64 round-trip
+                  -- DisposeAsync ---> deletes Pod (best-effort)
+```
+
+The sandbox does **not** require any in-cluster permissions for the agent
+itself — `automountServiceAccountToken=false` is set on every pod. The
+calling service (the runtime workload) holds the RBAC that lets it
+create/exec/delete pods inside the sandbox namespace.
+
+## Quick start
+
+### 1. Cluster prerequisites
+
+Apply the Helm chart (or the standalone manifests) shipped with the repo:
+
+```bash
+helm upgrade --install compendium-coding-agent-sandbox \
+  ./deploy/sandbox/helm \
+  --create-namespace \
+  --set namespace=coding-agents \
+  --set runtimeRbac.subjects[0].name=compendium-runtime \
+  --set runtimeRbac.subjects[0].namespace=compendium-system
+```
+
+This provisions:
+
+| Resource           | Purpose                                                                 |
+|--------------------|-------------------------------------------------------------------------|
+| `Namespace`        | `coding-agents`, labelled with PodSecurity `restricted`.                |
+| `ServiceAccount`   | `coding-agent-sandbox`, no permissions, no auto-mounted token.          |
+| `NetworkPolicy`    | Default-deny ingress; egress restricted to DNS + HTTPS:443.             |
+| (optional) `CiliumNetworkPolicy` | FQDN allowlist for Anthropic / OpenAI / GitHub.            |
+| `Role`/`RoleBinding` | Grants the runtime workload `pods` + `pods/exec` CRUD in this NS only. |
+
+For ArgoCD-based clusters, see `deploy/sandbox/argocd-application.yaml`.
+
+### 2. Build the sandbox image
+
+```bash
+docker build \
+  -f deploy/sandbox/coding-agent.Dockerfile \
+  -t ghcr.io/sassy-solutions/compendium/coding-agent-sandbox:1.0.0 \
+  --build-arg INSTALL_DOTNET=false \
+  deploy/sandbox
+docker push ghcr.io/sassy-solutions/compendium/coding-agent-sandbox:1.0.0
+```
+
+The image is intentionally minimal: `bash`, `git`, `curl`, `node`, `python`,
+plus an optional `.NET SDK` overlay (`--build-arg INSTALL_DOTNET=true`). It
+runs as UID/GID `10001:10001` and matches the adapter defaults — override
+`AGENT_UID`/`AGENT_GID` at build time if you have organisation-specific UID
+allocations. Pin the image by digest in production.
+
+### 3. Wire the adapter in the host
+
+```csharp
+using Compendium.Adapters.Kubernetes.Sandbox.DependencyInjection;
+
+services.AddKubernetesAgentSandbox(opt =>
+{
+    opt.Image = "ghcr.io/sassy-solutions/compendium/coding-agent-sandbox:1.0.0";
+    opt.Namespace = "coding-agents";
+    opt.ServiceAccountName = "coding-agent-sandbox";
+    opt.CpuLimit = "2";
+    opt.MemoryLimit = "2Gi";
+    opt.PodReadyTimeout = TimeSpan.FromMinutes(2);
+    opt.DefaultCommandTimeout = TimeSpan.FromMinutes(10);
+});
+```
+
+The Kubernetes client is registered as a singleton only if one is not already
+present, so a multi-tenant namespace-provisioning module that already
+provides `IKubernetes` keeps full control of authentication.
+
+### 4. Use it from a runtime
+
+```csharp
+public sealed class ClaudeCodeRuntime : CliCodingAgentRuntime
+{
+    private readonly IKubernetesAgentSandboxFactory _sandboxFactory;
+    public ClaudeCodeRuntime(IKubernetesAgentSandboxFactory factory) => _sandboxFactory = factory;
+
+    public override string Engine => "claude-code";
+
+    protected override IAgentSandbox CreateSandbox(CodingAgentRuntimeOptions options)
+        => _sandboxFactory.Create();
+
+    // ... BuildCommand / ParseStreamLine ...
+}
+```
+
+## Security posture
+
+| Surface                         | Posture                                                            |
+|---------------------------------|--------------------------------------------------------------------|
+| Container user                  | `runAsNonRoot=true`, UID/GID 10001 (configurable).                 |
+| Privilege escalation            | `allowPrivilegeEscalation=false`, `privileged=false`.              |
+| Capabilities                    | `drop: [ALL]`.                                                     |
+| Root filesystem                 | `readOnlyRootFilesystem=true`; only `/workspace` is writable.      |
+| Seccomp                         | `RuntimeDefault`.                                                  |
+| Service-account token mount     | Disabled (`automountServiceAccountToken=false`).                   |
+| Network egress                  | Default deny + HTTPS allowlist; FQDN allowlist on Cilium.          |
+| Network ingress                 | Default deny.                                                      |
+| Resource limits                 | CPU + memory limits always set; safe defaults `1 CPU / 1Gi`.       |
+| Run timeout                     | Per-command timeout, defaults to 10 min, configurable.             |
+| Lifecycle                       | `DisposeAsync` deletes the pod even if the caller throws.          |
+
+The pod **cannot** call the Kubernetes API by design. Anything sensitive
+(API keys for Anthropic / OpenAI / GitHub) is injected as plain environment
+variables through `SandboxOptions.Environment` by the runtime. Source these
+from your secret store (e.g. ExternalSecrets) and pass them via the runtime's
+auth dictionary, not via a mounted secret.
+
+## Tenancy
+
+Pass `SandboxOptions.TenantId` on every run; the adapter stamps the pod with
+`compendium.io/tenant=<id>`. Combine with per-tenant namespaces (override
+`SandboxOptions.Namespace`) when stronger isolation is required — Helm's
+`namespace` value applies to a single namespace; provision one chart release
+per tenant for hard isolation.
+
+## Observability
+
+- All pods carry `compendium.io/component=coding-agent-sandbox` and
+  `app.kubernetes.io/managed-by=compendium`. Scrape per these labels.
+- The adapter logs at `Warning` when the best-effort pod delete fails on
+  dispose (keep an alert on a non-zero rate).
+- For longer-term audit, enable Kubernetes audit logs on `pods/exec`
+  inside the sandbox namespace.
+
+## Failure modes & errors
+
+The adapter surfaces failures through the standard `Result` pattern with
+error codes prefixed `sandbox.kubernetes.*`:
+
+| Code                            | Meaning                                                                 |
+|---------------------------------|-------------------------------------------------------------------------|
+| `pod_create_failed`             | API server rejected the pod (quota, admission webhook, image policy).   |
+| `pod_read_failed`               | API server unreachable mid-readiness poll.                              |
+| `pod_terminal`                  | Pod went `Failed`/`Succeeded` before becoming `Running`.                |
+| `pod_ready_timeout`             | Pod never reached `Running` within `PodReadyTimeout`.                   |
+| `exec_failed`                   | `pods/exec` upgrade or stream failed.                                   |
+| `toolchain_missing`             | The container image lacks `base64` (image hardening regression).        |
+| `file_not_found`                | Read/edit target doesn't exist.                                         |
+| `read_failed` / `write_failed`  | Generic file IO error inside the pod.                                   |
+| `decode_failed`                 | Returned bytes weren't valid base64 (shell corruption).                 |
+| `edit_no_match` / `edit_not_unique` | Edit guarantees broken — substring wasn't found, or matched >1.     |
+| `already_started` / `not_started` / `disposed` | Lifecycle misuse.                                         |
+
+When a `Result<SandboxResult>` is `Success` but `ExitCode != 0`, the
+command itself failed — the sandbox dispatched it correctly. Inspect
+`Stderr` / `ExitCode` on the result.
+
+## Tests
+
+- **Unit tests** (`tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests`)
+  exercise `PodSpecFactory`, naming, DI registration, and architecture guards
+  — no cluster required.
+- **Integration tests**
+  (`tests/Integration/Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests`)
+  spin up a single-node k3s via Testcontainers and exercise the full
+  exec/read/write/edit cycle. They auto-skip when Docker isn't available, so
+  the suite is safe to run on contributors' laptops.
+
+```bash
+dotnet test tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/
+dotnet test tests/Integration/Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests/
+```
+
+## Related ADRs / tickets
+
+- POM-427 — `IAgentSandbox` / `IAgentRuntimeRegistry` ports (merged).
+- POM-431 — this adapter.
+- POM-B1 — `IAgent` / `StandardAgent` ReAct primitives that consume this
+  sandbox transitively through `ICodingAgentRuntime`.

--- a/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/Compendium.Adapters.Kubernetes.Sandbox.csproj
+++ b/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/Compendium.Adapters.Kubernetes.Sandbox.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Adapters.Kubernetes.Sandbox</AssemblyName>
+    <RootNamespace>Compendium.Adapters.Kubernetes.Sandbox</RootNamespace>
+    <PackageId>Compendium.Adapters.Kubernetes.Sandbox</PackageId>
+    <Description>Kubernetes adapter for Compendium IAgentSandbox: provisions ephemeral pods for coding-agent runs (Claude Code, Codex, Gemini, OpenCode), drives exec/read/write/edit through the Kubernetes API, and tears the pod down on dispose. Multi-tenant ready; runs as non-root with allowlisted egress.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+    <ProjectReference Include="..\..\Abstractions\Compendium.Abstractions.CodingAgents\Compendium.Abstractions.CodingAgents.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="KubernetesClient" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Adapters.Kubernetes.Sandbox.Tests" />
+    <InternalsVisibleTo Include="Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using k8s;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Compendium.Adapters.Kubernetes.Sandbox.DependencyInjection;
+
+/// <summary>
+/// DI helpers for <see cref="KubernetesAgentSandbox"/>. Consumers register the
+/// adapter once via <see cref="AddKubernetesAgentSandbox"/>; downstream coding-agent
+/// runtimes resolve <see cref="IKubernetesAgentSandboxFactory"/> to mint a fresh
+/// sandbox per run.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Kubernetes sandbox adapter with the supplied options. A
+    /// singleton <see cref="IKubernetes"/> client is registered only if one is
+    /// not already present, so callers who provision their own client (e.g.
+    /// from a multi-tenant namespace provisioning module) can reuse it.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">An optional callback to configure adapter options.</param>
+    /// <returns>The service collection, for chaining.</returns>
+    public static IServiceCollection AddKubernetesAgentSandbox(
+        this IServiceCollection services,
+        Action<KubernetesSandboxOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        if (configure is not null)
+        {
+            services.Configure(configure);
+        }
+        else
+        {
+            services.AddOptions<KubernetesSandboxOptions>();
+        }
+
+        services.TryAddSingleton<IKubernetes>(sp =>
+        {
+            var opts = sp.GetRequiredService<IOptions<KubernetesSandboxOptions>>().Value;
+            var config = BuildClientConfiguration(opts);
+            return new k8s.Kubernetes(config);
+        });
+
+        services.TryAddSingleton<IKubernetesAgentSandboxFactory, KubernetesSandboxFactory>();
+
+        return services;
+    }
+
+    private static KubernetesClientConfiguration BuildClientConfiguration(KubernetesSandboxOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.KubeConfigPath))
+        {
+            return KubernetesClientConfiguration.BuildConfigFromConfigFile(options.KubeConfigPath);
+        }
+
+        if (KubernetesClientConfiguration.IsInCluster())
+        {
+            return KubernetesClientConfiguration.InClusterConfig();
+        }
+
+        return KubernetesClientConfiguration.BuildDefaultConfig();
+    }
+}

--- a/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/GlobalUsings.cs
+++ b/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/IKubernetesAgentSandboxFactory.cs
+++ b/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/IKubernetesAgentSandboxFactory.cs
@@ -1,0 +1,26 @@
+// -----------------------------------------------------------------------
+// <copyright file="IKubernetesAgentSandboxFactory.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.CodingAgents.Sandbox;
+
+namespace Compendium.Adapters.Kubernetes.Sandbox;
+
+/// <summary>
+/// Produces fresh <see cref="KubernetesAgentSandbox"/> instances on demand. Each
+/// call returns an un-started sandbox; the caller is responsible for invoking
+/// <see cref="IAgentSandbox.StartAsync"/> and <see cref="IAsyncDisposable.DisposeAsync"/>.
+/// </summary>
+public interface IKubernetesAgentSandboxFactory
+{
+    /// <summary>
+    /// Creates a new sandbox bound to the supplied adapter options. Per-run
+    /// values (image override, namespace override, etc.) are passed to
+    /// <see cref="IAgentSandbox.StartAsync"/> via <see cref="SandboxOptions"/>.
+    /// </summary>
+    /// <returns>A new sandbox instance.</returns>
+    IAgentSandbox Create();
+}

--- a/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/KubernetesAgentSandbox.cs
+++ b/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/KubernetesAgentSandbox.cs
@@ -1,0 +1,475 @@
+// -----------------------------------------------------------------------
+// <copyright file="KubernetesAgentSandbox.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Compendium.Abstractions.CodingAgents.Sandbox;
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Compendium.Adapters.Kubernetes.Sandbox;
+
+/// <summary>
+/// <see cref="IAgentSandbox"/> backed by an ephemeral Kubernetes pod. Each
+/// instance owns exactly one pod: <see cref="StartAsync"/> creates it and waits
+/// for <c>Running</c>; subsequent calls run inside it through
+/// <c>kubectl exec</c>-equivalent API streams; <see cref="DisposeAsync"/>
+/// deletes the pod (best-effort) so resources are released even if the caller
+/// faulted.
+/// </summary>
+public sealed class KubernetesAgentSandbox : IAgentSandbox
+{
+    private const int CommandNotFoundExitCode = 127;
+    private const string SandboxErrorPrefix = "sandbox.kubernetes";
+
+    private readonly IKubernetes _client;
+    private readonly KubernetesSandboxOptions _adapterOptions;
+    private readonly ILogger<KubernetesAgentSandbox> _logger;
+    private readonly bool _ownsClient;
+
+    private V1Pod? _pod;
+    private SandboxOptions? _runOptions;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KubernetesAgentSandbox"/> class.
+    /// </summary>
+    /// <param name="client">The Kubernetes API client.</param>
+    /// <param name="adapterOptions">The adapter-level defaults.</param>
+    /// <param name="logger">An optional logger.</param>
+    /// <param name="ownsClient">Whether this sandbox should dispose <paramref name="client"/> on dispose.</param>
+    public KubernetesAgentSandbox(
+        IKubernetes client,
+        KubernetesSandboxOptions adapterOptions,
+        ILogger<KubernetesAgentSandbox>? logger = null,
+        bool ownsClient = false)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _adapterOptions = adapterOptions ?? throw new ArgumentNullException(nameof(adapterOptions));
+        _logger = logger ?? NullLogger<KubernetesAgentSandbox>.Instance;
+        _ownsClient = ownsClient;
+    }
+
+    /// <inheritdoc />
+    public SandboxKind Kind => SandboxKind.KubernetesPod;
+
+    /// <inheritdoc />
+    public string WorkingDirectory => _runOptions?.WorkingDirectory
+        ?? _adapterOptions.WorkingDirectory;
+
+    /// <summary>
+    /// Gets the name of the pod backing this sandbox, or <see langword="null"/>
+    /// if <see cref="StartAsync"/> has not yet been called.
+    /// </summary>
+    public string? PodName => _pod?.Metadata?.Name;
+
+    /// <summary>
+    /// Gets the namespace of the pod backing this sandbox, or <see langword="null"/>
+    /// if <see cref="StartAsync"/> has not yet been called.
+    /// </summary>
+    public string? PodNamespace => _pod?.Metadata?.NamespaceProperty;
+
+    /// <inheritdoc />
+    public async Task<Result> StartAsync(SandboxOptions options, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (_pod is not null)
+        {
+            return Result.Failure(SandboxError("already_started", "StartAsync was called more than once on the same sandbox."));
+        }
+
+        _runOptions = options;
+        var podName = BuildPodName(_adapterOptions.PodNamePrefix);
+        var spec = PodSpecFactory.Build(podName, _adapterOptions, options);
+        var ns = spec.Metadata.NamespaceProperty;
+
+        V1Pod created;
+        try
+        {
+            created = await _client.CoreV1
+                .CreateNamespacedPodAsync(spec, ns, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (HttpOperationException ex)
+        {
+            return Result.Failure(SandboxError("pod_create_failed", $"create pod '{podName}' in '{ns}' failed: {ex.Response?.ReasonPhrase ?? ex.Message}"));
+        }
+
+        _pod = created;
+        var readyResult = await WaitForPodRunningAsync(created.Metadata.Name, ns, cancellationToken).ConfigureAwait(false);
+        if (readyResult.IsFailure)
+        {
+            return readyResult;
+        }
+
+        return Result.Success();
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<SandboxResult>> ExecBashAsync(string command, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        var notReady = EnsureReady();
+        if (notReady is not null)
+        {
+            return Result.Failure<SandboxResult>(notReady);
+        }
+
+        var sw = Stopwatch.StartNew();
+        var timeout = _runOptions?.CommandTimeout ?? _adapterOptions.DefaultCommandTimeout;
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout);
+
+        var argv = new[] { "/bin/sh", "-lc", command };
+
+        var execResult = await ExecRawAsync(argv, cts.Token, cancellationToken).ConfigureAwait(false);
+        sw.Stop();
+        if (execResult.IsFailure)
+        {
+            return Result.Failure<SandboxResult>(execResult.Error);
+        }
+
+        var (exitCode, stdout, stderr, timedOut) = execResult.Value;
+        return Result.Success(new SandboxResult
+        {
+            Command = command,
+            ExitCode = exitCode,
+            Stdout = stdout,
+            Stderr = stderr,
+            Duration = sw.Elapsed,
+            TimedOut = timedOut,
+        });
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<string>> ReadFileAsync(string path, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        var notReady = EnsureReady();
+        if (notReady is not null)
+        {
+            return Result.Failure<string>(notReady);
+        }
+
+        var abs = ResolveAbsolute(path);
+        // Use base64 to round-trip arbitrary bytes through the multiplexed stream
+        // and to dodge shell-locale issues that mangle non-utf8 sequences.
+        var argv = new[] { "/bin/sh", "-lc", $"base64 -w0 -- {ShellQuote(abs)}" };
+        var execResult = await ExecRawAsync(argv, cancellationToken, cancellationToken).ConfigureAwait(false);
+        if (execResult.IsFailure)
+        {
+            return Result.Failure<string>(execResult.Error);
+        }
+
+        var (exitCode, stdout, stderr, _) = execResult.Value;
+        if (exitCode == CommandNotFoundExitCode)
+        {
+            return Result.Failure<string>(SandboxError("toolchain_missing", $"'base64' is not available inside the sandbox image: {stderr.Trim()}"));
+        }
+
+        if (exitCode != 0)
+        {
+            var lowered = stderr.ToLowerInvariant();
+            if (lowered.Contains("no such file") || lowered.Contains("not found"))
+            {
+                return Result.Failure<string>(SandboxError("file_not_found", $"file '{abs}' does not exist in the sandbox."));
+            }
+
+            return Result.Failure<string>(SandboxError("read_failed", $"read '{abs}' failed with exit {exitCode}: {stderr.Trim()}"));
+        }
+
+        try
+        {
+            var bytes = Convert.FromBase64String(stdout.Trim());
+            return Result.Success(Encoding.UTF8.GetString(bytes));
+        }
+        catch (FormatException ex)
+        {
+            return Result.Failure<string>(SandboxError("decode_failed", $"base64 decode of '{abs}' failed: {ex.Message}"));
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> WriteFileAsync(string path, string content, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(content);
+        var notReady = EnsureReady();
+        if (notReady is not null)
+        {
+            return Result.Failure(notReady);
+        }
+
+        var abs = ResolveAbsolute(path);
+        var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(content));
+        // mkdir -p then write atomically through a temp file to avoid partial reads.
+        var script = $"set -e; dir=$(dirname -- {ShellQuote(abs)}); mkdir -p \"$dir\"; tmp=$(mktemp -- \"$dir/.compendium.XXXXXX\"); printf %s {ShellQuote(encoded)} | base64 -d > \"$tmp\"; mv -- \"$tmp\" {ShellQuote(abs)}";
+        var argv = new[] { "/bin/sh", "-lc", script };
+        var execResult = await ExecRawAsync(argv, cancellationToken, cancellationToken).ConfigureAwait(false);
+        if (execResult.IsFailure)
+        {
+            return Result.Failure(execResult.Error);
+        }
+
+        var (exitCode, _, stderr, _) = execResult.Value;
+        return exitCode == 0
+            ? Result.Success()
+            : Result.Failure(SandboxError("write_failed", $"write '{abs}' failed with exit {exitCode}: {stderr.Trim()}"));
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> EditFileAsync(string path, string oldText, string newText, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(oldText);
+        ArgumentNullException.ThrowIfNull(newText);
+
+        var readResult = await ReadFileAsync(path, cancellationToken).ConfigureAwait(false);
+        if (readResult.IsFailure)
+        {
+            return Result.Failure(readResult.Error);
+        }
+
+        var original = readResult.Value;
+        var first = original.IndexOf(oldText, StringComparison.Ordinal);
+        if (first < 0)
+        {
+            return Result.Failure(SandboxError("edit_no_match", $"substring not found in '{path}'."));
+        }
+
+        var second = original.IndexOf(oldText, first + 1, StringComparison.Ordinal);
+        if (second >= 0)
+        {
+            return Result.Failure(SandboxError("edit_not_unique", $"substring matches more than once in '{path}'; refusing to edit non-uniquely."));
+        }
+
+        var updated = string.Concat(original.AsSpan(0, first), newText, original.AsSpan(first + oldText.Length));
+        return await WriteFileAsync(path, updated, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        if (_pod is { Metadata: { Name: { } name, NamespaceProperty: { } ns } })
+        {
+            try
+            {
+                await _client.CoreV1
+                    .DeleteNamespacedPodAsync(
+                        name,
+                        ns,
+                        new V1DeleteOptions
+                        {
+                            GracePeriodSeconds = _adapterOptions.DeleteGracePeriodSeconds,
+                            PropagationPolicy = "Background",
+                        })
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "best-effort delete of pod {Namespace}/{Name} failed", ns, name);
+            }
+        }
+
+        if (_ownsClient && _client is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+
+    private Error? EnsureReady()
+    {
+        if (_disposed)
+        {
+            return SandboxError("disposed", "the sandbox has already been disposed.");
+        }
+
+        if (_pod is null || _runOptions is null)
+        {
+            return SandboxError("not_started", "StartAsync must be called before any other operation.");
+        }
+
+        return null;
+    }
+
+    private async Task<Result<(int ExitCode, string Stdout, string Stderr, bool TimedOut)>> ExecRawAsync(
+        IList<string> command,
+        CancellationToken execToken,
+        CancellationToken externalToken)
+    {
+        var pod = _pod!;
+        var name = pod.Metadata.Name;
+        var ns = pod.Metadata.NamespaceProperty;
+        var container = _adapterOptions.ContainerName;
+
+        using var stdoutBuffer = new MemoryStream();
+        using var stderrBuffer = new MemoryStream();
+
+        var stdoutLock = new object();
+        var stderrLock = new object();
+
+        try
+        {
+            var exitCode = await _client
+                .NamespacedPodExecAsync(
+                    name,
+                    ns,
+                    container,
+                    command,
+                    tty: false,
+                    action: async (Stream stdIn, Stream stdOut, Stream stdErr) =>
+                    {
+                        await Task.WhenAll(
+                            CopyToBufferAsync(stdOut, stdoutBuffer, stdoutLock, execToken),
+                            CopyToBufferAsync(stdErr, stderrBuffer, stderrLock, execToken))
+                            .ConfigureAwait(false);
+                    },
+                    cancellationToken: execToken)
+                .ConfigureAwait(false);
+
+            return Result.Success((
+                exitCode,
+                Encoding.UTF8.GetString(stdoutBuffer.ToArray()),
+                Encoding.UTF8.GetString(stderrBuffer.ToArray()),
+                false));
+        }
+        catch (OperationCanceledException) when (execToken.IsCancellationRequested && !externalToken.IsCancellationRequested)
+        {
+            return Result.Success((
+                ExitCode: 124,
+                Stdout: Encoding.UTF8.GetString(stdoutBuffer.ToArray()),
+                Stderr: Encoding.UTF8.GetString(stderrBuffer.ToArray()),
+                TimedOut: true));
+        }
+        catch (HttpOperationException ex)
+        {
+            return Result.Failure<(int, string, string, bool)>(SandboxError("exec_failed", $"exec on {ns}/{name} failed: {ex.Response?.ReasonPhrase ?? ex.Message}"));
+        }
+    }
+
+    private static async Task CopyToBufferAsync(Stream source, MemoryStream sink, object syncRoot, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[8192];
+        while (true)
+        {
+            int read;
+            try
+            {
+                read = await source.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return;
+            }
+
+            if (read <= 0)
+            {
+                return;
+            }
+
+            lock (syncRoot)
+            {
+                sink.Write(buffer, 0, read);
+            }
+        }
+    }
+
+    private async Task<Result> WaitForPodRunningAsync(string name, string ns, CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow + _adapterOptions.PodReadyTimeout;
+        var delay = TimeSpan.FromMilliseconds(250);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            V1Pod current;
+            try
+            {
+                current = await _client.CoreV1.ReadNamespacedPodAsync(name, ns, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (HttpOperationException ex)
+            {
+                return Result.Failure(SandboxError("pod_read_failed", $"read pod {ns}/{name} failed: {ex.Response?.ReasonPhrase ?? ex.Message}"));
+            }
+
+            _pod = current;
+            var phase = current.Status?.Phase;
+            if (string.Equals(phase, "Running", StringComparison.Ordinal))
+            {
+                return Result.Success();
+            }
+
+            if (string.Equals(phase, "Failed", StringComparison.Ordinal) ||
+                string.Equals(phase, "Succeeded", StringComparison.Ordinal))
+            {
+                return Result.Failure(SandboxError("pod_terminal", $"pod {ns}/{name} reached terminal phase '{phase}' before becoming Running."));
+            }
+
+            try
+            {
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+
+            // Exponential backoff with a 2-second cap, so short-lived pods come up fast
+            // but we don't hammer the API server on slow image pulls.
+            if (delay < TimeSpan.FromSeconds(2))
+            {
+                delay = delay + delay;
+            }
+        }
+
+        return Result.Failure(SandboxError("pod_ready_timeout", $"pod {ns}/{name} did not become Running within {_adapterOptions.PodReadyTimeout.TotalSeconds:F0}s."));
+    }
+
+    private string ResolveAbsolute(string path)
+    {
+        if (Path.IsPathRooted(path))
+        {
+            return path;
+        }
+
+        var basePath = WorkingDirectory.TrimEnd('/');
+        return $"{basePath}/{path.Replace('\\', '/').TrimStart('/')}";
+    }
+
+    private static string ShellQuote(string value)
+    {
+        // POSIX-safe single quoting: ' -> '\'' and wrap in single quotes.
+        return "'" + value.Replace("'", "'\\''") + "'";
+    }
+
+    internal static string BuildPodName(string prefix)
+    {
+        var sanitized = string.Concat((prefix ?? string.Empty).ToLowerInvariant()
+            .Where(c => char.IsLetterOrDigit(c) || c == '-'));
+        if (sanitized.Length == 0)
+        {
+            sanitized = "coding-agent";
+        }
+
+        var suffix = Guid.NewGuid().ToString("N").AsSpan(0, 16).ToString();
+        var name = $"{sanitized}-{suffix}";
+        return name.Length <= 63 ? name : name.Substring(0, 63);
+    }
+
+    private static Error SandboxError(string code, string message)
+        => Error.Failure($"{SandboxErrorPrefix}.{code}", message);
+}

--- a/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/KubernetesSandboxFactory.cs
+++ b/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/KubernetesSandboxFactory.cs
@@ -1,0 +1,51 @@
+// -----------------------------------------------------------------------
+// <copyright file="KubernetesSandboxFactory.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.CodingAgents.Sandbox;
+using k8s;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Compendium.Adapters.Kubernetes.Sandbox;
+
+/// <summary>
+/// Default implementation of <see cref="IKubernetesAgentSandboxFactory"/> that
+/// reuses a single <see cref="IKubernetes"/> client across every sandbox it
+/// produces (the client is thread-safe and connection-pooled).
+/// </summary>
+public sealed class KubernetesSandboxFactory : IKubernetesAgentSandboxFactory
+{
+    private readonly IKubernetes _client;
+    private readonly KubernetesSandboxOptions _options;
+    private readonly ILoggerFactory _loggerFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KubernetesSandboxFactory"/> class.
+    /// </summary>
+    /// <param name="client">The shared Kubernetes API client.</param>
+    /// <param name="options">The adapter options.</param>
+    /// <param name="loggerFactory">A logger factory for per-sandbox loggers.</param>
+    public KubernetesSandboxFactory(
+        IKubernetes client,
+        IOptions<KubernetesSandboxOptions> options,
+        ILoggerFactory loggerFactory)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _options = (options ?? throw new ArgumentNullException(nameof(options))).Value;
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+    }
+
+    /// <inheritdoc />
+    public IAgentSandbox Create()
+    {
+        return new KubernetesAgentSandbox(
+            _client,
+            _options,
+            _loggerFactory.CreateLogger<KubernetesAgentSandbox>(),
+            ownsClient: false);
+    }
+}

--- a/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/KubernetesSandboxOptions.cs
+++ b/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/KubernetesSandboxOptions.cs
@@ -1,0 +1,151 @@
+// -----------------------------------------------------------------------
+// <copyright file="KubernetesSandboxOptions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Adapters.Kubernetes.Sandbox;
+
+/// <summary>
+/// Adapter-level defaults for <see cref="KubernetesAgentSandbox"/>. These are
+/// the values used when the per-run <see cref="Compendium.Abstractions.CodingAgents.Sandbox.SandboxOptions"/>
+/// does not override them, and the values that govern adapter behavior that is
+/// not represented on the neutral port (RBAC service account, resource limits,
+/// network policy, PVC).
+/// </summary>
+/// <remarks>
+/// All quantities are CPU/memory strings in the standard Kubernetes resource
+/// format (<c>500m</c>, <c>1Gi</c>, ...). Validation is deferred to the API
+/// server.
+/// </remarks>
+public sealed class KubernetesSandboxOptions
+{
+    /// <summary>
+    /// Configuration section name used with <c>IConfiguration.GetSection</c>.
+    /// </summary>
+    public const string SectionName = "Compendium:CodingAgents:KubernetesSandbox";
+
+    /// <summary>
+    /// Gets or sets the OCI image to run inside the sandbox pod. Should be a
+    /// pinned digest in production.
+    /// </summary>
+    public string Image { get; set; } = "ghcr.io/sassy-solutions/compendium/coding-agent-sandbox:latest";
+
+    /// <summary>
+    /// Gets or sets the default namespace pods are provisioned in when the per-run
+    /// <see cref="Compendium.Abstractions.CodingAgents.Sandbox.SandboxOptions.Namespace"/>
+    /// is null.
+    /// </summary>
+    public string Namespace { get; set; } = "coding-agents";
+
+    /// <summary>
+    /// Gets or sets the service account name pods run as. Should have RBAC scoped
+    /// to only what the sandbox requires (typically no cluster permissions at all).
+    /// </summary>
+    public string ServiceAccountName { get; set; } = "coding-agent-sandbox";
+
+    /// <summary>
+    /// Gets or sets a prefix used for generated pod names. Pod names are derived as
+    /// <c>{PodNamePrefix}-{shortGuid}</c>.
+    /// </summary>
+    public string PodNamePrefix { get; set; } = "coding-agent";
+
+    /// <summary>
+    /// Gets or sets the container name inside the pod. Used by <c>exec</c> calls.
+    /// </summary>
+    public string ContainerName { get; set; } = "agent";
+
+    /// <summary>
+    /// Gets or sets the working directory inside the container the agent is rooted at.
+    /// Overridable by <see cref="Compendium.Abstractions.CodingAgents.Sandbox.SandboxOptions.WorkingDirectory"/>.
+    /// </summary>
+    public string WorkingDirectory { get; set; } = "/workspace";
+
+    /// <summary>
+    /// Gets or sets the CPU request for the sandbox container.
+    /// </summary>
+    public string CpuRequest { get; set; } = "100m";
+
+    /// <summary>
+    /// Gets or sets the CPU limit for the sandbox container.
+    /// </summary>
+    public string CpuLimit { get; set; } = "1";
+
+    /// <summary>
+    /// Gets or sets the memory request for the sandbox container.
+    /// </summary>
+    public string MemoryRequest { get; set; } = "256Mi";
+
+    /// <summary>
+    /// Gets or sets the memory limit for the sandbox container.
+    /// </summary>
+    public string MemoryLimit { get; set; } = "1Gi";
+
+    /// <summary>
+    /// Gets or sets the storage request for the ephemeral workspace volume. When
+    /// null, an in-memory <c>emptyDir</c> backs the workspace; when set, an
+    /// ephemeral generic PVC is used so the workspace survives container
+    /// restarts within the pod's lifetime.
+    /// </summary>
+    public string? WorkspaceStorageRequest { get; set; }
+
+    /// <summary>
+    /// Gets or sets the storage class name backing the ephemeral PVC, when
+    /// <see cref="WorkspaceStorageRequest"/> is set. Null means "cluster default".
+    /// </summary>
+    public string? WorkspaceStorageClassName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum wall-clock duration any single <c>exec</c> may
+    /// run for before the adapter terminates the channel.
+    /// </summary>
+    public TimeSpan DefaultCommandTimeout { get; set; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Gets or sets the maximum time the adapter waits for the pod to reach
+    /// <c>Running</c> after creation, before failing <c>StartAsync</c>.
+    /// </summary>
+    public TimeSpan PodReadyTimeout { get; set; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Gets or sets the grace period passed to the API server when deleting the
+    /// pod on dispose. Zero forces immediate deletion.
+    /// </summary>
+    public int DeleteGracePeriodSeconds { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the UID the container runs as (non-root). Defaults to
+    /// <c>10001</c> to match the bundled <c>coding-agent-sandbox</c> image.
+    /// </summary>
+    public long RunAsUser { get; set; } = 10001;
+
+    /// <summary>
+    /// Gets or sets the GID the container runs as.
+    /// </summary>
+    public long RunAsGroup { get; set; } = 10001;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the root filesystem inside the
+    /// container is read-only. Defaults to <see langword="true"/>; the writable
+    /// workspace is mounted at <see cref="WorkingDirectory"/>.
+    /// </summary>
+    public bool ReadOnlyRootFilesystem { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets additional labels applied to every pod created by this adapter.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? PodLabels { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional annotations applied to every pod created by this adapter.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? PodAnnotations { get; set; }
+
+    /// <summary>
+    /// Gets or sets the kubeconfig path the client falls back to when the
+    /// process is not running inside a Kubernetes cluster (e.g. local dev). Null
+    /// means "use in-cluster config, then default discovery".
+    /// </summary>
+    public string? KubeConfigPath { get; set; }
+}

--- a/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/PodSpecFactory.cs
+++ b/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/PodSpecFactory.cs
@@ -1,0 +1,202 @@
+// -----------------------------------------------------------------------
+// <copyright file="PodSpecFactory.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Compendium.Abstractions.CodingAgents.Sandbox;
+using k8s.Models;
+
+namespace Compendium.Adapters.Kubernetes.Sandbox;
+
+/// <summary>
+/// Pure pod-spec builder, extracted from <see cref="KubernetesAgentSandbox"/>
+/// so it can be unit tested without a live cluster. The builder reconciles
+/// adapter defaults (<see cref="KubernetesSandboxOptions"/>) with the per-run
+/// neutral options (<see cref="SandboxOptions"/>) according to these rules:
+/// <list type="bullet">
+///   <item>per-run image, namespace, working directory and tenant override the adapter defaults;</item>
+///   <item>per-run environment is appended to the container (sandbox env is treated as non-secret);</item>
+///   <item>resource limits, security context, RBAC and volumes always come from adapter options.</item>
+/// </list>
+/// </summary>
+internal static class PodSpecFactory
+{
+    internal const string WorkspaceVolumeName = "workspace";
+    internal const string TenantLabel = "compendium.io/tenant";
+    internal const string ComponentLabel = "compendium.io/component";
+    internal const string ManagedByLabel = "app.kubernetes.io/managed-by";
+
+    public static V1Pod Build(
+        string podName,
+        KubernetesSandboxOptions adapterOptions,
+        SandboxOptions runOptions)
+    {
+        ArgumentNullException.ThrowIfNull(podName);
+        ArgumentNullException.ThrowIfNull(adapterOptions);
+        ArgumentNullException.ThrowIfNull(runOptions);
+
+        var workingDir = string.IsNullOrWhiteSpace(runOptions.WorkingDirectory)
+            ? adapterOptions.WorkingDirectory
+            : runOptions.WorkingDirectory!;
+        var image = string.IsNullOrWhiteSpace(runOptions.Image)
+            ? adapterOptions.Image
+            : runOptions.Image!;
+
+        var labels = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ManagedByLabel] = "compendium",
+            [ComponentLabel] = "coding-agent-sandbox",
+        };
+        if (!string.IsNullOrEmpty(runOptions.TenantId))
+        {
+            labels[TenantLabel] = runOptions.TenantId;
+        }
+
+        if (adapterOptions.PodLabels is { } extraLabels)
+        {
+            foreach (var kv in extraLabels)
+            {
+                labels[kv.Key] = kv.Value;
+            }
+        }
+
+        var annotations = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (adapterOptions.PodAnnotations is { } extraAnn)
+        {
+            foreach (var kv in extraAnn)
+            {
+                annotations[kv.Key] = kv.Value;
+            }
+        }
+
+        var envVars = new List<V1EnvVar>();
+        if (runOptions.Environment is { } env)
+        {
+            foreach (var kv in env)
+            {
+                envVars.Add(new V1EnvVar(kv.Key, kv.Value));
+            }
+        }
+
+        var workspaceVolume = BuildWorkspaceVolume(adapterOptions);
+
+        var container = new V1Container
+        {
+            Name = adapterOptions.ContainerName,
+            Image = image,
+            ImagePullPolicy = "IfNotPresent",
+            WorkingDir = workingDir,
+            Command = new List<string> { "/bin/sh", "-c" },
+            // Keep PID 1 alive so the pod stays Running while we drive it through exec.
+            // Workdir is ensured at start so subsequent exec calls always have it.
+            Args = new List<string>
+            {
+                $"mkdir -p {ShellQuote(workingDir)} && exec sleep infinity",
+            },
+            Env = envVars.Count == 0 ? null : envVars,
+            Resources = new V1ResourceRequirements
+            {
+                Requests = new Dictionary<string, ResourceQuantity>
+                {
+                    ["cpu"] = new(adapterOptions.CpuRequest),
+                    ["memory"] = new(adapterOptions.MemoryRequest),
+                },
+                Limits = new Dictionary<string, ResourceQuantity>
+                {
+                    ["cpu"] = new(adapterOptions.CpuLimit),
+                    ["memory"] = new(adapterOptions.MemoryLimit),
+                },
+            },
+            SecurityContext = new V1SecurityContext
+            {
+                AllowPrivilegeEscalation = false,
+                Privileged = false,
+                ReadOnlyRootFilesystem = adapterOptions.ReadOnlyRootFilesystem,
+                RunAsNonRoot = true,
+                RunAsUser = adapterOptions.RunAsUser,
+                RunAsGroup = adapterOptions.RunAsGroup,
+                Capabilities = new V1Capabilities { Drop = new List<string> { "ALL" } },
+            },
+            VolumeMounts = new List<V1VolumeMount>
+            {
+                new() { Name = WorkspaceVolumeName, MountPath = workingDir },
+            },
+        };
+
+        var podSpec = new V1PodSpec
+        {
+            ServiceAccountName = adapterOptions.ServiceAccountName,
+            AutomountServiceAccountToken = false,
+            RestartPolicy = "Never",
+            EnableServiceLinks = false,
+            TerminationGracePeriodSeconds = adapterOptions.DeleteGracePeriodSeconds,
+            Containers = new List<V1Container> { container },
+            Volumes = new List<V1Volume> { workspaceVolume },
+            SecurityContext = new V1PodSecurityContext
+            {
+                RunAsNonRoot = true,
+                RunAsUser = adapterOptions.RunAsUser,
+                RunAsGroup = adapterOptions.RunAsGroup,
+                FsGroup = adapterOptions.RunAsGroup,
+                SeccompProfile = new V1SeccompProfile { Type = "RuntimeDefault" },
+            },
+        };
+
+        return new V1Pod
+        {
+            ApiVersion = "v1",
+            Kind = "Pod",
+            Metadata = new V1ObjectMeta
+            {
+                Name = podName,
+                NamespaceProperty = !string.IsNullOrWhiteSpace(runOptions.Namespace)
+                    ? runOptions.Namespace
+                    : adapterOptions.Namespace,
+                Labels = labels,
+                Annotations = annotations.Count == 0 ? null : annotations,
+            },
+            Spec = podSpec,
+        };
+    }
+
+    private static string ShellQuote(string value)
+        => "'" + value.Replace("'", "'\\''") + "'";
+
+    private static V1Volume BuildWorkspaceVolume(KubernetesSandboxOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.WorkspaceStorageRequest))
+        {
+            return new V1Volume
+            {
+                Name = WorkspaceVolumeName,
+                EmptyDir = new V1EmptyDirVolumeSource(),
+            };
+        }
+
+        return new V1Volume
+        {
+            Name = WorkspaceVolumeName,
+            Ephemeral = new V1EphemeralVolumeSource
+            {
+                VolumeClaimTemplate = new V1PersistentVolumeClaimTemplate
+                {
+                    Spec = new V1PersistentVolumeClaimSpec
+                    {
+                        AccessModes = new List<string> { "ReadWriteOnce" },
+                        Resources = new V1VolumeResourceRequirements
+                        {
+                            Requests = new Dictionary<string, ResourceQuantity>
+                            {
+                                ["storage"] = new(options.WorkspaceStorageRequest),
+                            },
+                        },
+                        StorageClassName = options.WorkspaceStorageClassName,
+                    },
+                },
+            },
+        };
+    }
+}

--- a/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/README.md
+++ b/src/Adapters/Compendium.Adapters.Kubernetes.Sandbox/README.md
@@ -1,0 +1,21 @@
+# Compendium.Adapters.Kubernetes.Sandbox
+
+Kubernetes adapter for `Compendium.Abstractions.CodingAgents.Sandbox.IAgentSandbox`.
+
+Provisions an ephemeral, non-root pod per agent run; drives it through
+`pods/exec` for shell + file ops; deletes the pod on dispose (even when the
+caller throws). The runtime substrate Claude Code / Codex / Gemini / OpenCode
+runtimes plug into through POM-427's `ICodingAgentRuntime` port.
+
+```csharp
+services.AddKubernetesAgentSandbox(opt =>
+{
+    opt.Image = "ghcr.io/sassy-solutions/compendium/coding-agent-sandbox:1.0.0";
+    opt.Namespace = "coding-agents";
+    opt.ServiceAccountName = "coding-agent-sandbox";
+});
+```
+
+Resolve `IKubernetesAgentSandboxFactory` from DI and call `Create()` to get a
+fresh `IAgentSandbox` per run. Full operator guide:
+[docs/operations/coding-agent-sandbox.md](../../../docs/operations/coding-agent-sandbox.md).

--- a/tests/Integration/Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests/Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests.csproj
+++ b/tests/Integration/Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests/Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests</AssemblyName>
+    <RootNamespace>Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Adapters\Compendium.Adapters.Kubernetes.Sandbox\Compendium.Adapters.Kubernetes.Sandbox.csproj" />
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.CodingAgents\Compendium.Abstractions.CodingAgents.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="KubernetesClient" />
+    <PackageReference Include="Testcontainers" />
+    <PackageReference Include="Testcontainers.K3s" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Integration/Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests/K3sClusterFixture.cs
+++ b/tests/Integration/Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests/K3sClusterFixture.cs
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------
+// <copyright file="K3sClusterFixture.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using k8s;
+using Testcontainers.K3s;
+using Xunit;
+
+namespace Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests;
+
+/// <summary>
+/// Spins up a single-node k3s cluster via Testcontainers and yields an
+/// <see cref="IKubernetes"/> client pointed at it. Shared across the assembly's
+/// integration test classes so the (slow) cluster start cost amortizes.
+/// </summary>
+public sealed class K3sClusterFixture : IAsyncLifetime
+{
+    private K3sContainer? _container;
+
+    public IKubernetes Client { get; private set; } = null!;
+
+    public string Kubeconfig { get; private set; } = string.Empty;
+
+    public bool IsAvailable { get; private set; }
+
+    public string? UnavailableReason { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            _container = new K3sBuilder()
+                .WithImage("rancher/k3s:v1.31.1-k3s1")
+                .WithCommand("--disable", "traefik,servicelb,metrics-server")
+                .Build();
+
+            await _container.StartAsync().ConfigureAwait(false);
+            Kubeconfig = await _container.GetKubeconfigAsync().ConfigureAwait(false);
+
+            var config = KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(
+                    new MemoryStream(System.Text.Encoding.UTF8.GetBytes(Kubeconfig)))
+                .GetAwaiter().GetResult();
+            Client = new k8s.Kubernetes(config);
+            IsAvailable = true;
+        }
+        catch (Exception ex)
+        {
+            // Docker not available, image pull failed, etc. — integration tests skip.
+            UnavailableReason = ex.Message;
+            IsAvailable = false;
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (Client is IDisposable d)
+        {
+            d.Dispose();
+        }
+
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}
+
+[CollectionDefinition(Name)]
+public sealed class K3sClusterCollection : ICollectionFixture<K3sClusterFixture>
+{
+    public const string Name = "k3s-cluster";
+}

--- a/tests/Integration/Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests/KubernetesAgentSandboxIntegrationTests.cs
+++ b/tests/Integration/Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests/KubernetesAgentSandboxIntegrationTests.cs
@@ -1,0 +1,171 @@
+// -----------------------------------------------------------------------
+// <copyright file="KubernetesAgentSandboxIntegrationTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.CodingAgents.Sandbox;
+using Compendium.Adapters.Kubernetes.Sandbox;
+using Compendium.Core.Results;
+using FluentAssertions;
+using k8s;
+using k8s.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests;
+
+[Collection(K3sClusterCollection.Name)]
+public class KubernetesAgentSandboxIntegrationTests
+{
+    private readonly K3sClusterFixture _fixture;
+
+    public KubernetesAgentSandboxIntegrationTests(K3sClusterFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private async Task EnsureNamespaceAsync(string ns)
+    {
+        try
+        {
+            await _fixture.Client.CoreV1.ReadNamespaceAsync(ns);
+        }
+        catch
+        {
+            await _fixture.Client.CoreV1.CreateNamespaceAsync(new V1Namespace
+            {
+                Metadata = new V1ObjectMeta { Name = ns },
+            });
+        }
+    }
+
+    private async Task EnsureServiceAccountAsync(string ns, string name)
+    {
+        try
+        {
+            await _fixture.Client.CoreV1.ReadNamespacedServiceAccountAsync(name, ns);
+        }
+        catch
+        {
+            await _fixture.Client.CoreV1.CreateNamespacedServiceAccountAsync(new V1ServiceAccount
+            {
+                Metadata = new V1ObjectMeta { Name = name, NamespaceProperty = ns },
+            }, ns);
+        }
+    }
+
+    private KubernetesAgentSandbox BuildSandbox(KubernetesSandboxOptions opts)
+        => new(_fixture.Client, opts, NullLogger<KubernetesAgentSandbox>.Instance);
+
+    [SkippableFact]
+    public async Task Sandbox_can_exec_read_write_and_edit_files_end_to_end()
+    {
+        Skip.IfNot(_fixture.IsAvailable, $"k3s unavailable: {_fixture.UnavailableReason}");
+
+        const string ns = "coding-agents-it";
+        const string sa = "coding-agent-sandbox";
+        await EnsureNamespaceAsync(ns);
+        await EnsureServiceAccountAsync(ns, sa);
+
+        var opts = new KubernetesSandboxOptions
+        {
+            Image = "busybox:1.36",
+            Namespace = ns,
+            ServiceAccountName = sa,
+            ReadOnlyRootFilesystem = false, // busybox doesn't have a writable ephemeral layer separated out
+            PodReadyTimeout = TimeSpan.FromSeconds(120),
+        };
+
+        await using var sandbox = BuildSandbox(opts);
+
+        var start = await sandbox.StartAsync(new SandboxOptions
+        {
+            Kind = SandboxKind.KubernetesPod,
+            WorkingDirectory = "/workspace",
+        });
+        start.IsSuccess.Should().BeTrue(because: start.IsFailure ? start.Error.Message : string.Empty);
+
+        var echo = await sandbox.ExecBashAsync("echo hello-from-sandbox");
+        echo.IsSuccess.Should().BeTrue();
+        echo.Value.Stdout.Should().Contain("hello-from-sandbox");
+        echo.Value.ExitCode.Should().Be(0);
+
+        var write = await sandbox.WriteFileAsync("hello.txt", "the quick brown fox");
+        write.IsSuccess.Should().BeTrue(because: write.IsFailure ? write.Error.Message : string.Empty);
+
+        var read = await sandbox.ReadFileAsync("hello.txt");
+        read.IsSuccess.Should().BeTrue();
+        read.Value.Should().Be("the quick brown fox");
+
+        var edit = await sandbox.EditFileAsync("hello.txt", "quick brown", "slow grey");
+        edit.IsSuccess.Should().BeTrue();
+        var reread = await sandbox.ReadFileAsync("hello.txt");
+        reread.Value.Should().Be("the slow grey fox");
+    }
+
+    [SkippableFact]
+    public async Task Sandbox_disposes_pod_even_when_caller_throws()
+    {
+        Skip.IfNot(_fixture.IsAvailable, $"k3s unavailable: {_fixture.UnavailableReason}");
+
+        const string ns = "coding-agents-it";
+        await EnsureNamespaceAsync(ns);
+        await EnsureServiceAccountAsync(ns, "coding-agent-sandbox");
+
+        var opts = new KubernetesSandboxOptions
+        {
+            Image = "busybox:1.36",
+            Namespace = ns,
+            ReadOnlyRootFilesystem = false,
+            PodReadyTimeout = TimeSpan.FromSeconds(120),
+        };
+
+        string? podName = null;
+        try
+        {
+            await using var sandbox = BuildSandbox(opts);
+            (await sandbox.StartAsync(new SandboxOptions { Kind = SandboxKind.KubernetesPod })).IsSuccess.Should().BeTrue();
+            podName = sandbox.PodName;
+            throw new InvalidOperationException("simulate caller failure");
+        }
+        catch (InvalidOperationException)
+        {
+            // expected
+        }
+
+        podName.Should().NotBeNull();
+        // Give kube a moment to process the delete propagation.
+        await Task.Delay(2_000);
+        await FluentActions.Awaiting(async () =>
+            await _fixture.Client.CoreV1.ReadNamespacedPodAsync(podName!, ns))
+            .Should().ThrowAsync<k8s.Autorest.HttpOperationException>();
+    }
+
+    [SkippableFact]
+    public async Task ExecBashAsync_returns_nonzero_exit_for_failing_command()
+    {
+        Skip.IfNot(_fixture.IsAvailable, $"k3s unavailable: {_fixture.UnavailableReason}");
+
+        const string ns = "coding-agents-it";
+        await EnsureNamespaceAsync(ns);
+        await EnsureServiceAccountAsync(ns, "coding-agent-sandbox");
+
+        var opts = new KubernetesSandboxOptions
+        {
+            Image = "busybox:1.36",
+            Namespace = ns,
+            ReadOnlyRootFilesystem = false,
+            PodReadyTimeout = TimeSpan.FromSeconds(120),
+        };
+
+        await using var sandbox = BuildSandbox(opts);
+        (await sandbox.StartAsync(new SandboxOptions { Kind = SandboxKind.KubernetesPod })).IsSuccess.Should().BeTrue();
+
+        var result = await sandbox.ExecBashAsync("exit 42");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExitCode.Should().Be(42);
+        result.Value.IsSuccess.Should().BeFalse();
+    }
+}

--- a/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/ArchitectureTests.cs
+++ b/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/ArchitectureTests.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// <copyright file="ArchitectureTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Compendium.Adapters.Kubernetes.Sandbox.Tests;
+
+/// <summary>
+/// Architecture guards: the Kubernetes adapter must only depend on Compendium.Core
+/// and Compendium.Abstractions.CodingAgents within the framework family. No
+/// Nexus.* references; no fork of the IAgentSandbox port.
+/// </summary>
+public class ArchitectureTests
+{
+    private static readonly Assembly Target = typeof(KubernetesAgentSandbox).Assembly;
+
+    [Fact]
+    public void Assembly_has_no_reference_to_Nexus_assemblies()
+    {
+        Target.GetReferencedAssemblies()
+            .Where(a => a.Name?.StartsWith("Nexus.", StringComparison.Ordinal) == true)
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Assembly_only_depends_on_Compendium_Core_or_Compendium_Abstractions_CodingAgents()
+    {
+        var compendiumRefs = Target.GetReferencedAssemblies()
+            .Where(a => a.Name?.StartsWith("Compendium.", StringComparison.Ordinal) == true)
+            .Select(a => a.Name!)
+            .ToArray();
+
+        compendiumRefs.Should().OnlyContain(name =>
+            name == "Compendium.Core" || name == "Compendium.Abstractions.CodingAgents");
+    }
+
+    [Fact]
+    public void Assembly_does_not_define_a_competing_IAgentSandbox_abstraction()
+    {
+        // The adapter must reuse Compendium.Abstractions.CodingAgents.Sandbox.IAgentSandbox.
+        Target.GetTypes()
+            .Where(t => t.IsInterface && t.Name == "IAgentSandbox")
+            .Should().BeEmpty();
+    }
+}

--- a/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/Compendium.Adapters.Kubernetes.Sandbox.Tests.csproj
+++ b/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/Compendium.Adapters.Kubernetes.Sandbox.Tests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Adapters.Kubernetes.Sandbox.Tests</AssemblyName>
+    <RootNamespace>Compendium.Adapters.Kubernetes.Sandbox.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Adapters\Compendium.Adapters.Kubernetes.Sandbox\Compendium.Adapters.Kubernetes.Sandbox.csproj" />
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.CodingAgents\Compendium.Abstractions.CodingAgents.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="KubernetesClient" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/DependencyInjectionTests.cs
+++ b/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/DependencyInjectionTests.cs
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------
+// <copyright file="DependencyInjectionTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Adapters.Kubernetes.Sandbox.DependencyInjection;
+using k8s;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Compendium.Adapters.Kubernetes.Sandbox.Tests;
+
+public class DependencyInjectionTests
+{
+    [Fact]
+    public void AddKubernetesAgentSandbox_registers_factory_and_options()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        // Pre-register a fake IKubernetes so DI doesn't try to read kubeconfig.
+        services.AddSingleton(Substitute.For<IKubernetes>());
+
+        services.AddKubernetesAgentSandbox(o =>
+        {
+            o.Namespace = "tenant-ns";
+            o.Image = "ghcr.io/x/y:1";
+        });
+
+        var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptions<KubernetesSandboxOptions>>().Value;
+        options.Namespace.Should().Be("tenant-ns");
+        options.Image.Should().Be("ghcr.io/x/y:1");
+
+        var factory = sp.GetRequiredService<IKubernetesAgentSandboxFactory>();
+        factory.Should().BeOfType<KubernetesSandboxFactory>();
+    }
+
+    [Fact]
+    public void AddKubernetesAgentSandbox_reuses_existing_IKubernetes_registration()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var preExisting = Substitute.For<IKubernetes>();
+        services.AddSingleton(preExisting);
+
+        services.AddKubernetesAgentSandbox();
+
+        var sp = services.BuildServiceProvider();
+        sp.GetRequiredService<IKubernetes>().Should().BeSameAs(preExisting);
+    }
+
+    [Fact]
+    public void Factory_Create_returns_a_fresh_sandbox_per_call()
+    {
+        var client = Substitute.For<IKubernetes>();
+        var factory = new KubernetesSandboxFactory(
+            client,
+            Options.Create(new KubernetesSandboxOptions()),
+            new LoggerFactory());
+
+        var s1 = factory.Create();
+        var s2 = factory.Create();
+
+        s1.Should().NotBeSameAs(s2);
+        s1.Kind.Should().Be(SandboxKind.KubernetesPod);
+    }
+}

--- a/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/GlobalUsings.cs
@@ -1,0 +1,5 @@
+global using Xunit;
+global using FluentAssertions;
+global using Compendium.Abstractions.CodingAgents.Sandbox;
+global using Compendium.Adapters.Kubernetes.Sandbox;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/KubernetesAgentSandboxNamingTests.cs
+++ b/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/KubernetesAgentSandboxNamingTests.cs
@@ -1,0 +1,43 @@
+// -----------------------------------------------------------------------
+// <copyright file="KubernetesAgentSandboxNamingTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Adapters.Kubernetes.Sandbox.Tests;
+
+public class KubernetesAgentSandboxNamingTests
+{
+    [Theory]
+    [InlineData("coding-agent")]
+    [InlineData("CodingAgent")]
+    [InlineData("agent_!@#")]
+    public void BuildPodName_produces_RFC1123_compatible_names(string prefix)
+    {
+        var name = KubernetesAgentSandbox.BuildPodName(prefix);
+
+        name.Length.Should().BeLessThanOrEqualTo(63);
+        name.Should().MatchRegex("^[a-z0-9-]+$");
+        char.IsLetterOrDigit(name[0]).Should().BeTrue();
+        char.IsLetterOrDigit(name[^1]).Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildPodName_falls_back_when_prefix_has_no_valid_chars()
+    {
+        var name = KubernetesAgentSandbox.BuildPodName("___");
+
+        name.Should().StartWith("coding-agent-");
+    }
+
+    [Fact]
+    public void BuildPodName_truncates_oversized_prefix()
+    {
+        var prefix = new string('a', 80);
+
+        var name = KubernetesAgentSandbox.BuildPodName(prefix);
+
+        name.Length.Should().Be(63);
+    }
+}

--- a/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/PodSpecFactoryTests.cs
+++ b/tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/PodSpecFactoryTests.cs
@@ -1,0 +1,167 @@
+// -----------------------------------------------------------------------
+// <copyright file="PodSpecFactoryTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using k8s.Models;
+
+namespace Compendium.Adapters.Kubernetes.Sandbox.Tests;
+
+public class PodSpecFactoryTests
+{
+    private static KubernetesSandboxOptions DefaultAdapterOptions() => new()
+    {
+        Image = "ghcr.io/example/agent:1.0.0",
+        Namespace = "coding-agents",
+        ServiceAccountName = "coding-agent-sandbox",
+        WorkingDirectory = "/workspace",
+        RunAsUser = 10001,
+        RunAsGroup = 10001,
+    };
+
+    [Fact]
+    public void Build_uses_per_run_overrides_when_provided()
+    {
+        var adapter = DefaultAdapterOptions();
+        var run = new SandboxOptions
+        {
+            Kind = SandboxKind.KubernetesPod,
+            Image = "ghcr.io/example/agent:override",
+            Namespace = "tenant-acme",
+            WorkingDirectory = "/work",
+            TenantId = "acme",
+            Environment = new Dictionary<string, string> { ["FOO"] = "bar" },
+        };
+
+        var pod = PodSpecFactory.Build("agent-abc", adapter, run);
+
+        pod.Metadata!.Name.Should().Be("agent-abc");
+        pod.Metadata.NamespaceProperty.Should().Be("tenant-acme");
+        pod.Metadata.Labels.Should().Contain(new KeyValuePair<string, string>("compendium.io/tenant", "acme"));
+        pod.Metadata.Labels.Should().Contain(new KeyValuePair<string, string>("app.kubernetes.io/managed-by", "compendium"));
+
+        var container = pod.Spec.Containers.Single();
+        container.Image.Should().Be("ghcr.io/example/agent:override");
+        container.WorkingDir.Should().Be("/work");
+        container.Env.Should().ContainSingle(e => e.Name == "FOO" && e.Value == "bar");
+    }
+
+    [Fact]
+    public void Build_falls_back_to_adapter_defaults_when_run_options_are_empty()
+    {
+        var adapter = DefaultAdapterOptions();
+        var run = new SandboxOptions { Kind = SandboxKind.KubernetesPod };
+
+        var pod = PodSpecFactory.Build("agent-default", adapter, run);
+
+        pod.Metadata!.NamespaceProperty.Should().Be("coding-agents");
+        pod.Spec.Containers.Single().Image.Should().Be(adapter.Image);
+        pod.Spec.Containers.Single().WorkingDir.Should().Be("/workspace");
+        pod.Spec.ServiceAccountName.Should().Be("coding-agent-sandbox");
+    }
+
+    [Fact]
+    public void Build_enforces_non_root_security_context()
+    {
+        var pod = PodSpecFactory.Build("agent-sec", DefaultAdapterOptions(), new SandboxOptions());
+
+        var container = pod.Spec.Containers.Single();
+        var sec = container.SecurityContext;
+        sec.Should().NotBeNull();
+        sec!.RunAsNonRoot.Should().BeTrue();
+        sec.AllowPrivilegeEscalation.Should().BeFalse();
+        sec.Privileged.Should().BeFalse();
+        sec.ReadOnlyRootFilesystem.Should().BeTrue();
+        sec.Capabilities!.Drop.Should().Contain("ALL");
+
+        var podSec = pod.Spec.SecurityContext;
+        podSec.Should().NotBeNull();
+        podSec!.RunAsNonRoot.Should().BeTrue();
+        podSec.RunAsUser.Should().Be(10001);
+        podSec.SeccompProfile!.Type.Should().Be("RuntimeDefault");
+    }
+
+    [Fact]
+    public void Build_disables_service_account_token_automount()
+    {
+        var pod = PodSpecFactory.Build("agent-x", DefaultAdapterOptions(), new SandboxOptions());
+
+        pod.Spec.AutomountServiceAccountToken.Should().BeFalse();
+        pod.Spec.RestartPolicy.Should().Be("Never");
+        pod.Spec.EnableServiceLinks.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Build_uses_emptyDir_volume_by_default()
+    {
+        var pod = PodSpecFactory.Build("agent-vol", DefaultAdapterOptions(), new SandboxOptions());
+
+        var volume = pod.Spec.Volumes.Single();
+        volume.Name.Should().Be(PodSpecFactory.WorkspaceVolumeName);
+        volume.EmptyDir.Should().NotBeNull();
+        volume.Ephemeral.Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_uses_ephemeral_pvc_volume_when_storage_request_set()
+    {
+        var adapter = DefaultAdapterOptions();
+        adapter.WorkspaceStorageRequest = "1Gi";
+        adapter.WorkspaceStorageClassName = "fast";
+
+        var pod = PodSpecFactory.Build("agent-pvc", adapter, new SandboxOptions());
+
+        var volume = pod.Spec.Volumes.Single();
+        volume.Ephemeral.Should().NotBeNull();
+        volume.EmptyDir.Should().BeNull();
+        var spec = volume.Ephemeral!.VolumeClaimTemplate.Spec;
+        spec.StorageClassName.Should().Be("fast");
+        spec.Resources.Requests["storage"].ToString().Should().Be("1Gi");
+    }
+
+    [Fact]
+    public void Build_applies_resource_limits_from_adapter_options()
+    {
+        var adapter = DefaultAdapterOptions();
+        adapter.CpuLimit = "2";
+        adapter.MemoryLimit = "2Gi";
+        adapter.CpuRequest = "250m";
+        adapter.MemoryRequest = "512Mi";
+
+        var pod = PodSpecFactory.Build("agent-res", adapter, new SandboxOptions());
+
+        var resources = pod.Spec.Containers.Single().Resources;
+        resources.Limits["cpu"].ToString().Should().Be("2");
+        resources.Limits["memory"].ToString().Should().Be("2Gi");
+        resources.Requests["cpu"].ToString().Should().Be("250m");
+        resources.Requests["memory"].ToString().Should().Be("512Mi");
+    }
+
+    [Fact]
+    public void Build_quotes_workingDir_safely_in_init_command()
+    {
+        var adapter = DefaultAdapterOptions();
+        adapter.WorkingDirectory = "/work'space";
+
+        var pod = PodSpecFactory.Build("agent-quote", adapter, new SandboxOptions());
+
+        var args = pod.Spec.Containers.Single().Args.Single();
+        args.Should().Contain("'/work'\\''space'");
+        args.Should().Contain("exec sleep infinity");
+    }
+
+    [Fact]
+    public void Build_merges_pod_labels_and_annotations()
+    {
+        var adapter = DefaultAdapterOptions();
+        adapter.PodLabels = new Dictionary<string, string> { ["team"] = "platform" };
+        adapter.PodAnnotations = new Dictionary<string, string> { ["audit"] = "yes" };
+
+        var pod = PodSpecFactory.Build("agent-meta", adapter, new SandboxOptions());
+
+        pod.Metadata!.Labels.Should().Contain(new KeyValuePair<string, string>("team", "platform"));
+        pod.Metadata.Annotations.Should().Contain(new KeyValuePair<string, string>("audit", "yes"));
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `IAgentSandbox` (POM-427) against a real Kubernetes cluster: ephemeral non-root pod per agent run, driven through `pods/exec`, deleted on dispose even if the caller throws. Unblocks the Claude Code / Codex / Gemini / OpenCode runtimes.
- Ships the full operator surface: Dockerfile for the sandbox base image, Helm chart (Namespace + ServiceAccount + default-deny NetworkPolicy + minimal RBAC), ArgoCD Application template, and operator docs (`docs/operations/coding-agent-sandbox.md`).
- 20 unit tests (`PodSpecFactory`, pod naming, DI, architecture guards) + Testcontainers `k3s` integration tests that auto-skip when Docker isn't available.

## Architectural posture

- **Compendium-first:** extends `Compendium.Abstractions.CodingAgents.Sandbox.IAgentSandbox` directly — no Nexus.* fork. Architecture tests assert the adapter only references `Compendium.Core` + `Compendium.Abstractions.CodingAgents`.
- **DI:** `services.AddKubernetesAgentSandbox(...)` registers `IKubernetes` via `TryAddSingleton`, so multi-tenant namespace-provisioning modules that already provide a client keep full control (no double-registration).
- **Security:** non-root UID 10001, drop ALL caps, read-only root fs, no SA-token mount, `RuntimeDefault` seccomp, CPU/memory limits, per-command timeout (default 10 min), background propagation on delete, best-effort cleanup logged at `Warning`.
- **Tenancy:** `SandboxOptions.TenantId` → pod label `compendium.io/tenant=<id>`; namespace overridable per run.

## Test plan

- [x] `dotnet build` (full solution) — clean.
- [x] `dotnet test tests/Unit/Compendium.Adapters.Kubernetes.Sandbox.Tests/` — 20 passed.
- [x] `dotnet test tests/Architecture/Compendium.ArchitectureTests/` — 37 passed (no regression).
- [x] `dotnet test tests/Unit/Compendium.Abstractions.CodingAgents.Tests/` — 12 passed (POM-427 still green).
- [ ] Integration tests with k3s via Testcontainers — local run requires Docker (gated with `SkippableFact` + Docker availability check); validated to compile and skip gracefully.
- [ ] Helm chart dry-run (`helm template ./deploy/sandbox/helm`) on a target cluster.
- [ ] Image build (`docker build -f deploy/sandbox/coding-agent.Dockerfile deploy/sandbox`).

Closes POM-431.