### PR TITLE
fix(framework): restore Compendium.Abstractions.Storage assembly (bug e263abc6)

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -175,6 +175,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration", "Integration"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests", "tests\Integration\Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests\Compendium.Adapters.Kubernetes.Sandbox.IntegrationTests.csproj", "{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Storage", "src\Abstractions\Compendium.Abstractions.Storage\Compendium.Abstractions.Storage.csproj", "{B4108100-52A7-4680-A0C4-7EB6955DB5F6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Storage.Tests", "tests\Unit\Compendium.Abstractions.Storage.Tests\Compendium.Abstractions.Storage.Tests.csproj", "{585E082A-E775-426B-BEA5-D41D3AF53DE7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -448,6 +452,14 @@ Global
 		{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4108100-52A7-4680-A0C4-7EB6955DB5F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4108100-52A7-4680-A0C4-7EB6955DB5F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4108100-52A7-4680-A0C4-7EB6955DB5F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4108100-52A7-4680-A0C4-7EB6955DB5F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{585E082A-E775-426B-BEA5-D41D3AF53DE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{585E082A-E775-426B-BEA5-D41D3AF53DE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{585E082A-E775-426B-BEA5-D41D3AF53DE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{585E082A-E775-426B-BEA5-D41D3AF53DE7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -529,5 +541,7 @@ Global
 		{D098747F-BBF1-488B-9CC6-0E89D693440D} = {0CB45A8C-EFA9-418F-A1DE-1C5B082B238A}
 		{BFC22E6F-1619-4CC2-9773-0B57DA972B64} = {17245130-8317-4D67-B86D-BFA713DE2C1C}
 		{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B} = {A2517BFF-352C-4123-81B2-2D848F3FB497}
+		{B4108100-52A7-4680-A0C4-7EB6955DB5F6} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
+		{585E082A-E775-426B-BEA5-D41D3AF53DE7} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/src/Abstractions/Compendium.Abstractions.Storage/Compendium.Abstractions.Storage.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Storage/Compendium.Abstractions.Storage.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Storage</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Storage</RootNamespace>
+    <PackageId>Compendium.Abstractions.Storage</PackageId>
+    <Description>Object-storage abstractions for Compendium Framework: IObjectStore port for provider-agnostic object/blob storage (Put / Get / Delete / Exists / List / Presign).</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Compendium.Abstractions\Compendium.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Storage.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Storage/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Storage/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.Storage/IObjectStore.cs
+++ b/src/Abstractions/Compendium.Abstractions.Storage/IObjectStore.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="IObjectStore.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Storage.Models;
+
+namespace Compendium.Abstractions.Storage;
+
+/// <summary>
+/// Provides provider-agnostic object/blob storage operations.
+/// Implementations target backends such as AWS S3, Azure Blob Storage, Google Cloud Storage,
+/// MinIO, or local filesystems.
+/// </summary>
+public interface IObjectStore
+{
+    /// <summary>
+    /// Uploads an object to the store, replacing any existing object at the same key.
+    /// </summary>
+    /// <param name="key">The object key (path) inside the bucket / container.</param>
+    /// <param name="content">The readable stream containing the payload to upload.</param>
+    /// <param name="metadata">Optional metadata (content type, cache control, custom headers).</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the stored <see cref="ObjectInfo"/> on success, or an error.</returns>
+    Task<Result<ObjectInfo>> PutAsync(
+        string key,
+        Stream content,
+        ObjectMetadata? metadata = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Downloads an object from the store. The caller is responsible for disposing the returned <see cref="ObjectStream"/>.
+    /// </summary>
+    /// <param name="key">The object key to fetch.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the <see cref="ObjectStream"/> on success, or an error.</returns>
+    Task<Result<ObjectStream>> GetAsync(
+        string key,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes an object from the store. Deleting a non-existent key returns success.
+    /// </summary>
+    /// <param name="key">The object key to delete.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result indicating success or an error.</returns>
+    Task<Result> DeleteAsync(
+        string key,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines whether an object exists at the given key.
+    /// </summary>
+    /// <param name="key">The object key to test.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing <c>true</c> if the object exists, otherwise <c>false</c>; or an error.</returns>
+    Task<Result<bool>> ExistsAsync(
+        string key,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists a single page of objects matching the supplied options.
+    /// </summary>
+    /// <param name="options">Listing options (prefix, page size, continuation token). When <c>null</c>, defaults are used.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the next <see cref="ListPage"/>, or an error.</returns>
+    Task<Result<ListPage>> ListAsync(
+        ListOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates a time-limited presigned URL that allows performing the given action without further authentication.
+    /// </summary>
+    /// <param name="key">The object key to presign.</param>
+    /// <param name="action">The action allowed by the presigned URL (<see cref="PresignedAction.Get"/> or <see cref="PresignedAction.Put"/>).</param>
+    /// <param name="expiresIn">The lifetime of the presigned URL.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the presigned URL, or an error.</returns>
+    Task<Result<Uri>> GetPresignedUrlAsync(
+        string key,
+        PresignedAction action,
+        TimeSpan expiresIn,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/Compendium.Abstractions.Storage/Models/ListOptions.cs
+++ b/src/Abstractions/Compendium.Abstractions.Storage/Models/ListOptions.cs
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------
+// <copyright file="ListOptions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage.Models;
+
+/// <summary>
+/// Specifies options for listing objects in an object store.
+/// </summary>
+/// <param name="Prefix">If set, only objects whose key starts with this prefix are returned.</param>
+/// <param name="MaxKeys">The maximum number of keys to return in a single page. Defaults to <c>1000</c>.</param>
+/// <param name="ContinuationToken">An opaque token returned by a previous list call to fetch the next page.</param>
+public sealed record ListOptions(
+    string? Prefix = null,
+    int MaxKeys = 1000,
+    string? ContinuationToken = null);
+
+/// <summary>
+/// Represents a single page of results returned by <see cref="IObjectStore.ListAsync"/>.
+/// </summary>
+/// <param name="Items">The objects in this page, in provider-defined order.</param>
+/// <param name="NextContinuationToken">An opaque token used to fetch the next page, or <c>null</c> if no more pages remain.</param>
+public sealed record ListPage(
+    IReadOnlyList<ObjectInfo> Items,
+    string? NextContinuationToken = null);

--- a/src/Abstractions/Compendium.Abstractions.Storage/Models/ObjectInfo.cs
+++ b/src/Abstractions/Compendium.Abstractions.Storage/Models/ObjectInfo.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------
+// <copyright file="ObjectInfo.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage.Models;
+
+/// <summary>
+/// Describes an object stored in an object store.
+/// </summary>
+/// <param name="Key">The object key (path) inside the bucket / container.</param>
+/// <param name="Size">The size of the object in bytes.</param>
+/// <param name="ETag">The provider-supplied entity tag (typically a content hash).</param>
+/// <param name="ContentType">The MIME type of the object, when known.</param>
+/// <param name="LastModified">The UTC instant at which the object was last modified.</param>
+/// <param name="Metadata">Arbitrary user-defined metadata associated with the object.</param>
+public sealed record ObjectInfo(
+    string Key,
+    long Size,
+    string ETag,
+    string? ContentType,
+    DateTimeOffset LastModified,
+    IReadOnlyDictionary<string, string>? Metadata = null);

--- a/src/Abstractions/Compendium.Abstractions.Storage/Models/ObjectMetadata.cs
+++ b/src/Abstractions/Compendium.Abstractions.Storage/Models/ObjectMetadata.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+// <copyright file="ObjectMetadata.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage.Models;
+
+/// <summary>
+/// Describes metadata applied to an object on upload.
+/// </summary>
+/// <param name="ContentType">The MIME type of the object (for example <c>image/png</c>).</param>
+/// <param name="CacheControl">The HTTP <c>Cache-Control</c> header to apply when serving the object.</param>
+/// <param name="ContentDisposition">The HTTP <c>Content-Disposition</c> header to apply when serving the object.</param>
+/// <param name="Custom">Arbitrary user-defined metadata stored alongside the object.</param>
+public sealed record ObjectMetadata(
+    string? ContentType = null,
+    string? CacheControl = null,
+    string? ContentDisposition = null,
+    IReadOnlyDictionary<string, string>? Custom = null);

--- a/src/Abstractions/Compendium.Abstractions.Storage/Models/ObjectStream.cs
+++ b/src/Abstractions/Compendium.Abstractions.Storage/Models/ObjectStream.cs
@@ -1,0 +1,78 @@
+// -----------------------------------------------------------------------
+// <copyright file="ObjectStream.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage.Models;
+
+/// <summary>
+/// Represents the content of an object together with its metadata, returned by
+/// <see cref="IObjectStore.GetAsync"/>.
+/// </summary>
+/// <remarks>
+/// Disposing this instance disposes the underlying <see cref="System.IO.Stream"/>.
+/// Callers should always dispose the returned object (typically with <c>using</c>).
+/// </remarks>
+public sealed class ObjectStream : IDisposable, IAsyncDisposable
+{
+    private readonly Stream _content;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObjectStream"/> class.
+    /// </summary>
+    /// <param name="content">The readable content stream. Ownership is transferred to this instance.</param>
+    /// <param name="info">The metadata describing the object.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="content"/> or <paramref name="info"/> is <c>null</c>.</exception>
+    public ObjectStream(Stream content, ObjectInfo info)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(info);
+
+        _content = content;
+        Info = info;
+    }
+
+    /// <summary>
+    /// Gets the readable stream containing the object payload.
+    /// </summary>
+    public Stream Content
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _content;
+        }
+    }
+
+    /// <summary>
+    /// Gets the metadata describing the object.
+    /// </summary>
+    public ObjectInfo Info { get; }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _content.Dispose();
+        _disposed = true;
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await _content.DisposeAsync().ConfigureAwait(false);
+        _disposed = true;
+    }
+}

--- a/src/Abstractions/Compendium.Abstractions.Storage/Models/PresignedAction.cs
+++ b/src/Abstractions/Compendium.Abstractions.Storage/Models/PresignedAction.cs
@@ -1,0 +1,24 @@
+// -----------------------------------------------------------------------
+// <copyright file="PresignedAction.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage.Models;
+
+/// <summary>
+/// Specifies the action allowed by a presigned URL.
+/// </summary>
+public enum PresignedAction
+{
+    /// <summary>
+    /// Allows downloading the object via the presigned URL (HTTP GET).
+    /// </summary>
+    Get = 0,
+
+    /// <summary>
+    /// Allows uploading the object via the presigned URL (HTTP PUT).
+    /// </summary>
+    Put = 1,
+}

--- a/src/Abstractions/Compendium.Abstractions.Storage/StorageErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Storage/StorageErrors.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------
+// <copyright file="StorageErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage;
+
+/// <summary>
+/// Provides standardized error definitions for object-storage operations.
+/// </summary>
+public static class StorageErrors
+{
+    /// <summary>
+    /// Gets the error code prefix for storage errors.
+    /// </summary>
+    public const string Prefix = "Storage";
+
+    /// <summary>
+    /// The requested object key was not found in the bucket.
+    /// </summary>
+    public static Error NotFound(string key) =>
+        Error.NotFound($"{Prefix}.NotFound", $"Object '{key}' was not found.");
+
+    /// <summary>
+    /// The caller does not have permission to perform the requested operation.
+    /// </summary>
+    public static Error AccessDenied(string key) =>
+        Error.Forbidden($"{Prefix}.AccessDenied", $"Access denied for object '{key}'.");
+
+    /// <summary>
+    /// The bucket name is missing, malformed, or does not exist.
+    /// </summary>
+    public static Error InvalidBucket(string bucket) =>
+        Error.Validation($"{Prefix}.InvalidBucket", $"Bucket '{bucket}' is invalid or does not exist.");
+
+    /// <summary>
+    /// The provider rejected the request because too many requests have been issued.
+    /// </summary>
+    public static Error Throttled(TimeSpan? retryAfter = null) =>
+        Error.TooManyRequests(
+            $"{Prefix}.Throttled",
+            retryAfter.HasValue
+                ? $"Storage provider throttled the request. Retry after {retryAfter.Value.TotalSeconds} seconds."
+                : "Storage provider throttled the request. Please try again later.");
+
+    /// <summary>
+    /// The object payload exceeds the maximum allowed size.
+    /// </summary>
+    public static Error ContentTooLarge(long size, long maximum) =>
+        Error.Validation(
+            $"{Prefix}.ContentTooLarge",
+            $"Object size {size} bytes exceeds the maximum of {maximum} bytes.");
+
+    /// <summary>
+    /// An object with the same key already exists and the operation requires it to be absent.
+    /// </summary>
+    public static Error ConflictExists(string key) =>
+        Error.Conflict($"{Prefix}.ConflictExists", $"Object '{key}' already exists.");
+}

--- a/tests/Unit/Compendium.Abstractions.Storage.Tests/Compendium.Abstractions.Storage.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Storage.Tests/Compendium.Abstractions.Storage.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Storage.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Storage.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Storage\Compendium.Abstractions.Storage.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Storage.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Storage.Tests/GlobalUsings.cs
@@ -1,0 +1,13 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Xunit;
+global using FluentAssertions;
+global using NSubstitute;
+global using Compendium.Abstractions.Storage;
+global using Compendium.Abstractions.Storage.Models;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Abstractions.Storage.Tests/Models/ListOptionsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Storage.Tests/Models/ListOptionsTests.cs
@@ -1,0 +1,151 @@
+// -----------------------------------------------------------------------
+// <copyright file="ListOptionsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage.Tests.Models;
+
+public class ListOptionsTests
+{
+    [Fact]
+    public void ListOptions_Defaults_PrefixNull_MaxKeysOneThousand_TokenNull()
+    {
+        // Act
+        var options = new ListOptions();
+
+        // Assert
+        options.Prefix.Should().BeNull();
+        options.MaxKeys.Should().Be(1000);
+        options.ContinuationToken.Should().BeNull();
+    }
+
+    [Fact]
+    public void ListOptions_Constructor_StoresAllValues()
+    {
+        // Act
+        var options = new ListOptions(Prefix: "tenants/t-1/", MaxKeys: 50, ContinuationToken: "tok-42");
+
+        // Assert
+        options.Prefix.Should().Be("tenants/t-1/");
+        options.MaxKeys.Should().Be(50);
+        options.ContinuationToken.Should().Be("tok-42");
+    }
+
+    [Fact]
+    public void ListOptions_Equality_IdenticalRecords_AreEqual()
+    {
+        // Arrange
+        var a = new ListOptions("p", 10, "t");
+        var b = new ListOptions("p", 10, "t");
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void ListOptions_WithExpression_CreatesModifiedCopy()
+    {
+        // Arrange
+        var original = new ListOptions("p", 10, "t1");
+
+        // Act
+        var copy = original with { ContinuationToken = "t2" };
+
+        // Assert
+        copy.Prefix.Should().Be("p");
+        copy.MaxKeys.Should().Be(10);
+        copy.ContinuationToken.Should().Be("t2");
+        copy.Should().NotBe(original);
+    }
+
+    [Fact]
+    public void ListOptions_ToString_IncludesFieldNames()
+    {
+        // Arrange
+        var options = new ListOptions("p", 10, "t");
+
+        // Act
+        var text = options.ToString();
+
+        // Assert
+        text.Should().Contain("Prefix");
+        text.Should().Contain("MaxKeys");
+        text.Should().Contain("ContinuationToken");
+    }
+
+    [Fact]
+    public void ListPage_Constructor_StoresItemsAndToken()
+    {
+        // Arrange
+        var items = new List<ObjectInfo>
+        {
+            new("k1", 1, "e1", null, DateTimeOffset.UnixEpoch),
+            new("k2", 2, "e2", null, DateTimeOffset.UnixEpoch),
+        };
+
+        // Act
+        var page = new ListPage(items, "next-tok");
+
+        // Assert
+        page.Items.Should().BeSameAs(items);
+        page.NextContinuationToken.Should().Be("next-tok");
+    }
+
+    [Fact]
+    public void ListPage_Constructor_DefaultsTokenToNull()
+    {
+        // Arrange
+        var items = Array.Empty<ObjectInfo>();
+
+        // Act
+        var page = new ListPage(items);
+
+        // Assert
+        page.Items.Should().BeSameAs(items);
+        page.NextContinuationToken.Should().BeNull();
+    }
+
+    [Fact]
+    public void ListPage_Equality_SameItemsReferenceAndToken_AreEqual()
+    {
+        // Arrange
+        var items = new List<ObjectInfo>();
+        var a = new ListPage(items, "t");
+        var b = new ListPage(items, "t");
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void ListPage_WithExpression_CreatesModifiedCopy()
+    {
+        // Arrange
+        var original = new ListPage(Array.Empty<ObjectInfo>(), "t1");
+
+        // Act
+        var copy = original with { NextContinuationToken = "t2" };
+
+        // Assert
+        copy.NextContinuationToken.Should().Be("t2");
+        copy.Should().NotBe(original);
+    }
+
+    [Fact]
+    public void ListPage_ToString_IncludesFieldNames()
+    {
+        // Arrange
+        var page = new ListPage(Array.Empty<ObjectInfo>(), "t");
+
+        // Act
+        var text = page.ToString();
+
+        // Assert
+        text.Should().Contain("Items");
+        text.Should().Contain("NextContinuationToken");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Storage.Tests/Models/ObjectInfoTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Storage.Tests/Models/ObjectInfoTests.cs
@@ -1,0 +1,111 @@
+// -----------------------------------------------------------------------
+// <copyright file="ObjectInfoTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage.Tests.Models;
+
+public class ObjectInfoTests
+{
+    private static ObjectInfo Sample(
+        string key = "tenants/t-1/file.png",
+        long size = 1024,
+        string etag = "abc",
+        string? contentType = "image/png",
+        IReadOnlyDictionary<string, string>? metadata = null)
+    {
+        return new ObjectInfo(
+            key,
+            size,
+            etag,
+            contentType,
+            new DateTimeOffset(2026, 5, 10, 12, 0, 0, TimeSpan.Zero),
+            metadata);
+    }
+
+    [Fact]
+    public void ObjectInfo_Constructor_StoresAllValues()
+    {
+        // Arrange
+        var lastModified = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var metadata = new Dictionary<string, string> { ["owner"] = "alice" };
+
+        // Act
+        var info = new ObjectInfo("k", 42, "etag-1", "text/plain", lastModified, metadata);
+
+        // Assert
+        info.Key.Should().Be("k");
+        info.Size.Should().Be(42);
+        info.ETag.Should().Be("etag-1");
+        info.ContentType.Should().Be("text/plain");
+        info.LastModified.Should().Be(lastModified);
+        info.Metadata.Should().BeSameAs(metadata);
+    }
+
+    [Fact]
+    public void ObjectInfo_Metadata_DefaultsToNull()
+    {
+        // Act
+        var info = new ObjectInfo("k", 0, "e", null, DateTimeOffset.UnixEpoch);
+
+        // Assert
+        info.ContentType.Should().BeNull();
+        info.Metadata.Should().BeNull();
+    }
+
+    [Fact]
+    public void ObjectInfo_Equality_TwoIdenticalRecords_AreEqual()
+    {
+        // Arrange
+        var a = Sample();
+        var b = Sample();
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void ObjectInfo_Equality_DifferentKey_AreNotEqual()
+    {
+        // Arrange
+        var a = Sample(key: "a");
+        var b = Sample(key: "b");
+
+        // Act / Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void ObjectInfo_WithExpression_CreatesModifiedCopy()
+    {
+        // Arrange
+        var original = Sample();
+
+        // Act
+        var copy = original with { Size = 9999, ETag = "new-etag" };
+
+        // Assert
+        copy.Should().NotBe(original);
+        copy.Size.Should().Be(9999);
+        copy.ETag.Should().Be("new-etag");
+        copy.Key.Should().Be(original.Key);
+        copy.LastModified.Should().Be(original.LastModified);
+    }
+
+    [Fact]
+    public void ObjectInfo_ToString_IncludesAllFieldNames()
+    {
+        // Arrange
+        var info = Sample();
+
+        // Act
+        var text = info.ToString();
+
+        // Assert
+        text.Should().Contain("Key").And.Contain("Size").And.Contain("ETag");
+        text.Should().Contain("ContentType").And.Contain("LastModified").And.Contain("Metadata");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Storage.Tests/Models/ObjectMetadataTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Storage.Tests/Models/ObjectMetadataTests.cs
@@ -1,0 +1,98 @@
+// -----------------------------------------------------------------------
+// <copyright file="ObjectMetadataTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage.Tests.Models;
+
+public class ObjectMetadataTests
+{
+    [Fact]
+    public void ObjectMetadata_DefaultConstructor_AllFieldsNull()
+    {
+        // Act
+        var metadata = new ObjectMetadata();
+
+        // Assert
+        metadata.ContentType.Should().BeNull();
+        metadata.CacheControl.Should().BeNull();
+        metadata.ContentDisposition.Should().BeNull();
+        metadata.Custom.Should().BeNull();
+    }
+
+    [Fact]
+    public void ObjectMetadata_Constructor_StoresAllValues()
+    {
+        // Arrange
+        var custom = new Dictionary<string, string> { ["x-owner"] = "bob" };
+
+        // Act
+        var metadata = new ObjectMetadata(
+            ContentType: "application/pdf",
+            CacheControl: "max-age=3600",
+            ContentDisposition: "attachment; filename=foo.pdf",
+            Custom: custom);
+
+        // Assert
+        metadata.ContentType.Should().Be("application/pdf");
+        metadata.CacheControl.Should().Be("max-age=3600");
+        metadata.ContentDisposition.Should().Be("attachment; filename=foo.pdf");
+        metadata.Custom.Should().BeSameAs(custom);
+    }
+
+    [Fact]
+    public void ObjectMetadata_Equality_IdenticalRecords_AreEqual()
+    {
+        // Arrange
+        var a = new ObjectMetadata("text/plain", "no-cache", "inline");
+        var b = new ObjectMetadata("text/plain", "no-cache", "inline");
+
+        // Act / Assert
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void ObjectMetadata_Equality_DifferentContentType_AreNotEqual()
+    {
+        // Arrange
+        var a = new ObjectMetadata(ContentType: "text/plain");
+        var b = new ObjectMetadata(ContentType: "text/html");
+
+        // Act / Assert
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void ObjectMetadata_WithExpression_CreatesModifiedCopy()
+    {
+        // Arrange
+        var original = new ObjectMetadata("text/plain", "no-cache");
+
+        // Act
+        var copy = original with { CacheControl = "max-age=60" };
+
+        // Assert
+        copy.ContentType.Should().Be("text/plain");
+        copy.CacheControl.Should().Be("max-age=60");
+        copy.Should().NotBe(original);
+    }
+
+    [Fact]
+    public void ObjectMetadata_ToString_IncludesFieldNames()
+    {
+        // Arrange
+        var metadata = new ObjectMetadata("text/plain");
+
+        // Act
+        var text = metadata.ToString();
+
+        // Assert
+        text.Should().Contain("ContentType");
+        text.Should().Contain("CacheControl");
+        text.Should().Contain("ContentDisposition");
+        text.Should().Contain("Custom");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Storage.Tests/Models/ObjectStreamTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Storage.Tests/Models/ObjectStreamTests.cs
@@ -1,0 +1,159 @@
+// -----------------------------------------------------------------------
+// <copyright file="ObjectStreamTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage.Tests.Models;
+
+public class ObjectStreamTests
+{
+    private static ObjectInfo SampleInfo() => new(
+        "k",
+        4,
+        "etag",
+        "text/plain",
+        new DateTimeOffset(2026, 5, 10, 0, 0, 0, TimeSpan.Zero));
+
+    [Fact]
+    public void ObjectStream_Constructor_StoresContentAndInfo()
+    {
+        // Arrange
+        var content = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+        var info = SampleInfo();
+
+        // Act
+        using var stream = new ObjectStream(content, info);
+
+        // Assert
+        stream.Content.Should().BeSameAs(content);
+        stream.Info.Should().BeSameAs(info);
+    }
+
+    [Fact]
+    public void ObjectStream_Constructor_NullContent_Throws()
+    {
+        // Arrange
+        var info = SampleInfo();
+
+        // Act
+        Action act = () => _ = new ObjectStream(null!, info);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("content");
+    }
+
+    [Fact]
+    public void ObjectStream_Constructor_NullInfo_Throws()
+    {
+        // Arrange
+        using var content = new MemoryStream();
+
+        // Act
+        Action act = () => _ = new ObjectStream(content, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("info");
+    }
+
+    [Fact]
+    public void ObjectStream_Dispose_DisposesUnderlyingStream()
+    {
+        // Arrange
+        var content = new TrackingStream();
+        var stream = new ObjectStream(content, SampleInfo());
+
+        // Act
+        stream.Dispose();
+
+        // Assert
+        content.IsDisposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ObjectStream_Dispose_CalledTwice_OnlyDisposesOnce()
+    {
+        // Arrange
+        var content = new TrackingStream();
+        var stream = new ObjectStream(content, SampleInfo());
+
+        // Act
+        stream.Dispose();
+        stream.Dispose();
+
+        // Assert
+        content.DisposeCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void ObjectStream_Content_AfterDispose_Throws()
+    {
+        // Arrange
+        var stream = new ObjectStream(new MemoryStream(), SampleInfo());
+        stream.Dispose();
+
+        // Act
+        Action act = () => _ = stream.Content;
+
+        // Assert
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task ObjectStream_DisposeAsync_DisposesUnderlyingStream()
+    {
+        // Arrange
+        var content = new TrackingStream();
+        var stream = new ObjectStream(content, SampleInfo());
+
+        // Act
+        await stream.DisposeAsync();
+
+        // Assert
+        content.IsDisposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ObjectStream_DisposeAsync_CalledTwice_OnlyDisposesOnce()
+    {
+        // Arrange
+        var content = new TrackingStream();
+        var stream = new ObjectStream(content, SampleInfo());
+
+        // Act
+        await stream.DisposeAsync();
+        await stream.DisposeAsync();
+
+        // Assert
+        content.DisposeCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void ObjectStream_Info_RemainsAccessibleAfterDispose()
+    {
+        // Arrange
+        var info = SampleInfo();
+        var stream = new ObjectStream(new MemoryStream(), info);
+
+        // Act
+        stream.Dispose();
+
+        // Assert
+        stream.Info.Should().BeSameAs(info);
+    }
+
+    private sealed class TrackingStream : MemoryStream
+    {
+        public int DisposeCount { get; private set; }
+
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCount++;
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Storage.Tests/Models/PresignedActionTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Storage.Tests/Models/PresignedActionTests.cs
@@ -1,0 +1,59 @@
+// -----------------------------------------------------------------------
+// <copyright file="PresignedActionTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage.Tests.Models;
+
+public class PresignedActionTests
+{
+    [Fact]
+    public void PresignedAction_Get_HasValueZero()
+    {
+        // Arrange
+        var action = PresignedAction.Get;
+
+        // Act
+        var value = (int)action;
+
+        // Assert
+        value.Should().Be(0);
+    }
+
+    [Fact]
+    public void PresignedAction_Put_HasValueOne()
+    {
+        // Arrange
+        var action = PresignedAction.Put;
+
+        // Act
+        var value = (int)action;
+
+        // Assert
+        value.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(PresignedAction.Get, "Get")]
+    [InlineData(PresignedAction.Put, "Put")]
+    public void PresignedAction_ToString_ReturnsName(PresignedAction action, string expected)
+    {
+        // Act
+        var actual = action.ToString();
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void PresignedAction_DefinedValues_AreExactlyGetAndPut()
+    {
+        // Act
+        var values = Enum.GetValues<PresignedAction>();
+
+        // Assert
+        values.Should().BeEquivalentTo(new[] { PresignedAction.Get, PresignedAction.Put });
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Storage.Tests/StorageErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Storage.Tests/StorageErrorsTests.cs
@@ -1,0 +1,106 @@
+// -----------------------------------------------------------------------
+// <copyright file="StorageErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Storage.Tests;
+
+public class StorageErrorsTests
+{
+    [Fact]
+    public void Prefix_IsStorage()
+    {
+        // Act / Assert
+        StorageErrors.Prefix.Should().Be("Storage");
+    }
+
+    [Fact]
+    public void NotFound_ReturnsNotFoundErrorWithKey()
+    {
+        // Act
+        var error = StorageErrors.NotFound("tenants/t-1/file.png");
+
+        // Assert
+        error.Code.Should().Be("Storage.NotFound");
+        error.Type.Should().Be(ErrorType.NotFound);
+        error.Message.Should().Contain("tenants/t-1/file.png");
+    }
+
+    [Fact]
+    public void AccessDenied_ReturnsForbiddenErrorWithKey()
+    {
+        // Act
+        var error = StorageErrors.AccessDenied("private/secret.txt");
+
+        // Assert
+        error.Code.Should().Be("Storage.AccessDenied");
+        error.Type.Should().Be(ErrorType.Forbidden);
+        error.Message.Should().Contain("private/secret.txt");
+    }
+
+    [Fact]
+    public void InvalidBucket_ReturnsValidationErrorWithBucket()
+    {
+        // Act
+        var error = StorageErrors.InvalidBucket("BadBucketName");
+
+        // Assert
+        error.Code.Should().Be("Storage.InvalidBucket");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain("BadBucketName");
+    }
+
+    [Fact]
+    public void Throttled_WithoutRetryAfter_ReturnsTooManyRequestsGenericMessage()
+    {
+        // Act
+        var error = StorageErrors.Throttled();
+
+        // Assert
+        error.Code.Should().Be("Storage.Throttled");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().Contain("throttled");
+    }
+
+    [Fact]
+    public void Throttled_WithRetryAfter_IncludesSeconds()
+    {
+        // Arrange
+        var retryAfter = TimeSpan.FromSeconds(45);
+
+        // Act
+        var error = StorageErrors.Throttled(retryAfter);
+
+        // Assert
+        error.Code.Should().Be("Storage.Throttled");
+        error.Type.Should().Be(ErrorType.TooManyRequests);
+        error.Message.Should().Contain("45");
+    }
+
+    [Fact]
+    public void ContentTooLarge_ReturnsValidationErrorWithSizes()
+    {
+        // Act
+        var error = StorageErrors.ContentTooLarge(size: 5_000_000, maximum: 1_000_000);
+
+        // Assert
+        error.Code.Should().Be("Storage.ContentTooLarge");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain("5000000");
+        error.Message.Should().Contain("1000000");
+    }
+
+    [Fact]
+    public void ConflictExists_ReturnsConflictErrorWithKey()
+    {
+        // Act
+        var error = StorageErrors.ConflictExists("tenants/t-1/file.png");
+
+        // Assert
+        error.Code.Should().Be("Storage.ConflictExists");
+        error.Type.Should().Be(ErrorType.Conflict);
+        error.Message.Should().Contain("tenants/t-1/file.png");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes VK bug `e263abc6` — \`Compendium.Abstractions.Storage\` was added by PR #69 then accidentally lost in the squash + a subsequent sln edit, so the assembly never shipped to nuget despite PR #69 claiming 44 tests at 100% coverage.

This commit restores the 17 files from \`4869762\` (the original feature-branch tip) verbatim and re-adds the two \`.sln\` entries.

## Files restored

\`\`\`
src/Abstractions/Compendium.Abstractions.Storage/
  Compendium.Abstractions.Storage.csproj
  GlobalUsings.cs
  IObjectStore.cs
  Models/ListOptions.cs, ObjectInfo.cs, ObjectMetadata.cs, ObjectStream.cs, PresignedAction.cs
  StorageErrors.cs

tests/Unit/Compendium.Abstractions.Storage.Tests/
  Compendium.Abstractions.Storage.Tests.csproj
  GlobalUsings.cs
  Models/{ListOptions,ObjectInfo,ObjectMetadata,ObjectStream,PresignedAction}Tests.cs
  StorageErrorsTests.cs
\`\`\`

## Verification

- \`dotnet build src/Abstractions/Compendium.Abstractions.Storage\` → 0 warnings, 0 errors.
- \`dotnet test tests/Unit/Compendium.Abstractions.Storage.Tests\` → **44/44 green** (100% line + branch coverage on the surface).
- \`Compendium.sln\` lists both projects under Abstractions/Tests solution folders.
- Full sln build still green; no regression in existing tests.

## What unlocks

- After merge → tag \`v1.0.2\` → \`Compendium.Abstractions.Storage@1.0.2\` ships to nuget (along with all other Compendium.* at 1.0.2; mechanical re-tag).
- Follow-up PR on \`compendium-adapter-s3\` removes its inlined \`IObjectStore\` types and binds \`<PackageReference Include=\"Compendium.Abstractions.Storage\" Version=\"1.0.2\" />\`.
- \`compendium-adapter-azure-blob\` (POM-519) + \`compendium-adapter-gcs\` (POM-520) are now unblocked.

## Test plan

- [ ] CI green.
- [ ] Visual check of restored files matches \`git show 4869762\` (it does — `git checkout 4869762 -- ...`).