### PR TITLE
fix(application): typed Result<T>.Failure on validation failures (POM-482)

### DIFF
--- a/src/Application/Compendium.Application/CQRS/Behaviors/ValidationBehavior.cs
+++ b/src/Application/Compendium.Application/CQRS/Behaviors/ValidationBehavior.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 
 namespace Compendium.Application.CQRS.Behaviors;
 
@@ -33,16 +34,25 @@ public sealed class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<
 
             var errorMessage = string.Join("; ", errors);
 
-            // For Result<T> responses, we need to handle this differently
+            // For Result<T> responses, dispatch through the non-generic Result.Failure<T>(Error)
+            // static factory. The previous lookup against typeof(Result<>) returned null because
+            // Failure<T> is a static on the Result base type, not on the closed generic
+            // Result<TValue>, and GetMethod on a closed generic does not surface inherited statics
+            // without BindingFlags.FlattenHierarchy.
             if (typeof(TResponse).IsGenericType && typeof(TResponse).GetGenericTypeDefinition() == typeof(Result<>))
             {
                 var resultType = typeof(TResponse).GetGenericArguments()[0];
-                var failureMethod = typeof(Result<>).MakeGenericType(resultType)
-                    .GetMethod(nameof(Result<object>.Failure), new[] { typeof(Error) });
+                var failureMethod = typeof(Result)
+                    .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                    .Single(m => m.Name == nameof(Result.Failure)
+                              && m.IsGenericMethodDefinition
+                              && m.GetParameters().Length == 1
+                              && m.GetParameters()[0].ParameterType == typeof(Error))
+                    .MakeGenericMethod(resultType);
 
                 var error = Error.Validation("Validation.Failed", errorMessage);
-                var result = failureMethod?.Invoke(null, new object[] { error });
-                return (TResponse)result!;
+                var result = failureMethod.Invoke(null, new object[] { error })!;
+                return (TResponse)result;
             }
 
             // For Result responses

--- a/tests/Unit/Compendium.Application.Tests/CQRS/Behaviors/ValidationBehaviorTests.cs
+++ b/tests/Unit/Compendium.Application.Tests/CQRS/Behaviors/ValidationBehaviorTests.cs
@@ -70,21 +70,14 @@ public class ValidationBehaviorTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenInvalidAndResponseIsGenericResult_ShortCircuitsBeforeNext()
+    public async Task HandleAsync_WhenInvalidAndResponseIsGenericResult_ReturnsFailureAndShortCircuits()
     {
         // Arrange
-        // NOTE: The Result<T> branch in ValidationBehavior uses reflection
-        // (typeof(Result<>).MakeGenericType(...).GetMethod("Failure", new[] { typeof(Error) })).
-        // Because Failure<T>(Error) lives on the non-generic Result base, the lookup returns
-        // null without BindingFlags.FlattenHierarchy, so the behavior currently returns null
-        // instead of Result<T>.Failure. We assert the *short-circuit* (no call to next) here,
-        // since asserting "expected failure result" would surface the upstream bug; the
-        // returned value itself is intentionally not asserted.
         var behavior = new ValidationBehavior<ValidatableRequest, Result<int>>();
         var nextCalled = false;
 
         // Act
-        _ = await behavior.HandleAsync(
+        var actual = await behavior.HandleAsync(
             new ValidatableRequest { Name = null, Quantity = 0 },
             () =>
             {
@@ -94,6 +87,10 @@ public class ValidationBehaviorTests
             CancellationToken.None);
 
         // Assert
+        actual.Should().NotBeNull();
+        actual.IsFailure.Should().BeTrue();
+        actual.Error.Code.Should().Be("Validation.Failed");
+        actual.Error.Type.Should().Be(ErrorType.Validation);
         nextCalled.Should().BeFalse();
     }
 


### PR DESCRIPTION
## Summary

Fixes [POM-482](https://github.com/sassy-solutions/compendium/issues) — `ValidationBehavior` was returning `null` (cast to `TResponse`) for the `Result<T>` failure path, silently corrupting the CQRS pipeline for any handler whose response is `Result<TValue>`.

## Root cause

`src/Application/Compendium.Application/CQRS/Behaviors/ValidationBehavior.cs:40-44` did :

\`\`\`csharp
var failureMethod = typeof(Result<>).MakeGenericType(resultType)
    .GetMethod(nameof(Result<object>.Failure), new[] { typeof(Error) });

var result = failureMethod?.Invoke(null, new object[] { error });  // ← null in production
return (TResponse)result!;
\`\`\`

\`Failure<T>(Error)\` is a static **on the non-generic \`Result\` base class** (`src/Core/Compendium.Core/Results/Result.cs:88`). \`GetMethod\` on the closed generic \`Result<TValue>\` does not surface inherited statics without \`BindingFlags.FlattenHierarchy\`, so the lookup returned \`null\` and the null-conditional invocation silently produced \`null\`.

## Fix

Resolve the static through the non-generic \`Result\` type and close it over the response's inner type via \`MakeGenericMethod\` :

\`\`\`csharp
var failureMethod = typeof(Result)
    .GetMethods(BindingFlags.Public | BindingFlags.Static)
    .Single(m => m.Name == nameof(Result.Failure)
              && m.IsGenericMethodDefinition
              && m.GetParameters().Length == 1
              && m.GetParameters()[0].ParameterType == typeof(Error))
    .MakeGenericMethod(resultType);
\`\`\`

## Test

The existing \`HandleAsync_WhenInvalidAndResponseIsGenericResult_ShortCircuitsBeforeNext\` was renamed to \`_ReturnsFailureAndShortCircuits\` and now asserts :
- \`actual.Should().NotBeNull()\`
- \`actual.IsFailure.Should().BeTrue()\`
- \`actual.Error.Code.Should().Be(\"Validation.Failed\")\`
- \`actual.Error.Type.Should().Be(ErrorType.Validation)\`
- \`nextCalled.Should().BeFalse()\`

The previous version accepted the buggy \`null\` with a comment — that comment is now removed.

## Verification

- \`dotnet test tests/Unit/Compendium.Application.Tests\` → 225/225 green locally.
- No regression in any other Application test (LoggingBehavior, TransactionBehavior, IdempotencyBehavior, dispatchers, etc.).
- No prod-code change outside the affected method body + a single \`using System.Reflection;\`.

## Release impact

After merge, target framework v1.0.1 → republishes \`Compendium.Application\`.

## Test plan

- [ ] CI green (build + 90 % coverage gate).
- [ ] CodeQL green.
- [ ] User reviews and merges.