### PR TITLE
feat(adapters): Claude Code CLI runtime adapter (POM-433)

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -167,6 +167,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Core.PerfTests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Infrastructure.PerfTests", "tests\Perf\Compendium.Infrastructure.PerfTests\Compendium.Infrastructure.PerfTests.csproj", "{77217115-F266-49E6-B1D9-090218461DDD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.ClaudeCode", "src\Adapters\Compendium.Adapters.ClaudeCode\Compendium.Adapters.ClaudeCode.csproj", "{03BA154C-FB1D-4EBB-9AAB-A38EF18EEE4C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.ClaudeCode.Tests", "tests\Unit\Compendium.Adapters.ClaudeCode.Tests\Compendium.Adapters.ClaudeCode.Tests.csproj", "{6B7CA3D8-B870-4C2B-A395-7F690C023984}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.ClaudeCode.IntegrationTests", "tests\Integration\Compendium.Adapters.ClaudeCode.IntegrationTests\Compendium.Adapters.ClaudeCode.IntegrationTests.csproj", "{926E1CB6-3A16-4210-9B71-4CF2C14097A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -432,6 +438,18 @@ Global
 		{77217115-F266-49E6-B1D9-090218461DDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{77217115-F266-49E6-B1D9-090218461DDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{77217115-F266-49E6-B1D9-090218461DDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03BA154C-FB1D-4EBB-9AAB-A38EF18EEE4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03BA154C-FB1D-4EBB-9AAB-A38EF18EEE4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03BA154C-FB1D-4EBB-9AAB-A38EF18EEE4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03BA154C-FB1D-4EBB-9AAB-A38EF18EEE4C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B7CA3D8-B870-4C2B-A395-7F690C023984}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B7CA3D8-B870-4C2B-A395-7F690C023984}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B7CA3D8-B870-4C2B-A395-7F690C023984}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B7CA3D8-B870-4C2B-A395-7F690C023984}.Release|Any CPU.Build.0 = Release|Any CPU
+		{926E1CB6-3A16-4210-9B71-4CF2C14097A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{926E1CB6-3A16-4210-9B71-4CF2C14097A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{926E1CB6-3A16-4210-9B71-4CF2C14097A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{926E1CB6-3A16-4210-9B71-4CF2C14097A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -511,5 +529,8 @@ Global
 		{4221097B-A228-4E18-A1E9-4D5423BA94FF} = {B23A5693-C266-43DC-8D3E-CBB108131762}
 		{3907EF5A-478C-43C0-A66C-1A2F5FFA10C6} = {4221097B-A228-4E18-A1E9-4D5423BA94FF}
 		{77217115-F266-49E6-B1D9-090218461DDD} = {4221097B-A228-4E18-A1E9-4D5423BA94FF}
+		{03BA154C-FB1D-4EBB-9AAB-A38EF18EEE4C} = {73261E87-8FCA-40B6-940B-E25CBDBE33FB}
+		{6B7CA3D8-B870-4C2B-A395-7F690C023984} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{926E1CB6-3A16-4210-9B71-4CF2C14097A8} = {DEEC6B90-90D2-4053-A2CE-1958BB881B5E}
 	EndGlobalSection
 EndGlobal

--- a/src/Adapters/Compendium.Adapters.ClaudeCode/Compendium.Adapters.ClaudeCode.csproj
+++ b/src/Adapters/Compendium.Adapters.ClaudeCode/Compendium.Adapters.ClaudeCode.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Adapters.ClaudeCode</AssemblyName>
+    <RootNamespace>Compendium.Adapters.ClaudeCode</RootNamespace>
+    <PackageId>Compendium.Adapters.ClaudeCode</PackageId>
+    <Description>Claude Code CLI adapter for Compendium Framework: concrete ICodingAgentRuntime implementation that spawns the `claude` CLI as a subprocess and streams its stream-json output as neutral CodingAgentStreamEvents.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
+    <ProjectReference Include="..\..\Abstractions\Compendium.Abstractions.CodingAgents\Compendium.Abstractions.CodingAgents.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Adapters.ClaudeCode.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Adapters/Compendium.Adapters.ClaudeCode/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Adapters/Compendium.Adapters.ClaudeCode/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Adapters.ClaudeCode.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Compendium.Adapters.ClaudeCode.DependencyInjection;
+
+/// <summary>
+/// DI extensions for registering the Claude Code coding-agent adapter.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="ClaudeCodeRuntime"/> as a singleton
+    /// <see cref="ICodingAgentRuntime"/>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddClaudeCodeRuntime(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.AddSingleton<ICodingAgentRuntime, ClaudeCodeRuntime>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="ClaudeCodeRuntime"/> with a custom sandbox factory
+    /// (e.g. a Kubernetes-pod sandbox injected by the host).
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="sandboxFactory">Factory invoked once per run.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddClaudeCodeRuntime(
+        this IServiceCollection services,
+        Func<IServiceProvider, CodingAgentRuntimeOptions, IAgentSandbox> sandboxFactory)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(sandboxFactory);
+        services.AddSingleton<ICodingAgentRuntime>(sp =>
+            new ClaudeCodeRuntime(options => sandboxFactory(sp, options)));
+        return services;
+    }
+}

--- a/src/Adapters/Compendium.Adapters.ClaudeCode/GlobalUsings.cs
+++ b/src/Adapters/Compendium.Adapters.ClaudeCode/GlobalUsings.cs
@@ -1,0 +1,11 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Abstractions.CodingAgents.Events;
+global using Compendium.Abstractions.CodingAgents.Runtime;
+global using Compendium.Abstractions.CodingAgents.Sandbox;
+global using Compendium.Core.Results;

--- a/src/Adapters/Compendium.Adapters.ClaudeCode/Runtime/ClaudeCodeRuntime.cs
+++ b/src/Adapters/Compendium.Adapters.ClaudeCode/Runtime/ClaudeCodeRuntime.cs
@@ -1,0 +1,172 @@
+// -----------------------------------------------------------------------
+// <copyright file="ClaudeCodeRuntime.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Globalization;
+using Compendium.Adapters.ClaudeCode.Sandbox;
+
+namespace Compendium.Adapters.ClaudeCode.Runtime;
+
+/// <summary>
+/// <see cref="ICodingAgentRuntime"/> implementation that drives the
+/// <c>claude</c> CLI. Composes the <see cref="CliCodingAgentRuntime"/>
+/// base: builds the argv from <see cref="CodingAgentRuntimeOptions.Parameters"/>,
+/// parses the CLI's <c>stream-json</c> NDJSON output via
+/// <see cref="ClaudeCodeStreamParser"/>, and provisions an
+/// <see cref="IAgentSandbox"/> appropriate for the requested
+/// <see cref="SandboxKind"/>.
+/// </summary>
+/// <remarks>
+/// Sandbox selection is driven by <see cref="CodingAgentRuntimeOptions.Sandbox"/>:
+/// <list type="bullet">
+///   <item><see cref="SandboxKind.None"/> / <see cref="SandboxKind.LocalProcess"/> — uses <see cref="LocalAgentSandbox"/>;</item>
+///   <item><see cref="SandboxKind.KubernetesPod"/> — caller injects a factory via the constructor.</item>
+/// </list>
+/// The runtime sets <c>ANTHROPIC_API_KEY</c> automatically when supplied via
+/// <see cref="CodingAgentRuntimeOptions.Auth"/>.
+/// </remarks>
+public class ClaudeCodeRuntime : CliCodingAgentRuntime
+{
+    private readonly Func<CodingAgentRuntimeOptions, IAgentSandbox>? _sandboxFactory;
+
+    /// <summary>
+    /// Creates a runtime that uses a <see cref="LocalAgentSandbox"/> for any
+    /// sandbox kind. Suitable for tests and local development.
+    /// </summary>
+    public ClaudeCodeRuntime()
+    {
+    }
+
+    /// <summary>
+    /// Creates a runtime that delegates sandbox provisioning to the supplied
+    /// factory. Hosts use this constructor to inject a Kubernetes-pod sandbox
+    /// (or any other implementation) without coupling the adapter to that
+    /// package.
+    /// </summary>
+    /// <param name="sandboxFactory">Factory invoked once per run with the resolved options.</param>
+    public ClaudeCodeRuntime(Func<CodingAgentRuntimeOptions, IAgentSandbox> sandboxFactory)
+    {
+        ArgumentNullException.ThrowIfNull(sandboxFactory);
+        _sandboxFactory = sandboxFactory;
+    }
+
+    /// <inheritdoc />
+    public override string Engine => ClaudeCodeRuntimeDefaults.EngineId;
+
+    /// <inheritdoc />
+    protected override CliCommand BuildCommand(
+        CodingAgentRuntimeOptions options,
+        CodingAgentRunRequest request)
+    {
+        var executable = StringParam(options, ClaudeCodeRuntimeDefaults.ParamExecutable)
+            ?? ClaudeCodeRuntimeDefaults.DefaultExecutable;
+
+        var args = new List<string>
+        {
+            "--print",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+        };
+
+        if (StringParam(options, ClaudeCodeRuntimeDefaults.ParamModel) is { Length: > 0 } model)
+        {
+            args.Add("--model");
+            args.Add(model);
+        }
+
+        if (IntParam(options, ClaudeCodeRuntimeDefaults.ParamMaxTurns) is { } maxTurns)
+        {
+            args.Add("--max-turns");
+            args.Add(maxTurns.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (StringParam(options, ClaudeCodeRuntimeDefaults.ParamAllowedTools) is { Length: > 0 } allowed)
+        {
+            args.Add("--allowedTools");
+            args.Add(allowed);
+        }
+
+        if (StringParam(options, ClaudeCodeRuntimeDefaults.ParamDisallowedTools) is { Length: > 0 } denied)
+        {
+            args.Add("--disallowedTools");
+            args.Add(denied);
+        }
+
+        if (StringParam(options, ClaudeCodeRuntimeDefaults.ParamMcpConfig) is { Length: > 0 } mcp)
+        {
+            args.Add("--mcp-config");
+            args.Add(mcp);
+        }
+
+        if (StringParam(options, ClaudeCodeRuntimeDefaults.ParamPermissionMode) is { Length: > 0 } mode)
+        {
+            args.Add("--permission-mode");
+            args.Add(mode);
+        }
+
+        if (!string.IsNullOrEmpty(request.SystemPrompt))
+        {
+            args.Add("--append-system-prompt");
+            args.Add(request.SystemPrompt);
+        }
+
+        if (!string.IsNullOrEmpty(request.SessionId))
+        {
+            args.Add("--resume");
+            args.Add(request.SessionId);
+        }
+
+        args.Add(request.Prompt);
+
+        return new CliCommand(executable, args);
+    }
+
+    /// <inheritdoc />
+    protected override CodingAgentStreamEvent? ParseStreamLine(CliStreamLine line)
+        => ClaudeCodeStreamParser.Parse(line);
+
+    /// <inheritdoc />
+    protected override IAgentSandbox CreateSandbox(CodingAgentRuntimeOptions options)
+    {
+        if (_sandboxFactory is not null)
+        {
+            return _sandboxFactory(options);
+        }
+
+        return new LocalAgentSandbox();
+    }
+
+    private static string? StringParam(CodingAgentRuntimeOptions options, string key)
+    {
+        if (!options.Parameters.TryGetValue(key, out var value) || value is null)
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            string s => s,
+            _ => value.ToString(),
+        };
+    }
+
+    private static int? IntParam(CodingAgentRuntimeOptions options, string key)
+    {
+        if (!options.Parameters.TryGetValue(key, out var value) || value is null)
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            int i => i,
+            long l => (int)l,
+            string s when int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null,
+        };
+    }
+}

--- a/src/Adapters/Compendium.Adapters.ClaudeCode/Runtime/ClaudeCodeRuntimeDefaults.cs
+++ b/src/Adapters/Compendium.Adapters.ClaudeCode/Runtime/ClaudeCodeRuntimeDefaults.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="ClaudeCodeRuntimeDefaults.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Adapters.ClaudeCode.Runtime;
+
+/// <summary>
+/// Constants used by the Claude Code adapter: the engine identifier exposed
+/// via <see cref="ICodingAgentRuntime.Engine"/>, the default executable name,
+/// and the recognised parameter keys read from
+/// <see cref="CodingAgentRuntimeOptions.Parameters"/>.
+/// </summary>
+public static class ClaudeCodeRuntimeDefaults
+{
+    /// <summary>The engine identifier this adapter handles.</summary>
+    public const string EngineId = "claude-code";
+
+    /// <summary>The default executable name, resolved via <c>PATH</c>.</summary>
+    public const string DefaultExecutable = "claude";
+
+    /// <summary>Parameter key: override the executable path or name.</summary>
+    public const string ParamExecutable = "executable";
+
+    /// <summary>Parameter key: model alias (e.g. <c>sonnet</c>, <c>opus</c>).</summary>
+    public const string ParamModel = "model";
+
+    /// <summary>Parameter key: max conversation turns before the run halts.</summary>
+    public const string ParamMaxTurns = "max_turns";
+
+    /// <summary>Parameter key: comma-separated tools to allow (e.g. <c>"Bash,Read"</c>).</summary>
+    public const string ParamAllowedTools = "allowed_tools";
+
+    /// <summary>Parameter key: comma-separated tools to deny.</summary>
+    public const string ParamDisallowedTools = "disallowed_tools";
+
+    /// <summary>Parameter key: path to an MCP server configuration JSON file.</summary>
+    public const string ParamMcpConfig = "mcp_config";
+
+    /// <summary>Parameter key: permission mode (e.g. <c>acceptEdits</c>, <c>bypassPermissions</c>).</summary>
+    public const string ParamPermissionMode = "permission_mode";
+
+    /// <summary>Auth key: the Anthropic API key forwarded as <c>ANTHROPIC_API_KEY</c>.</summary>
+    public const string AuthAnthropicApiKey = "ANTHROPIC_API_KEY";
+}

--- a/src/Adapters/Compendium.Adapters.ClaudeCode/Runtime/ClaudeCodeStreamParser.cs
+++ b/src/Adapters/Compendium.Adapters.ClaudeCode/Runtime/ClaudeCodeStreamParser.cs
@@ -1,0 +1,190 @@
+// -----------------------------------------------------------------------
+// <copyright file="ClaudeCodeStreamParser.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Text.Json;
+
+namespace Compendium.Adapters.ClaudeCode.Runtime;
+
+/// <summary>
+/// Translates lines from <c>claude --output-format stream-json</c> into neutral
+/// <see cref="CodingAgentStreamEvent"/>s. The Claude CLI emits one JSON object
+/// per line with a <c>type</c> discriminator. This parser handles the subset
+/// the runtime needs: <c>assistant</c>, <c>user</c> (for tool results),
+/// <c>result</c> (terminal), and <c>system</c> banners (skipped). stderr
+/// lines are mapped to <see cref="CodingAgentStreamEvent.Error"/> with a
+/// well-known failure code when they match known patterns
+/// (auth, rate-limit, network).
+/// </summary>
+internal static class ClaudeCodeStreamParser
+{
+    internal const string CodeAuth = "auth_failed";
+    internal const string CodeRateLimit = "rate_limit";
+    internal const string CodeNetwork = "network";
+    internal const string CodeStderr = "stderr";
+    internal const string CodeBadJson = "bad_json";
+
+    public static CodingAgentStreamEvent? Parse(CliStreamLine line)
+    {
+        if (string.IsNullOrWhiteSpace(line.Text))
+        {
+            return null;
+        }
+
+        if (line.Stream == CliStream.Stderr)
+        {
+            return new CodingAgentStreamEvent.Error(line.Text, Code: ClassifyStderr(line.Text));
+        }
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(line.Text);
+        }
+        catch (JsonException)
+        {
+            // CLI may emit non-JSON banners before stream-json kicks in;
+            // surface as Output so callers can inspect, but flag the line.
+            return new CodingAgentStreamEvent.Output(line.Text);
+        }
+
+        using (doc)
+        {
+            if (!doc.RootElement.TryGetProperty("type", out var typeElement))
+            {
+                return null;
+            }
+
+            var type = typeElement.GetString();
+            return type switch
+            {
+                "assistant" => ParseAssistant(doc.RootElement),
+                "user" => ParseUserToolResult(doc.RootElement),
+                "result" => ParseResult(doc.RootElement),
+                _ => null,
+            };
+        }
+    }
+
+    internal static string ClassifyStderr(string text)
+    {
+        if (text.Contains("invalid api key", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("authentication", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("unauthorized", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("not authenticated", StringComparison.OrdinalIgnoreCase))
+        {
+            return CodeAuth;
+        }
+
+        if (text.Contains("rate limit", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("rate_limit", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("429", StringComparison.Ordinal))
+        {
+            return CodeRateLimit;
+        }
+
+        if (text.Contains("network", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("connection", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("timeout", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("ENOTFOUND", StringComparison.Ordinal) ||
+            text.Contains("ECONNREFUSED", StringComparison.Ordinal))
+        {
+            return CodeNetwork;
+        }
+
+        return CodeStderr;
+    }
+
+    private static CodingAgentStreamEvent? ParseAssistant(JsonElement root)
+    {
+        if (!root.TryGetProperty("message", out var message))
+        {
+            return null;
+        }
+
+        if (!message.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var block in content.EnumerateArray())
+        {
+            if (!block.TryGetProperty("type", out var blockType))
+            {
+                continue;
+            }
+
+            switch (blockType.GetString())
+            {
+                case "text":
+                    if (block.TryGetProperty("text", out var text))
+                    {
+                        return new CodingAgentStreamEvent.Output(text.GetString() ?? string.Empty);
+                    }
+
+                    break;
+                case "tool_use":
+                    return new CodingAgentStreamEvent.ToolCall(
+                        ToolName: block.TryGetProperty("name", out var n) ? n.GetString() ?? string.Empty : string.Empty,
+                        Arguments: block.TryGetProperty("input", out var input) ? input.GetRawText() : "{}",
+                        CallId: block.TryGetProperty("id", out var id) ? id.GetString() ?? string.Empty : string.Empty);
+            }
+        }
+
+        return null;
+    }
+
+    private static CodingAgentStreamEvent? ParseUserToolResult(JsonElement root)
+    {
+        if (!root.TryGetProperty("message", out var message))
+        {
+            return null;
+        }
+
+        if (!message.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var block in content.EnumerateArray())
+        {
+            if (!block.TryGetProperty("type", out var blockType) ||
+                blockType.GetString() != "tool_result")
+            {
+                continue;
+            }
+
+            var callId = block.TryGetProperty("tool_use_id", out var tid) ? tid.GetString() ?? string.Empty : string.Empty;
+            var isError = block.TryGetProperty("is_error", out var err) && err.ValueKind == JsonValueKind.True;
+            string result = string.Empty;
+            if (block.TryGetProperty("content", out var inner))
+            {
+                result = inner.ValueKind switch
+                {
+                    JsonValueKind.String => inner.GetString() ?? string.Empty,
+                    _ => inner.GetRawText(),
+                };
+            }
+
+            return new CodingAgentStreamEvent.ToolResult(callId, result, isError);
+        }
+
+        return null;
+    }
+
+    private static CodingAgentStreamEvent ParseResult(JsonElement root)
+    {
+        var isError = root.TryGetProperty("is_error", out var err) && err.ValueKind == JsonValueKind.True;
+        var subtype = root.TryGetProperty("subtype", out var s) ? s.GetString() : null;
+        var summary = root.TryGetProperty("result", out var r) && r.ValueKind == JsonValueKind.String
+            ? r.GetString()
+            : null;
+
+        // Subtype != "success" means the run halted (max-turns, etc.) — treat as failure.
+        var success = !isError && (subtype is null || subtype == "success");
+        return new CodingAgentStreamEvent.Done(Success: success, ExitCode: success ? 0 : null, Summary: summary);
+    }
+}

--- a/src/Adapters/Compendium.Adapters.ClaudeCode/Sandbox/LocalAgentSandbox.cs
+++ b/src/Adapters/Compendium.Adapters.ClaudeCode/Sandbox/LocalAgentSandbox.cs
@@ -1,0 +1,182 @@
+// -----------------------------------------------------------------------
+// <copyright file="LocalAgentSandbox.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+
+namespace Compendium.Adapters.ClaudeCode.Sandbox;
+
+/// <summary>
+/// A minimal <see cref="IAgentSandbox"/> that runs commands directly on the
+/// host, rooted at a chosen working directory. Provides file-system scoping
+/// but no kernel-level isolation. Intended for local development and tests
+/// against the Claude Code CLI when a Kubernetes sandbox is not available.
+/// </summary>
+public sealed class LocalAgentSandbox : IAgentSandbox
+{
+    private string? _workingDirectory;
+
+    /// <inheritdoc />
+    public SandboxKind Kind => SandboxKind.LocalProcess;
+
+    /// <inheritdoc />
+    public string WorkingDirectory =>
+        _workingDirectory ?? throw new InvalidOperationException("Sandbox has not been started.");
+
+    /// <inheritdoc />
+    public Task<Result> StartAsync(SandboxOptions options, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var dir = options.WorkingDirectory ?? Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.CreateDirectory(dir);
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(Result.Failure(
+                Error.Unavailable("sandbox.start_failed", $"Could not provision working directory '{dir}': {ex.Message}")));
+        }
+
+        _workingDirectory = dir;
+        return Task.FromResult(Result.Success());
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<SandboxResult>> ExecBashAsync(string command, CancellationToken cancellationToken = default)
+    {
+        if (_workingDirectory is null)
+        {
+            return Result.Failure<SandboxResult>(Error.Failure("sandbox.not_started", "Sandbox must be started before exec."));
+        }
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "/bin/bash",
+            WorkingDirectory = _workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add("-lc");
+        psi.ArgumentList.Add(command);
+
+        using var process = new Process { StartInfo = psi };
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            process.Start();
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            sw.Stop();
+
+            return new SandboxResult
+            {
+                Command = command,
+                ExitCode = process.ExitCode,
+                Stdout = await stdoutTask.ConfigureAwait(false),
+                Stderr = await stderrTask.ConfigureAwait(false),
+                Duration = sw.Elapsed,
+                TimedOut = false,
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            try { if (!process.HasExited) { process.Kill(entireProcessTree: true); } } catch { }
+            return Result.Failure<SandboxResult>(Error.Failure("sandbox.cancelled", "Command was cancelled."));
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<SandboxResult>(Error.Unexpected("sandbox.exec_failed", ex.Message));
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<string>> ReadFileAsync(string path, CancellationToken cancellationToken = default)
+    {
+        if (_workingDirectory is null)
+        {
+            return Result.Failure<string>(Error.Failure("sandbox.not_started", "Sandbox must be started."));
+        }
+
+        var full = Path.Combine(_workingDirectory, path);
+        if (!File.Exists(full))
+        {
+            return Result.Failure<string>(Error.NotFound("sandbox.file_not_found", $"File '{path}' not found."));
+        }
+
+        try
+        {
+            var content = await File.ReadAllTextAsync(full, cancellationToken).ConfigureAwait(false);
+            return content;
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<string>(Error.Unexpected("sandbox.read_failed", ex.Message));
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> WriteFileAsync(string path, string content, CancellationToken cancellationToken = default)
+    {
+        if (_workingDirectory is null)
+        {
+            return Result.Failure(Error.Failure("sandbox.not_started", "Sandbox must be started."));
+        }
+
+        try
+        {
+            var full = Path.Combine(_workingDirectory, path);
+            var dir = Path.GetDirectoryName(full);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            await File.WriteAllTextAsync(full, content, cancellationToken).ConfigureAwait(false);
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure(Error.Unexpected("sandbox.write_failed", ex.Message));
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> EditFileAsync(string path, string oldText, string newText, CancellationToken cancellationToken = default)
+    {
+        var read = await ReadFileAsync(path, cancellationToken).ConfigureAwait(false);
+        if (read.IsFailure)
+        {
+            return Result.Failure(read.Error);
+        }
+
+        var content = read.Value;
+        var first = content.IndexOf(oldText, StringComparison.Ordinal);
+        if (first < 0)
+        {
+            return Result.Failure(Error.NotFound("sandbox.edit_no_match", "Old text not found in file."));
+        }
+
+        var second = content.IndexOf(oldText, first + oldText.Length, StringComparison.Ordinal);
+        if (second >= 0)
+        {
+            return Result.Failure(Error.Conflict("sandbox.edit_ambiguous", "Old text occurs more than once in file."));
+        }
+
+        var updated = string.Concat(content.AsSpan(0, first), newText, content.AsSpan(first + oldText.Length));
+        return await WriteFileAsync(path, updated, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        _workingDirectory = null;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/Integration/Compendium.Adapters.ClaudeCode.IntegrationTests/ClaudeCliFact.cs
+++ b/tests/Integration/Compendium.Adapters.ClaudeCode.IntegrationTests/ClaudeCliFact.cs
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="ClaudeCliFact.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+
+namespace Compendium.Adapters.ClaudeCode.IntegrationTests;
+
+/// <summary>
+/// xUnit <c>[Fact]</c> that auto-skips when the <c>claude</c> CLI is not on
+/// <c>PATH</c>. Lets the integration test suite pass on machines without the
+/// CLI installed (CI, contributors who haven't configured Anthropic creds).
+/// </summary>
+public sealed class ClaudeCliFactAttribute : FactAttribute
+{
+    private static readonly Lazy<bool> ClaudeAvailable = new(ResolveClaudeAvailability);
+
+    public ClaudeCliFactAttribute()
+    {
+        if (!ClaudeAvailable.Value)
+        {
+            Skip = "claude CLI not installed (set CLAUDE_CLI=1 to require it).";
+        }
+    }
+
+    private static bool ResolveClaudeAvailability()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("claude", "--version")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            using var p = Process.Start(psi);
+            if (p is null)
+            {
+                return false;
+            }
+
+            return p.WaitForExit(5000) && p.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/tests/Integration/Compendium.Adapters.ClaudeCode.IntegrationTests/ClaudeCodeRuntimeIntegrationTests.cs
+++ b/tests/Integration/Compendium.Adapters.ClaudeCode.IntegrationTests/ClaudeCodeRuntimeIntegrationTests.cs
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="ClaudeCodeRuntimeIntegrationTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Adapters.ClaudeCode.IntegrationTests;
+
+/// <summary>
+/// Integration tests that drive the real <c>claude</c> CLI as a subprocess.
+/// Every test is gated by <see cref="ClaudeCliFactAttribute"/>, which skips
+/// the test when the CLI is not installed (no Anthropic credentials required
+/// for <c>--version</c>; the real-run test additionally requires the CLI to
+/// be configured/authenticated).
+/// </summary>
+public class ClaudeCodeRuntimeIntegrationTests
+{
+    [ClaudeCliFact]
+    public async Task RunAsync_against_real_cli_emits_terminal_done_event()
+    {
+        var runtime = new ClaudeCodeRuntime();
+        var tmp = Path.Combine(Path.GetTempPath(), "claude-it-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+
+        try
+        {
+            var options = new CodingAgentRuntimeOptions
+            {
+                Engine = ClaudeCodeRuntimeDefaults.EngineId,
+                Sandbox = new SandboxOptions { Kind = SandboxKind.LocalProcess, WorkingDirectory = tmp },
+                Parameters = new Dictionary<string, object?>
+                {
+                    [ClaudeCodeRuntimeDefaults.ParamMaxTurns] = 1,
+                    [ClaudeCodeRuntimeDefaults.ParamDisallowedTools] = "Bash,Write,Edit",
+                },
+            };
+            var request = new CodingAgentRunRequest
+            {
+                Prompt = "Reply with exactly the single word: pong",
+            };
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+            var events = new List<CodingAgentStreamEvent>();
+            await foreach (var ev in runtime.RunAsync(options, request, cts.Token))
+            {
+                events.Add(ev);
+                if (events.Count > 500)
+                {
+                    break;
+                }
+            }
+
+            events.Should().NotBeEmpty();
+            events.Last().Should().BeOfType<CodingAgentStreamEvent.Done>(
+                "every run must terminate with exactly one Done event");
+        }
+        finally
+        {
+            try { Directory.Delete(tmp, recursive: true); } catch { }
+        }
+    }
+}

--- a/tests/Integration/Compendium.Adapters.ClaudeCode.IntegrationTests/Compendium.Adapters.ClaudeCode.IntegrationTests.csproj
+++ b/tests/Integration/Compendium.Adapters.ClaudeCode.IntegrationTests/Compendium.Adapters.ClaudeCode.IntegrationTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Compendium.Adapters.ClaudeCode.IntegrationTests</AssemblyName>
+    <RootNamespace>Compendium.Adapters.ClaudeCode.IntegrationTests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Adapters\Compendium.Adapters.ClaudeCode\Compendium.Adapters.ClaudeCode.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Integration/Compendium.Adapters.ClaudeCode.IntegrationTests/GlobalUsings.cs
+++ b/tests/Integration/Compendium.Adapters.ClaudeCode.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using Xunit;
+global using FluentAssertions;
+global using Compendium.Abstractions.CodingAgents.Events;
+global using Compendium.Abstractions.CodingAgents.Runtime;
+global using Compendium.Abstractions.CodingAgents.Sandbox;
+global using Compendium.Adapters.ClaudeCode.Runtime;

--- a/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/Compendium.Adapters.ClaudeCode.Tests.csproj
+++ b/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/Compendium.Adapters.ClaudeCode.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Adapters.ClaudeCode.Tests</AssemblyName>
+    <RootNamespace>Compendium.Adapters.ClaudeCode.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Adapters\Compendium.Adapters.ClaudeCode\Compendium.Adapters.ClaudeCode.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/GlobalUsings.cs
@@ -1,0 +1,8 @@
+global using Xunit;
+global using FluentAssertions;
+global using Compendium.Abstractions.CodingAgents.Events;
+global using Compendium.Abstractions.CodingAgents.Runtime;
+global using Compendium.Abstractions.CodingAgents.Sandbox;
+global using Compendium.Adapters.ClaudeCode.Runtime;
+global using Compendium.Adapters.ClaudeCode.Sandbox;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/Runtime/ClaudeCodeRuntimeTests.cs
+++ b/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/Runtime/ClaudeCodeRuntimeTests.cs
@@ -1,0 +1,268 @@
+// -----------------------------------------------------------------------
+// <copyright file="ClaudeCodeRuntimeTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Adapters.ClaudeCode.Tests.Runtime;
+
+public class ClaudeCodeRuntimeTests
+{
+    private static CodingAgentRuntimeOptions Options(
+        Dictionary<string, object?>? parameters = null,
+        Dictionary<string, string>? auth = null,
+        SandboxOptions? sandbox = null) => new()
+    {
+        Engine = ClaudeCodeRuntimeDefaults.EngineId,
+        Parameters = parameters ?? new Dictionary<string, object?>(),
+        Sandbox = sandbox ?? new SandboxOptions { Kind = SandboxKind.LocalProcess, WorkingDirectory = "/tmp/agent" },
+        Auth = auth ?? new Dictionary<string, string>(),
+    };
+
+    private static CodingAgentRunRequest Request(string prompt = "fix the bug") => new()
+    {
+        Prompt = prompt,
+    };
+
+    [Fact]
+    public void Engine_id_is_claude_code()
+    {
+        new ClaudeCodeRuntime().Engine.Should().Be("claude-code");
+    }
+
+    [Fact]
+    public async Task RunAsync_translates_stream_json_assistant_text_into_output_event()
+    {
+        var lines = new[]
+        {
+            new CliStreamLine(CliStream.Stdout,
+                """{"type":"system","subtype":"init","session_id":"s1"}"""),
+            new CliStreamLine(CliStream.Stdout,
+                """{"type":"assistant","message":{"content":[{"type":"text","text":"hello world"}]}}"""),
+            new CliStreamLine(CliStream.Stdout,
+                """{"type":"result","subtype":"success","is_error":false,"result":"done"}"""),
+        };
+        var runtime = new TestableClaudeCodeRuntime(lines);
+
+        var events = new List<CodingAgentStreamEvent>();
+        await foreach (var ev in runtime.RunAsync(Options(), Request()))
+        {
+            events.Add(ev);
+        }
+
+        events.Should().HaveCount(2);
+        events[0].Should().BeOfType<CodingAgentStreamEvent.Output>()
+            .Which.Text.Should().Be("hello world");
+        var done = events[1].Should().BeOfType<CodingAgentStreamEvent.Done>().Subject;
+        done.Success.Should().BeTrue();
+        done.Summary.Should().Be("done");
+    }
+
+    [Fact]
+    public async Task RunAsync_translates_tool_use_block_into_tool_call_event()
+    {
+        var lines = new[]
+        {
+            new CliStreamLine(CliStream.Stdout,
+                """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tool-1","name":"Bash","input":{"command":"ls -la"}}]}}"""),
+            new CliStreamLine(CliStream.Stdout,
+                """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"file1\nfile2","is_error":false}]}}"""),
+            new CliStreamLine(CliStream.Stdout,
+                """{"type":"result","subtype":"success","is_error":false}"""),
+        };
+        var runtime = new TestableClaudeCodeRuntime(lines);
+
+        var events = new List<CodingAgentStreamEvent>();
+        await foreach (var ev in runtime.RunAsync(Options(), Request()))
+        {
+            events.Add(ev);
+        }
+
+        events.Should().HaveCount(3);
+        var toolCall = events[0].Should().BeOfType<CodingAgentStreamEvent.ToolCall>().Subject;
+        toolCall.ToolName.Should().Be("Bash");
+        toolCall.CallId.Should().Be("tool-1");
+        toolCall.Arguments.Should().Contain("\"command\"");
+
+        var toolResult = events[1].Should().BeOfType<CodingAgentStreamEvent.ToolResult>().Subject;
+        toolResult.CallId.Should().Be("tool-1");
+        toolResult.Result.Should().Contain("file1");
+        toolResult.IsError.Should().BeFalse();
+
+        events[2].Should().BeOfType<CodingAgentStreamEvent.Done>()
+            .Which.Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RunAsync_marks_done_failed_when_result_is_error()
+    {
+        var lines = new[]
+        {
+            new CliStreamLine(CliStream.Stdout,
+                """{"type":"result","subtype":"error_max_turns","is_error":true,"result":"turn limit"}"""),
+        };
+        var runtime = new TestableClaudeCodeRuntime(lines);
+
+        var events = new List<CodingAgentStreamEvent>();
+        await foreach (var ev in runtime.RunAsync(Options(), Request()))
+        {
+            events.Add(ev);
+        }
+
+        events.Should().ContainSingle();
+        var done = events[0].Should().BeOfType<CodingAgentStreamEvent.Done>().Subject;
+        done.Success.Should().BeFalse();
+        done.Summary.Should().Be("turn limit");
+    }
+
+    [Fact]
+    public async Task RunAsync_routes_stderr_to_error_event_with_classified_code()
+    {
+        var lines = new[]
+        {
+            new CliStreamLine(CliStream.Stderr, "Invalid API key provided"),
+        };
+        var runtime = new TestableClaudeCodeRuntime(lines);
+
+        var events = new List<CodingAgentStreamEvent>();
+        await foreach (var ev in runtime.RunAsync(Options(), Request()))
+        {
+            events.Add(ev);
+        }
+
+        events.Should().HaveCount(2);
+        var err = events[0].Should().BeOfType<CodingAgentStreamEvent.Error>().Subject;
+        err.Code.Should().Be(ClaudeCodeStreamParser.CodeAuth);
+        events[1].Should().BeOfType<CodingAgentStreamEvent.Done>()
+            .Which.Success.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Rate limit exceeded, please retry", "rate_limit")]
+    [InlineData("Got HTTP 429", "rate_limit")]
+    [InlineData("Connection refused: ECONNREFUSED", "network")]
+    [InlineData("getaddrinfo ENOTFOUND api.anthropic.com", "network")]
+    [InlineData("Request timeout after 30000ms", "network")]
+    [InlineData("Unauthorized: missing credentials", "auth_failed")]
+    [InlineData("something else entirely", "stderr")]
+    public void Stderr_classifier_maps_known_failure_modes(string text, string expected)
+    {
+        ClaudeCodeStreamParser.ClassifyStderr(text).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task RunAsync_returns_engine_mismatch_for_other_engine()
+    {
+        var runtime = new TestableClaudeCodeRuntime(Array.Empty<CliStreamLine>());
+        var options = Options() with { Engine = "codex" };
+
+        var events = new List<CodingAgentStreamEvent>();
+        await foreach (var ev in runtime.RunAsync(options, Request()))
+        {
+            events.Add(ev);
+        }
+
+        events.Should().HaveCount(2);
+        events[0].Should().BeOfType<CodingAgentStreamEvent.Error>()
+            .Which.Code.Should().Be("engine_mismatch");
+    }
+
+    [Fact]
+    public async Task BuildCommand_emits_default_executable_and_stream_json_args()
+    {
+        var lines = new[]
+        {
+            new CliStreamLine(CliStream.Stdout, """{"type":"result","subtype":"success","is_error":false}"""),
+        };
+        var runtime = new TestableClaudeCodeRuntime(lines);
+
+        await foreach (var _ in runtime.RunAsync(Options(), Request("write tests")))
+        {
+        }
+
+        runtime.LastCommand.Should().NotBeNull();
+        runtime.LastCommand!.Executable.Should().Be("claude");
+        runtime.LastCommand.Arguments.Should().StartWith(new[] { "--print", "--output-format", "stream-json", "--verbose" });
+        runtime.LastCommand.Arguments.Should().EndWith(new[] { "write tests" });
+    }
+
+    [Fact]
+    public async Task BuildCommand_passes_through_known_parameters()
+    {
+        var lines = new[]
+        {
+            new CliStreamLine(CliStream.Stdout, """{"type":"result","subtype":"success","is_error":false}"""),
+        };
+        var runtime = new TestableClaudeCodeRuntime(lines);
+        var options = Options(parameters: new Dictionary<string, object?>
+        {
+            [ClaudeCodeRuntimeDefaults.ParamExecutable] = "/usr/local/bin/claude",
+            [ClaudeCodeRuntimeDefaults.ParamModel] = "sonnet",
+            [ClaudeCodeRuntimeDefaults.ParamMaxTurns] = 5,
+            [ClaudeCodeRuntimeDefaults.ParamAllowedTools] = "Bash,Read",
+            [ClaudeCodeRuntimeDefaults.ParamMcpConfig] = "/tmp/mcp.json",
+            [ClaudeCodeRuntimeDefaults.ParamPermissionMode] = "acceptEdits",
+        });
+        var request = new CodingAgentRunRequest
+        {
+            Prompt = "do work",
+            SystemPrompt = "be terse",
+            SessionId = "sess-1",
+        };
+
+        await foreach (var _ in runtime.RunAsync(options, request))
+        {
+        }
+
+        var args = runtime.LastCommand!.Arguments;
+        runtime.LastCommand.Executable.Should().Be("/usr/local/bin/claude");
+        args.Should().Contain("--model").And.Contain("sonnet");
+        args.Should().Contain("--max-turns").And.Contain("5");
+        args.Should().Contain("--allowedTools").And.Contain("Bash,Read");
+        args.Should().Contain("--mcp-config").And.Contain("/tmp/mcp.json");
+        args.Should().Contain("--permission-mode").And.Contain("acceptEdits");
+        args.Should().Contain("--append-system-prompt").And.Contain("be terse");
+        args.Should().Contain("--resume").And.Contain("sess-1");
+        args.Last().Should().Be("do work");
+    }
+
+    [Fact]
+    public async Task BuildEnvironment_forwards_anthropic_api_key()
+    {
+        var lines = new[]
+        {
+            new CliStreamLine(CliStream.Stdout, """{"type":"result","subtype":"success","is_error":false}"""),
+        };
+        var runtime = new TestableClaudeCodeRuntime(lines);
+        var options = Options(auth: new Dictionary<string, string>
+        {
+            [ClaudeCodeRuntimeDefaults.AuthAnthropicApiKey] = "sk-test-123",
+        });
+
+        await foreach (var _ in runtime.RunAsync(options, Request()))
+        {
+        }
+
+        runtime.LastEnvironment.Should().NotBeNull();
+        runtime.LastEnvironment![ClaudeCodeRuntimeDefaults.AuthAnthropicApiKey].Should().Be("sk-test-123");
+    }
+
+    [Fact]
+    public async Task RunAsync_disposes_sandbox_on_completion()
+    {
+        var sandbox = new RecordingSandbox();
+        var lines = new[]
+        {
+            new CliStreamLine(CliStream.Stdout, """{"type":"result","subtype":"success","is_error":false}"""),
+        };
+        var runtime = new TestableClaudeCodeRuntime(lines, sandbox);
+
+        await foreach (var _ in runtime.RunAsync(Options(), Request()))
+        {
+        }
+
+        sandbox.Started.Should().BeTrue();
+        sandbox.Disposed.Should().BeTrue();
+    }
+}

--- a/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/Runtime/TestableClaudeCodeRuntime.cs
+++ b/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/Runtime/TestableClaudeCodeRuntime.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="TestableClaudeCodeRuntime.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+namespace Compendium.Adapters.ClaudeCode.Tests.Runtime;
+
+/// <summary>
+/// Wraps <see cref="ClaudeCodeRuntime"/> by exposing a canned line stream and
+/// recording the resolved <c>CliCommand</c> + environment. Lets tests drive
+/// the full base-class pipeline without actually spawning <c>claude</c>.
+/// </summary>
+internal sealed class TestableClaudeCodeRuntime : ClaudeCodeRuntime
+{
+    private readonly IReadOnlyList<CliStreamLine> _lines;
+
+    public TestableClaudeCodeRuntime(IReadOnlyList<CliStreamLine> lines, IAgentSandbox? sandbox = null)
+        : base(_ => sandbox ?? new RecordingSandbox())
+    {
+        _lines = lines;
+    }
+
+    public CliCommand? LastCommand { get; private set; }
+
+    public IReadOnlyDictionary<string, string>? LastEnvironment { get; private set; }
+
+    protected override async IAsyncEnumerable<CliStreamLine> SpawnAndStreamLinesAsync(
+        CliCommand command,
+        IReadOnlyDictionary<string, string> environment,
+        IAgentSandbox sandbox,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        LastCommand = command;
+        LastEnvironment = environment;
+        foreach (var line in _lines)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return line;
+            await Task.Yield();
+        }
+    }
+}
+
+internal sealed class RecordingSandbox : IAgentSandbox
+{
+    public bool Started { get; private set; }
+
+    public bool Disposed { get; private set; }
+
+    public SandboxKind Kind => SandboxKind.LocalProcess;
+
+    public string WorkingDirectory { get; private set; } = "/tmp/agent";
+
+    public Task<Result> StartAsync(SandboxOptions options, CancellationToken cancellationToken = default)
+    {
+        Started = true;
+        if (!string.IsNullOrEmpty(options.WorkingDirectory))
+        {
+            WorkingDirectory = options.WorkingDirectory;
+        }
+
+        return Task.FromResult(Result.Success());
+    }
+
+    public Task<Result<SandboxResult>> ExecBashAsync(string command, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException();
+
+    public Task<Result<string>> ReadFileAsync(string path, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException();
+
+    public Task<Result> WriteFileAsync(string path, string content, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException();
+
+    public Task<Result> EditFileAsync(string path, string oldText, string newText, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException();
+
+    public ValueTask DisposeAsync()
+    {
+        Disposed = true;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/Sandbox/LocalAgentSandboxTests.cs
+++ b/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/Sandbox/LocalAgentSandboxTests.cs
@@ -1,0 +1,105 @@
+// -----------------------------------------------------------------------
+// <copyright file="LocalAgentSandboxTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Adapters.ClaudeCode.Tests.Sandbox;
+
+public sealed class LocalAgentSandboxTests : IAsyncDisposable
+{
+    private readonly string _root;
+
+    public LocalAgentSandboxTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "compendium-localsandbox-" + Guid.NewGuid().ToString("N"));
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+        return ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public async Task StartAsync_creates_working_directory_when_missing()
+    {
+        await using var sb = new LocalAgentSandbox();
+        var result = await sb.StartAsync(new SandboxOptions { WorkingDirectory = _root });
+
+        result.IsSuccess.Should().BeTrue();
+        Directory.Exists(_root).Should().BeTrue();
+        sb.WorkingDirectory.Should().Be(_root);
+    }
+
+    [Fact]
+    public async Task WriteFile_then_ReadFile_round_trips_content()
+    {
+        await using var sb = new LocalAgentSandbox();
+        await sb.StartAsync(new SandboxOptions { WorkingDirectory = _root });
+
+        var write = await sb.WriteFileAsync("nested/file.txt", "hello world");
+        write.IsSuccess.Should().BeTrue();
+
+        var read = await sb.ReadFileAsync("nested/file.txt");
+        read.IsSuccess.Should().BeTrue();
+        read.Value.Should().Be("hello world");
+    }
+
+    [Fact]
+    public async Task ReadFile_returns_not_found_when_missing()
+    {
+        await using var sb = new LocalAgentSandbox();
+        await sb.StartAsync(new SandboxOptions { WorkingDirectory = _root });
+
+        var read = await sb.ReadFileAsync("missing.txt");
+
+        read.IsFailure.Should().BeTrue();
+        read.Error.Code.Should().Be("sandbox.file_not_found");
+    }
+
+    [Fact]
+    public async Task EditFile_replaces_unique_substring()
+    {
+        await using var sb = new LocalAgentSandbox();
+        await sb.StartAsync(new SandboxOptions { WorkingDirectory = _root });
+        await sb.WriteFileAsync("f.txt", "alpha beta gamma");
+
+        var result = await sb.EditFileAsync("f.txt", "beta", "BETA");
+
+        result.IsSuccess.Should().BeTrue();
+        (await sb.ReadFileAsync("f.txt")).Value.Should().Be("alpha BETA gamma");
+    }
+
+    [Fact]
+    public async Task EditFile_fails_when_substring_is_ambiguous()
+    {
+        await using var sb = new LocalAgentSandbox();
+        await sb.StartAsync(new SandboxOptions { WorkingDirectory = _root });
+        await sb.WriteFileAsync("f.txt", "foo foo");
+
+        var result = await sb.EditFileAsync("f.txt", "foo", "bar");
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("sandbox.edit_ambiguous");
+    }
+
+    [Fact]
+    public async Task ExecBash_runs_a_command_and_captures_stdout()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return; // Skip — /bin/bash not available on Windows.
+        }
+
+        await using var sb = new LocalAgentSandbox();
+        await sb.StartAsync(new SandboxOptions { WorkingDirectory = _root });
+
+        var result = await sb.ExecBashAsync("echo hello");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExitCode.Should().Be(0);
+        result.Value.Stdout.Trim().Should().Be("hello");
+    }
+}

--- a/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/Compendium.Adapters.ClaudeCode.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Adapters.ClaudeCode.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Compendium.Adapters.ClaudeCode.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddClaudeCodeRuntime_registers_runtime_as_singleton()
+    {
+        var services = new ServiceCollection();
+        services.AddClaudeCodeRuntime();
+
+        using var provider = services.BuildServiceProvider();
+        var runtime = provider.GetRequiredService<ICodingAgentRuntime>();
+
+        runtime.Should().BeOfType<ClaudeCodeRuntime>();
+        runtime.Engine.Should().Be("claude-code");
+        provider.GetRequiredService<ICodingAgentRuntime>().Should().BeSameAs(runtime);
+    }
+}


### PR DESCRIPTION
## Summary

Implements `Compendium.Adapters.ClaudeCode` — a concrete `ICodingAgentRuntime` (per POM-427) that drives the `claude` CLI as a subprocess and streams its `stream-json` output as neutral `CodingAgentStreamEvent`s.

- New csproj `src/Adapters/Compendium.Adapters.ClaudeCode/` with `ClaudeCodeRuntime` (extends `CliCodingAgentRuntime`), `LocalAgentSandbox`, NDJSON stream parser, and DI registration.
- Translates the `CodingAgentRunRequest` + `CodingAgentRuntimeOptions.Parameters` into Claude CLI flags: `--model`, `--max-turns`, `--allowedTools`, `--disallowedTools`, `--mcp-config`, `--permission-mode`, `--append-system-prompt`, `--resume`.
- Forwards `ANTHROPIC_API_KEY` via `CodingAgentRuntimeOptions.Auth`.
- Classifies stderr failure modes (auth / rate-limit / network) into well-known error codes on `CodingAgentStreamEvent.Error`.
- Accepts an injected sandbox factory so hosts can swap in a Kubernetes-pod sandbox (POM-431) without coupling this package to it; falls back to `LocalAgentSandbox` for dev/tests.

## Test plan

- [x] Unit tests (24, mocked process IO): assistant text → Output, tool_use → ToolCall, user/tool_result → ToolResult, result → Done, stderr classification (auth/rate_limit/network/stderr), engine-mismatch, BuildCommand pass-through, BuildEnvironment auth forwarding, sandbox dispose, DI singleton registration, LocalAgentSandbox round-trips.
- [x] Integration test gated by `[ClaudeCliFact]` (auto-skip when `claude` is absent from PATH).
- [x] `dotnet build Compendium.sln` succeeds with 0 errors.