### PR TITLE
feat(caching): ICache port + InMemoryCache adapter (POM-512)

### DIFF
--- a/Compendium.sln
+++ b/Compendium.sln
@@ -179,6 +179,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Sto
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Storage.Tests", "tests\Unit\Compendium.Abstractions.Storage.Tests\Compendium.Abstractions.Storage.Tests.csproj", "{585E082A-E775-426B-BEA5-D41D3AF53DE7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Caching", "src\Abstractions\Compendium.Abstractions.Caching\Compendium.Abstractions.Caching.csproj", "{4A6496B8-5833-428F-92D7-3EB331F5CA32}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compendium.Abstractions.Caching.Tests", "tests\Unit\Compendium.Abstractions.Caching.Tests\Compendium.Abstractions.Caching.Tests.csproj", "{262B8E91-B53C-49BC-833D-739DD4CFC2E1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -460,6 +464,14 @@ Global
 		{585E082A-E775-426B-BEA5-D41D3AF53DE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{585E082A-E775-426B-BEA5-D41D3AF53DE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{585E082A-E775-426B-BEA5-D41D3AF53DE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A6496B8-5833-428F-92D7-3EB331F5CA32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A6496B8-5833-428F-92D7-3EB331F5CA32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A6496B8-5833-428F-92D7-3EB331F5CA32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A6496B8-5833-428F-92D7-3EB331F5CA32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{262B8E91-B53C-49BC-833D-739DD4CFC2E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{262B8E91-B53C-49BC-833D-739DD4CFC2E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{262B8E91-B53C-49BC-833D-739DD4CFC2E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{262B8E91-B53C-49BC-833D-739DD4CFC2E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FE421F00-7FFD-4666-A961-F1FF325ECD34} = {E35C8F52-5000-4427-9589-AEB5987C1AC6}
@@ -543,5 +555,7 @@ Global
 		{D8DAEEF0-931B-4CE8-BEC4-767162B4CE7B} = {A2517BFF-352C-4123-81B2-2D848F3FB497}
 		{B4108100-52A7-4680-A0C4-7EB6955DB5F6} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
 		{585E082A-E775-426B-BEA5-D41D3AF53DE7} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
+		{4A6496B8-5833-428F-92D7-3EB331F5CA32} = {DE85A2F8-C0BA-47FD-8E9A-7D782FD6D3E2}
+		{262B8E91-B53C-49BC-833D-739DD4CFC2E1} = {6E0B453A-55CF-4567-ADBD-50CFB84CE629}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,8 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.16" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.16" />

--- a/src/Abstractions/Compendium.Abstractions.Caching/CachingErrors.cs
+++ b/src/Abstractions/Compendium.Abstractions.Caching/CachingErrors.cs
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------
+// <copyright file="CachingErrors.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Caching;
+
+/// <summary>
+/// Provides standardized error definitions for caching operations.
+/// </summary>
+public static class CachingErrors
+{
+    /// <summary>
+    /// Gets the error code prefix for caching errors.
+    /// </summary>
+    public const string Prefix = "Caching";
+
+    /// <summary>
+    /// The supplied TTL was zero or negative.
+    /// </summary>
+    public static Error InvalidTtl(TimeSpan ttl) =>
+        Error.Validation(
+            $"{Prefix}.InvalidTtl",
+            $"TTL must be positive; received {ttl}.");
+
+    /// <summary>
+    /// The cache backend failed to satisfy the request and the failure is non-retriable
+    /// from the caller's perspective.
+    /// </summary>
+    public static Error BackendFailure(string message) =>
+        Error.Failure($"{Prefix}.BackendFailure", message);
+}

--- a/src/Abstractions/Compendium.Abstractions.Caching/Compendium.Abstractions.Caching.csproj
+++ b/src/Abstractions/Compendium.Abstractions.Caching/Compendium.Abstractions.Caching.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Caching</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Caching</RootNamespace>
+    <PackageId>Compendium.Abstractions.Caching</PackageId>
+    <Description>Caching abstractions for Compendium Framework: ICache port for provider-agnostic key/value caching (Get / Set / Remove / Exists) with TTL.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Compendium.Abstractions\Compendium.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Compendium.Abstractions.Caching.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Abstractions/Compendium.Abstractions.Caching/GlobalUsings.cs
+++ b/src/Abstractions/Compendium.Abstractions.Caching/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Compendium.Core.Results;

--- a/src/Abstractions/Compendium.Abstractions.Caching/ICache.cs
+++ b/src/Abstractions/Compendium.Abstractions.Caching/ICache.cs
@@ -1,0 +1,69 @@
+// -----------------------------------------------------------------------
+// <copyright file="ICache.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Caching;
+
+/// <summary>
+/// Provides provider-agnostic key/value caching operations with TTL.
+/// Implementations may target backends such as in-memory dictionaries, Redis, Memcached,
+/// or distributed caches behind <c>IDistributedCache</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations should never throw for ordinary cache misses or transient backend failures;
+/// they MUST surface failures via <see cref="Result"/> instead. Argument-validation errors
+/// (null / whitespace key) are permitted to throw.
+/// </para>
+/// <para>
+/// Tenant isolation, key namespacing, and serialization are implementation concerns and
+/// MUST be transparent to callers.
+/// </para>
+/// </remarks>
+public interface ICache
+{
+    /// <summary>
+    /// Retrieves the cached value at <paramref name="key"/>, or <c>null</c> when no
+    /// live entry exists. A missing key is a successful result with a <c>null</c> value,
+    /// not a failure.
+    /// </summary>
+    /// <typeparam name="T">The expected value type.</typeparam>
+    /// <param name="key">The cache key. Must be non-null and non-whitespace.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the cached value (or <c>null</c>), or an error.</returns>
+    Task<Result<T?>> GetAsync<T>(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stores <paramref name="value"/> at <paramref name="key"/>, replacing any existing entry.
+    /// </summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="key">The cache key. Must be non-null and non-whitespace.</param>
+    /// <param name="value">The value to store.</param>
+    /// <param name="ttl">Optional absolute time-to-live. When <c>null</c>, the entry has no expiry.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result indicating success or an error.</returns>
+    Task<Result> SetAsync<T>(
+        string key,
+        T value,
+        TimeSpan? ttl = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes the entry at <paramref name="key"/>. Removing a missing key is a no-op success.
+    /// </summary>
+    /// <param name="key">The cache key. Must be non-null and non-whitespace.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result indicating success or an error.</returns>
+    Task<Result> RemoveAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines whether a live entry exists at <paramref name="key"/>.
+    /// </summary>
+    /// <param name="key">The cache key. Must be non-null and non-whitespace.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing <c>true</c> when an entry exists, otherwise <c>false</c>; or an error.</returns>
+    Task<Result<bool>> ExistsAsync(string key, CancellationToken cancellationToken = default);
+}

--- a/src/Infrastructure/Compendium.Infrastructure/Caching/InMemoryCache.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/Caching/InMemoryCache.cs
@@ -1,0 +1,114 @@
+// -----------------------------------------------------------------------
+// <copyright file="InMemoryCache.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Caching;
+using Compendium.Multitenancy;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Compendium.Infrastructure.Caching;
+
+/// <summary>
+/// In-memory implementation of <see cref="ICache"/> backed by
+/// <see cref="IMemoryCache"/>. Suitable for single-process scenarios, tests,
+/// and framework E2E samples. For multi-instance deployments, use a distributed
+/// adapter (e.g. <c>Compendium.Adapters.Redis</c>).
+/// </summary>
+/// <remarks>
+/// <para><b>Tenant isolation</b>. When an <see cref="ITenantContext"/> with a non-empty
+/// <see cref="ITenantContext.TenantId"/> is resolved from DI, every key is prefixed
+/// with <c>{tenantId}:</c> before being stored. With no tenant context (null or empty
+/// <c>TenantId</c>), keys are written verbatim. The prefix is applied transparently
+/// — callers always see the original key.</para>
+/// <para><b>Thread safety</b>. <see cref="IMemoryCache"/> is thread-safe, so this
+/// adapter is also thread-safe.</para>
+/// <para><b>Result contract</b>. Cache-miss is a successful <see cref="Result{T}"/>
+/// with a <c>null</c> value, never a failure. Argument validation (null/whitespace
+/// key) is permitted to throw <see cref="ArgumentException"/>.</para>
+/// </remarks>
+public sealed class InMemoryCache : ICache
+{
+    private readonly IMemoryCache _memoryCache;
+    private readonly ITenantContext? _tenantContext;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InMemoryCache"/> class.
+    /// </summary>
+    /// <param name="memoryCache">The underlying <see cref="IMemoryCache"/>.</param>
+    /// <param name="tenantContext">Optional tenant context used to scope keys per tenant.</param>
+    public InMemoryCache(IMemoryCache memoryCache, ITenantContext? tenantContext = null)
+    {
+        _memoryCache = memoryCache ?? throw new ArgumentNullException(nameof(memoryCache));
+        _tenantContext = tenantContext;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<T?>> GetAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        var scopedKey = ScopeKey(key);
+
+        if (_memoryCache.TryGetValue(scopedKey, out var raw) && raw is T typed)
+        {
+            return Task.FromResult(Result.Success<T?>(typed));
+        }
+
+        return Task.FromResult(Result.Success<T?>(default));
+    }
+
+    /// <inheritdoc />
+    public Task<Result> SetAsync<T>(
+        string key,
+        T value,
+        TimeSpan? ttl = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        if (ttl.HasValue && ttl.Value <= TimeSpan.Zero)
+        {
+            return Task.FromResult(Result.Failure(CachingErrors.InvalidTtl(ttl.Value)));
+        }
+
+        var options = new MemoryCacheEntryOptions();
+        if (ttl.HasValue)
+        {
+            options.AbsoluteExpirationRelativeToNow = ttl.Value;
+        }
+
+        _memoryCache.Set(ScopeKey(key), value, options);
+        return Task.FromResult(Result.Success());
+    }
+
+    /// <inheritdoc />
+    public Task<Result> RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        _memoryCache.Remove(ScopeKey(key));
+        return Task.FromResult(Result.Success());
+    }
+
+    /// <inheritdoc />
+    public Task<Result<bool>> ExistsAsync(string key, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        var exists = _memoryCache.TryGetValue(ScopeKey(key), out _);
+        return Task.FromResult(Result.Success(exists));
+    }
+
+    /// <summary>
+    /// Applies the active tenant's prefix to <paramref name="key"/>, or returns it unchanged
+    /// when no tenant context is bound.
+    /// </summary>
+    private string ScopeKey(string key)
+    {
+        var tenantId = _tenantContext?.TenantId;
+        return string.IsNullOrEmpty(tenantId) ? key : $"{tenantId}:{key}";
+    }
+}

--- a/src/Infrastructure/Compendium.Infrastructure/Caching/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Compendium.Infrastructure/Caching/ServiceCollectionExtensions.cs
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensions.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Caching;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Compendium.Infrastructure.Caching;
+
+/// <summary>
+/// DI extension methods for registering the in-memory <see cref="ICache"/> adapter.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="InMemoryCache"/> as the <see cref="ICache"/> implementation,
+    /// backed by <see cref="IMemoryCache"/>. The underlying <see cref="IMemoryCache"/> is
+    /// also registered (via <see cref="MemoryCacheServiceCollectionExtensions.AddMemoryCache(IServiceCollection)"/>)
+    /// when no other registration exists.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Optional configuration for the underlying <see cref="MemoryCacheOptions"/>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddInMemoryCache(
+        this IServiceCollection services,
+        Action<MemoryCacheOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        if (configure is null)
+        {
+            services.AddMemoryCache();
+        }
+        else
+        {
+            services.AddMemoryCache(configure);
+        }
+
+        services.TryAddSingleton<ICache, InMemoryCache>();
+
+        return services;
+    }
+}

--- a/src/Infrastructure/Compendium.Infrastructure/Compendium.Infrastructure.csproj
+++ b/src/Infrastructure/Compendium.Infrastructure/Compendium.Infrastructure.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Abstractions\Compendium.Abstractions\Compendium.Abstractions.csproj" />
+    <ProjectReference Include="..\..\Abstractions\Compendium.Abstractions.Caching\Compendium.Abstractions.Caching.csproj" />
     <ProjectReference Include="..\..\Core\Compendium.Core\Compendium.Core.csproj" />
     <ProjectReference Include="..\..\Application\Compendium.Application\Compendium.Application.csproj" />
     <ProjectReference Include="..\..\Multitenancy\Compendium.Multitenancy\Compendium.Multitenancy.csproj" />
@@ -24,6 +25,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="System.Text.Json" />
 
     <!-- Resilience -->

--- a/tests/Unit/Compendium.Abstractions.Caching.Tests/CachingErrorsTests.cs
+++ b/tests/Unit/Compendium.Abstractions.Caching.Tests/CachingErrorsTests.cs
@@ -1,0 +1,43 @@
+// -----------------------------------------------------------------------
+// <copyright file="CachingErrorsTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Compendium.Abstractions.Caching.Tests;
+
+public class CachingErrorsTests
+{
+    [Fact]
+    public void Prefix_IsCaching()
+    {
+        CachingErrors.Prefix.Should().Be("Caching");
+    }
+
+    [Fact]
+    public void InvalidTtl_ReturnsValidationErrorIncludingTtl()
+    {
+        // Arrange
+        var ttl = TimeSpan.FromSeconds(-5);
+
+        // Act
+        var error = CachingErrors.InvalidTtl(ttl);
+
+        // Assert
+        error.Code.Should().Be("Caching.InvalidTtl");
+        error.Type.Should().Be(ErrorType.Validation);
+        error.Message.Should().Contain(ttl.ToString());
+    }
+
+    [Fact]
+    public void BackendFailure_ReturnsFailureWithMessage()
+    {
+        // Act
+        var error = CachingErrors.BackendFailure("Redis unreachable");
+
+        // Assert
+        error.Code.Should().Be("Caching.BackendFailure");
+        error.Type.Should().Be(ErrorType.Failure);
+        error.Message.Should().Be("Redis unreachable");
+    }
+}

--- a/tests/Unit/Compendium.Abstractions.Caching.Tests/Compendium.Abstractions.Caching.Tests.csproj
+++ b/tests/Unit/Compendium.Abstractions.Caching.Tests/Compendium.Abstractions.Caching.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Compendium.Abstractions.Caching.Tests</AssemblyName>
+    <RootNamespace>Compendium.Abstractions.Caching.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Abstractions\Compendium.Abstractions.Caching\Compendium.Abstractions.Caching.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit/Compendium.Abstractions.Caching.Tests/GlobalUsings.cs
+++ b/tests/Unit/Compendium.Abstractions.Caching.Tests/GlobalUsings.cs
@@ -1,0 +1,12 @@
+// -----------------------------------------------------------------------
+// <copyright file="GlobalUsings.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+global using Xunit;
+global using FluentAssertions;
+global using NSubstitute;
+global using Compendium.Abstractions.Caching;
+global using Compendium.Core.Results;

--- a/tests/Unit/Compendium.Infrastructure.Tests/Caching/InMemoryCacheTests.cs
+++ b/tests/Unit/Compendium.Infrastructure.Tests/Caching/InMemoryCacheTests.cs
@@ -1,0 +1,344 @@
+// -----------------------------------------------------------------------
+// <copyright file="InMemoryCacheTests.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Compendium.Abstractions.Caching;
+using Compendium.Infrastructure.Caching;
+using Compendium.Multitenancy;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Compendium.Infrastructure.Tests.Caching;
+
+public sealed class InMemoryCacheTests
+{
+    private static InMemoryCache CreateSut(out IMemoryCache memoryCache, ITenantContext? tenant = null)
+    {
+        memoryCache = new MemoryCache(new MemoryCacheOptions());
+        return new InMemoryCache(memoryCache, tenant);
+    }
+
+    [Fact]
+    public void Ctor_NullMemoryCache_Throws()
+    {
+        Action act = () => _ = new InMemoryCache(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task GetAsync_MissingKey_ReturnsSuccessWithNull()
+    {
+        var sut = CreateSut(out _);
+
+        var result = await sut.GetAsync<string>("missing");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SetAndGet_String_RoundTrip()
+    {
+        var sut = CreateSut(out _);
+
+        await sut.SetAsync("k", "hello");
+        var result = await sut.GetAsync<string>("k");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("hello");
+    }
+
+    [Fact]
+    public async Task SetAndGet_Int_RoundTrip()
+    {
+        var sut = CreateSut(out _);
+
+        await sut.SetAsync("n", 42);
+        var result = await sut.GetAsync<int>("n");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(42);
+    }
+
+    public sealed record Person(string Name, int Age);
+
+    [Fact]
+    public async Task SetAndGet_ComplexRecord_RoundTrip()
+    {
+        var sut = CreateSut(out _);
+        var person = new Person("Ada", 36);
+
+        await sut.SetAsync("person", person);
+        var result = await sut.GetAsync<Person>("person");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(person);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenStoredTypeDiffers_ReturnsNull()
+    {
+        var sut = CreateSut(out _);
+
+        await sut.SetAsync("k", 42);
+
+        // Stored an int; requesting a string → contract returns null (not a failure).
+        var result = await sut.GetAsync<string>("k");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SetAsync_ConfiguresAbsoluteExpirationRelativeToNow_OnEntryOptions()
+    {
+        // Arrange — substitute IMemoryCache so we can inspect the configured options
+        // without relying on wall-clock waits.
+        var memoryCache = Substitute.For<IMemoryCache>();
+        var entry = Substitute.For<ICacheEntry>();
+        entry.AbsoluteExpirationRelativeToNow.Returns((TimeSpan?)null);
+        memoryCache.CreateEntry(Arg.Any<object>()).Returns(entry);
+
+        var sut = new InMemoryCache(memoryCache);
+
+        // Act
+        var ttl = TimeSpan.FromMinutes(5);
+        var result = await sut.SetAsync("k", "v", ttl);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        entry.Received().AbsoluteExpirationRelativeToNow = ttl;
+    }
+
+    [Fact]
+    public async Task SetAsync_NoTtl_LeavesAbsoluteExpirationNull()
+    {
+        // The Set<T> overload always copies options onto the ICacheEntry — what we care
+        // about is that AbsoluteExpirationRelativeToNow stays null (no expiration).
+        TimeSpan? captured = TimeSpan.FromDays(999); // sentinel
+        var memoryCache = Substitute.For<IMemoryCache>();
+        var entry = Substitute.For<ICacheEntry>();
+        entry.When(e => e.AbsoluteExpirationRelativeToNow = Arg.Any<TimeSpan?>())
+             .Do(call => captured = call.Arg<TimeSpan?>());
+        memoryCache.CreateEntry(Arg.Any<object>()).Returns(entry);
+
+        var sut = new InMemoryCache(memoryCache);
+
+        var result = await sut.SetAsync("k", "v");
+
+        result.IsSuccess.Should().BeTrue();
+        captured.Should().BeNull("entries with no TTL must not have an absolute expiration");
+    }
+
+    [Fact]
+    public async Task SetAsync_LiveEntry_PersistsValueWithoutTtl()
+    {
+        // End-to-end check using a real MemoryCache: a value stored without TTL
+        // can be retrieved immediately and on subsequent reads.
+        var sut = CreateSut(out _);
+
+        await sut.SetAsync("k", "v");
+
+        (await sut.GetAsync<string>("k")).Value.Should().Be("v");
+        (await sut.ExistsAsync("k")).Value.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task SetAsync_NonPositiveTtl_ReturnsInvalidTtlFailure(int seconds)
+    {
+        var sut = CreateSut(out _);
+
+        var result = await sut.SetAsync("k", "v", TimeSpan.FromSeconds(seconds));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Caching.InvalidTtl");
+    }
+
+    [Fact]
+    public async Task SetAsync_ShortTtl_ExpiresAfterWait()
+    {
+        var sut = CreateSut(out _);
+
+        await sut.SetAsync("k", "v", TimeSpan.FromMilliseconds(50));
+        await Task.Delay(200);
+
+        var result = await sut.GetAsync<string>("k");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RemoveAsync_AfterSet_GetReturnsNull()
+    {
+        var sut = CreateSut(out _);
+
+        await sut.SetAsync("k", "v");
+        var remove = await sut.RemoveAsync("k");
+        var get = await sut.GetAsync<string>("k");
+
+        remove.IsSuccess.Should().BeTrue();
+        get.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RemoveAsync_MissingKey_IsSuccess()
+    {
+        var sut = CreateSut(out _);
+
+        var result = await sut.RemoveAsync("never-set");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_MissingKey_ReturnsFalse()
+    {
+        var sut = CreateSut(out _);
+
+        var result = await sut.ExistsAsync("missing");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExistsAsync_AfterSet_ReturnsTrue()
+    {
+        var sut = CreateSut(out _);
+
+        await sut.SetAsync("k", "v");
+        var result = await sut.ExistsAsync("k");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task NullOrWhitespaceKey_AcrossAllOps_Throws(string? key)
+    {
+        var sut = CreateSut(out _);
+
+        var get = () => sut.GetAsync<string>(key!);
+        var set = () => sut.SetAsync(key!, "v");
+        var remove = () => sut.RemoveAsync(key!);
+        var exists = () => sut.ExistsAsync(key!);
+
+        await get.Should().ThrowAsync<ArgumentException>();
+        await set.Should().ThrowAsync<ArgumentException>();
+        await remove.Should().ThrowAsync<ArgumentException>();
+        await exists.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task TenantPrefix_KeysAreIsolatedBetweenTenants()
+    {
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var tenantA = new TenantContext();
+        tenantA.SetTenant(new TenantInfo { Id = "tenant-a" });
+        var tenantB = new TenantContext();
+        tenantB.SetTenant(new TenantInfo { Id = "tenant-b" });
+
+        var cacheA = new InMemoryCache(memoryCache, tenantA);
+        var cacheB = new InMemoryCache(memoryCache, tenantB);
+
+        await cacheA.SetAsync("x", "from-A");
+
+        (await cacheA.GetAsync<string>("x")).Value.Should().Be("from-A");
+        (await cacheB.GetAsync<string>("x")).Value.Should().BeNull();
+        (await cacheB.ExistsAsync("x")).Value.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task NoTenantContext_WritesAndReadsWithoutPrefix()
+    {
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var sut = new InMemoryCache(memoryCache);
+
+        await sut.SetAsync("x", "raw");
+
+        // Sanity check: the underlying entry is stored at the unprefixed key.
+        memoryCache.TryGetValue("x", out var raw).Should().BeTrue();
+        raw.Should().Be("raw");
+
+        (await sut.GetAsync<string>("x")).Value.Should().Be("raw");
+    }
+
+    [Fact]
+    public async Task EmptyTenantId_IsTreatedAsNoTenant()
+    {
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var emptyTenant = new TenantContext();
+        emptyTenant.SetTenant(new TenantInfo { Id = string.Empty });
+
+        var sut = new InMemoryCache(memoryCache, emptyTenant);
+
+        await sut.SetAsync("x", "raw");
+
+        memoryCache.TryGetValue("x", out var raw).Should().BeTrue();
+        raw.Should().Be("raw");
+    }
+
+    [Fact]
+    public async Task TenantPrefix_AppearsInUnderlyingKey()
+    {
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var tenant = new TenantContext();
+        tenant.SetTenant(new TenantInfo { Id = "acme" });
+
+        var sut = new InMemoryCache(memoryCache, tenant);
+
+        await sut.SetAsync("x", "v");
+
+        memoryCache.TryGetValue("acme:x", out var raw).Should().BeTrue();
+        raw.Should().Be("v");
+        // The unprefixed key alone is not present.
+        memoryCache.TryGetValue("x", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AddInMemoryCache_RegistersICache_ResolvableFromServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddInMemoryCache();
+
+        using var sp = services.BuildServiceProvider();
+
+        var cache = sp.GetService<ICache>();
+        cache.Should().NotBeNull();
+        cache.Should().BeOfType<InMemoryCache>();
+
+        var memory = sp.GetService<IMemoryCache>();
+        memory.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddInMemoryCache_WithConfigure_AppliesMemoryCacheOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddInMemoryCache(opts => opts.SizeLimit = 123);
+
+        using var sp = services.BuildServiceProvider();
+
+        var options = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<MemoryCacheOptions>>();
+        options.Value.SizeLimit.Should().Be(123);
+
+        sp.GetService<ICache>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddInMemoryCache_NullServices_Throws()
+    {
+        IServiceCollection? services = null;
+        Action act = () => services!.AddInMemoryCache();
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Decision: define `ICache` here (Option B)

Investigation confirmed there is **no existing `ICache` port** in either `Compendium.Abstractions` or any sibling assembly (verified via `grep` across `src/` and the `compendium-adapter-redis@1.0.0` package contents — it ships only `Idempotency/` + `Projections/`, no caching). So the contract is defined here, in a new per-port assembly **`Compendium.Abstractions.Caching`**, matching the project layout already used for Storage, Search, VectorStore, etc.

## Summary

- **`Compendium.Abstractions.Caching`** — new port assembly with `ICache` (Get/Set/Remove/Exists, optional TTL, `Result<T>` throughout) and `CachingErrors` (`InvalidTtl`, `BackendFailure`).
- **`Compendium.Infrastructure/Caching/InMemoryCache`** — `IMemoryCache`-backed implementation. Optional `ITenantContext` injection: a non-empty `TenantId` scopes every key as `{tenantId}:{key}`. No tenant / empty tenant → keys are written verbatim. Cache misses are `Result.Success(null)`, never failures.
- **DI**: `AddInMemoryCache(IServiceCollection, Action<MemoryCacheOptions>? configure = null)` registers `IMemoryCache` (idempotent) + `ICache → InMemoryCache` singleton.
- `Microsoft.Extensions.Caching.{Abstractions,Memory}` pinned at `9.0.16` in `Directory.Packages.props`.
- **No changes to the Redis adapter** — that repo's README will be updated in a separate follow-up.

## Files

- `src/Abstractions/Compendium.Abstractions.Caching/{ICache,CachingErrors,GlobalUsings}.cs` + `.csproj`
- `src/Infrastructure/Compendium.Infrastructure/Caching/{InMemoryCache,ServiceCollectionExtensions}.cs`
- `tests/Unit/Compendium.Abstractions.Caching.Tests/CachingErrorsTests.cs` (3 tests)
- `tests/Unit/Compendium.Infrastructure.Tests/Caching/InMemoryCacheTests.cs` (23 tests)
- `Directory.Packages.props`, `Compendium.Infrastructure.csproj`, `Compendium.sln`

## Coverage (per-class, line / branch)

| Class | Line | Branch |
|---|---|---|
| `Compendium.Infrastructure.Caching.InMemoryCache` | 100% | 100% |
| `Compendium.Infrastructure.Caching.ServiceCollectionExtensions` | 100% | 100% |
| `Compendium.Abstractions.Caching.CachingErrors` | 100% | 100% (via abstraction tests) |

`ICache` itself is an interface and contributes no IL to coverage instrumentation.

## Test plan

- [x] `dotnet build Compendium.sln -c Release` — **0 errors**, warnings unchanged from baseline (104 → 104).
- [x] `dotnet test tests/Unit/Compendium.Infrastructure.Tests` — **595 passed / 2 skipped (pre-existing) / 0 failed**.
- [x] `dotnet test tests/Unit/Compendium.Abstractions.Caching.Tests` — **3 passed**.
- [x] Architecture tests (`HexagonalLayeringTests`, etc.) — **37 passed**, no new layering violations.
- [x] Full unit + architecture test pass across all 31 assemblies — 0 failures.
- [x] Coverage: ≥95% target met (100% line / 100% branch on the new code).

## Constraints checked

- Branch `feat/inmemory-cache` against `main`. **No tag.**
- No edits to the Redis adapter repo.
- `Microsoft.Extensions.Caching.*` versions match the existing 9.0.16 `Microsoft.Extensions.*` band.
- Followed `compendium-test-author` conventions (xUnit / FluentAssertions / NSubstitute, no `Thread.Sleep`, TTL configuration verified via `ICacheEntry` substitution rather than wall-clock).