### PR TITLE
fix(application): log swallowed handler exceptions before wrapping in Result.Failure

### DIFF
--- a/src/Application/Compendium.Application/CQRS/CommandDispatcher.cs
+++ b/src/Application/Compendium.Application/CQRS/CommandDispatcher.cs
@@ -2,6 +2,8 @@ using System.Diagnostics;
 using Compendium.Application.CQRS.Behaviors;
 using Compendium.Core.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Compendium.Application.CQRS;
 
@@ -40,15 +42,23 @@ public interface ICommandDispatcher
 public sealed class CommandDispatcher : ICommandDispatcher
 {
     private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<CommandDispatcher> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CommandDispatcher"/> class.
     /// </summary>
     /// <param name="serviceProvider">The service provider for resolving handlers and behaviors.</param>
     /// <exception cref="ArgumentNullException">Thrown when serviceProvider is null.</exception>
+    /// <remarks>
+    /// P0-02: The logger is resolved from <paramref name="serviceProvider"/> rather than injected
+    /// directly so that the existing public single-parameter constructor remains binary- and
+    /// source-compatible for downstream consumers. When the container has no logging configured
+    /// (e.g. in lightweight unit tests) a <see cref="NullLogger{T}"/> is used as a safe fallback.
+    /// </remarks>
     public CommandDispatcher(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _logger = _serviceProvider.GetService<ILogger<CommandDispatcher>>() ?? NullLogger<CommandDispatcher>.Instance;
     }
 
     /// <summary>
@@ -139,7 +149,20 @@ public sealed class CommandDispatcher : ICommandDispatcher
             activity?.SetTag("exception.type", ex.GetType().FullName);
             activity?.SetTag("exception.message", ex.Message);
 
-            return Result.Failure(Error.Failure("Command.ExecutionFailed", ex.Message));
+            // P0-02: Log the swallowed exception with stack trace BEFORE wrapping it into a
+            // Result.Failure. Without this, production debugging is blind — the exception is
+            // converted to a failure Result and the only trace is on OTel spans.
+            _logger.LogError(
+                ex,
+                "Command handler for {CommandType} threw an unhandled exception after {ElapsedMs}ms; converting to Result.Failure({ErrorCode})",
+                typeof(TCommand).Name,
+                sw.Elapsed.TotalMilliseconds,
+                "Command.ExecutionFailed");
+
+            return Result.Failure(Error.Failure(
+                "Command.ExecutionFailed",
+                ex.Message,
+                BuildExceptionMetadata(ex)));
         }
     }
 
@@ -232,8 +255,37 @@ public sealed class CommandDispatcher : ICommandDispatcher
             activity?.SetTag("exception.type", ex.GetType().FullName);
             activity?.SetTag("exception.message", ex.Message);
 
-            return Result.Failure<TResult>(Error.Failure("Command.ExecutionFailed", ex.Message));
+            // P0-02: Log the swallowed exception with stack trace BEFORE wrapping it into a
+            // Result.Failure. Without this, production debugging is blind — the exception is
+            // converted to a failure Result and the only trace is on OTel spans.
+            _logger.LogError(
+                ex,
+                "Command handler for {CommandType} returning {ResultType} threw an unhandled exception after {ElapsedMs}ms; converting to Result.Failure({ErrorCode})",
+                typeof(TCommand).Name,
+                typeof(TResult).Name,
+                sw.Elapsed.TotalMilliseconds,
+                "Command.ExecutionFailed");
+
+            return Result.Failure<TResult>(Error.Failure(
+                "Command.ExecutionFailed",
+                ex.Message,
+                BuildExceptionMetadata(ex)));
         }
+    }
+
+    /// <summary>
+    /// Builds the error metadata dictionary attached to an execution-failure error, capturing the
+    /// exception type so downstream consumers can discriminate the underlying failure cause without
+    /// parsing the message string. P0-02.
+    /// </summary>
+    /// <param name="exception">The exception that was thrown by the handler pipeline.</param>
+    /// <returns>A read-only metadata dictionary containing the exception type name.</returns>
+    private static IReadOnlyDictionary<string, object> BuildExceptionMetadata(Exception exception)
+    {
+        return new Dictionary<string, object>
+        {
+            ["exceptionType"] = exception.GetType().FullName ?? exception.GetType().Name,
+        };
     }
 
     /// <summary>

--- a/src/Application/Compendium.Application/CQRS/QueryDispatcher.cs
+++ b/src/Application/Compendium.Application/CQRS/QueryDispatcher.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using Compendium.Core.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Compendium.Application.CQRS;
 
@@ -29,15 +31,23 @@ public interface IQueryDispatcher
 public sealed class QueryDispatcher : IQueryDispatcher
 {
     private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<QueryDispatcher> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="QueryDispatcher"/> class.
     /// </summary>
     /// <param name="serviceProvider">The service provider for resolving handlers.</param>
     /// <exception cref="ArgumentNullException">Thrown when serviceProvider is null.</exception>
+    /// <remarks>
+    /// P0-02: The logger is resolved from <paramref name="serviceProvider"/> rather than injected
+    /// directly so that the existing public single-parameter constructor remains binary- and
+    /// source-compatible for downstream consumers. When the container has no logging configured
+    /// (e.g. in lightweight unit tests) a <see cref="NullLogger{T}"/> is used as a safe fallback.
+    /// </remarks>
     public QueryDispatcher(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _logger = _serviceProvider.GetService<ILogger<QueryDispatcher>>() ?? NullLogger<QueryDispatcher>.Instance;
     }
 
     /// <summary>
@@ -116,7 +126,36 @@ public sealed class QueryDispatcher : IQueryDispatcher
             activity?.SetTag("exception.type", ex.GetType().FullName);
             activity?.SetTag("exception.message", ex.Message);
 
-            return Result.Failure<TResult>(Error.Failure("Query.ExecutionFailed", ex.Message));
+            // P0-02: Log the swallowed exception with stack trace BEFORE wrapping it into a
+            // Result.Failure. Without this, production debugging is blind — the exception is
+            // converted to a failure Result and the only trace is on OTel spans.
+            _logger.LogError(
+                ex,
+                "Query handler for {QueryType} returning {ResultType} threw an unhandled exception after {ElapsedMs}ms; converting to Result.Failure({ErrorCode})",
+                typeof(TQuery).Name,
+                typeof(TResult).Name,
+                sw.Elapsed.TotalMilliseconds,
+                "Query.ExecutionFailed");
+
+            return Result.Failure<TResult>(Error.Failure(
+                "Query.ExecutionFailed",
+                ex.Message,
+                BuildExceptionMetadata(ex)));
         }
+    }
+
+    /// <summary>
+    /// Builds the error metadata dictionary attached to an execution-failure error, capturing the
+    /// exception type so downstream consumers can discriminate the underlying failure cause without
+    /// parsing the message string. P0-02.
+    /// </summary>
+    /// <param name="exception">The exception that was thrown by the handler.</param>
+    /// <returns>A read-only metadata dictionary containing the exception type name.</returns>
+    private static IReadOnlyDictionary<string, object> BuildExceptionMetadata(Exception exception)
+    {
+        return new Dictionary<string, object>
+        {
+            ["exceptionType"] = exception.GetType().FullName ?? exception.GetType().Name,
+        };
     }
 }

--- a/tests/Unit/Compendium.Application.Tests/CQRS/CapturingLogger.cs
+++ b/tests/Unit/Compendium.Application.Tests/CQRS/CapturingLogger.cs
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="CapturingLogger.cs" company="Sassy Solutions">
+//     Copyright (c) 2026 Sassy Solutions. Licensed under the MIT License.
+//     See LICENSE in the project root for license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Compendium.Application.Tests.CQRS;
+
+/// <summary>
+/// A minimal in-memory <see cref="ILogger{T}"/> implementation that records every log entry it
+/// receives. Used to assert that the CQRS dispatchers log swallowed handler exceptions (P0-02)
+/// before wrapping them into a <see cref="Result"/> failure. Avoids taking a dependency on
+/// <c>Microsoft.Extensions.Diagnostics.Testing</c> just for the <c>FakeLogger</c> type.
+/// </summary>
+/// <typeparam name="T">The category type for the logger.</typeparam>
+public sealed class CapturingLogger<T> : ILogger<T>
+{
+    private readonly List<CapturedLogEntry> _entries = [];
+
+    /// <summary>
+    /// Gets the captured log entries in the order they were recorded.
+    /// </summary>
+    public IReadOnlyList<CapturedLogEntry> Entries => _entries;
+
+    /// <inheritdoc />
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull => NullScope.Instance;
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    /// <inheritdoc />
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        _entries.Add(new CapturedLogEntry(logLevel, exception, formatter(state, exception)));
+    }
+
+    /// <summary>
+    /// Represents a single captured log entry.
+    /// </summary>
+    /// <param name="Level">The log level.</param>
+    /// <param name="Exception">The exception associated with the entry, if any.</param>
+    /// <param name="Message">The rendered log message.</param>
+    public sealed record CapturedLogEntry(LogLevel Level, Exception? Exception, string Message);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+            // No-op.
+        }
+    }
+}

--- a/tests/Unit/Compendium.Application.Tests/CQRS/CommandDispatcherTests.cs
+++ b/tests/Unit/Compendium.Application.Tests/CQRS/CommandDispatcherTests.cs
@@ -8,6 +8,7 @@
 using Compendium.Application.CQRS;
 using Compendium.Application.CQRS.Behaviors;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Compendium.Application.Tests.CQRS;
 
@@ -131,6 +132,116 @@ public class CommandDispatcherTests
         result.IsFailure.Should().BeTrue();
         result.Error.Code.Should().Be("Command.ExecutionFailed");
         result.Error.Message.Should().Contain("kaboom");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenHandlerThrows_LogsExceptionBeforeWrappingInFailure()
+    {
+        // Arrange
+        var thrown = new InvalidOperationException("kaboom");
+        var handler = Substitute.For<ICommandHandler<TestCommand>>();
+        handler.HandleAsync(Arg.Any<TestCommand>(), Arg.Any<CancellationToken>())
+            .Returns<Task<Result>>(_ => throw thrown);
+
+        var logger = new CapturingLogger<CommandDispatcher>();
+        var sp = new ServiceCollection()
+            .AddSingleton(handler)
+            .AddSingleton<ILogger<CommandDispatcher>>(logger)
+            .BuildServiceProvider();
+        var dispatcher = new CommandDispatcher(sp);
+
+        // Act
+        var result = await dispatcher.DispatchAsync(new TestCommand(), CancellationToken.None);
+
+        // Assert — the Result contract is preserved (P0-02: never rethrow)
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Command.ExecutionFailed");
+
+        // Assert — the exception was logged with its stack trace, not silently swallowed
+        var errorEntry = logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Error).Subject;
+        errorEntry.Exception.Should().BeSameAs(thrown);
+        errorEntry.Message.Should().Contain(nameof(TestCommand));
+
+        // Assert — the exception type is preserved in the error metadata (non-breaking enrichment)
+        result.Error.Metadata.Should().ContainKey("exceptionType");
+        result.Error.Metadata["exceptionType"].Should().Be(typeof(InvalidOperationException).FullName);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenNoLoggerRegistered_StillReturnsFailureWithoutThrowing()
+    {
+        // Arrange — no ILogger registered; dispatcher must fall back to NullLogger and not throw
+        var handler = Substitute.For<ICommandHandler<TestCommand>>();
+        handler.HandleAsync(Arg.Any<TestCommand>(), Arg.Any<CancellationToken>())
+            .Returns<Task<Result>>(_ => throw new InvalidOperationException("kaboom"));
+
+        var sp = new ServiceCollection()
+            .AddSingleton(handler)
+            .BuildServiceProvider();
+        var dispatcher = new CommandDispatcher(sp);
+
+        // Act
+        var result = await dispatcher.DispatchAsync(new TestCommand(), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Command.ExecutionFailed");
+    }
+
+    [Fact]
+    public async Task DispatchAsyncTResult_WhenHandlerThrows_LogsExceptionBeforeWrappingInFailure()
+    {
+        // Arrange
+        var thrown = new InvalidOperationException("oops");
+        var handler = Substitute.For<ICommandHandler<TestCommandWithResult, int>>();
+        handler.HandleAsync(Arg.Any<TestCommandWithResult>(), Arg.Any<CancellationToken>())
+            .Returns<Task<Result<int>>>(_ => throw thrown);
+
+        var logger = new CapturingLogger<CommandDispatcher>();
+        var sp = new ServiceCollection()
+            .AddSingleton(handler)
+            .AddSingleton<ILogger<CommandDispatcher>>(logger)
+            .BuildServiceProvider();
+        var dispatcher = new CommandDispatcher(sp);
+
+        // Act
+        var result = await dispatcher.DispatchAsync<TestCommandWithResult, int>(
+            new TestCommandWithResult { Value = 1 },
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Command.ExecutionFailed");
+
+        var errorEntry = logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Error).Subject;
+        errorEntry.Exception.Should().BeSameAs(thrown);
+        errorEntry.Message.Should().Contain(nameof(TestCommandWithResult));
+
+        result.Error.Metadata.Should().ContainKey("exceptionType");
+        result.Error.Metadata["exceptionType"].Should().Be(typeof(InvalidOperationException).FullName);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenHandlerSucceeds_DoesNotLogError()
+    {
+        // Arrange
+        var handler = Substitute.For<ICommandHandler<TestCommand>>();
+        handler.HandleAsync(Arg.Any<TestCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success()));
+
+        var logger = new CapturingLogger<CommandDispatcher>();
+        var sp = new ServiceCollection()
+            .AddSingleton(handler)
+            .AddSingleton<ILogger<CommandDispatcher>>(logger)
+            .BuildServiceProvider();
+        var dispatcher = new CommandDispatcher(sp);
+
+        // Act
+        var result = await dispatcher.DispatchAsync(new TestCommand(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        logger.Entries.Should().NotContain(e => e.Level == LogLevel.Error);
     }
 
     [Fact]

--- a/tests/Unit/Compendium.Application.Tests/CQRS/QueryDispatcherTests.cs
+++ b/tests/Unit/Compendium.Application.Tests/CQRS/QueryDispatcherTests.cs
@@ -7,6 +7,7 @@
 
 using Compendium.Application.CQRS;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Compendium.Application.Tests.CQRS;
 
@@ -133,5 +134,88 @@ public class QueryDispatcherTests
         result.IsFailure.Should().BeTrue();
         result.Error.Code.Should().Be("Query.ExecutionFailed");
         result.Error.Message.Should().Contain("query bad");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenHandlerThrows_LogsExceptionBeforeWrappingInFailure()
+    {
+        // Arrange
+        var thrown = new InvalidOperationException("query bad");
+        var handler = Substitute.For<IQueryHandler<TestQuery, string>>();
+        handler.HandleAsync(Arg.Any<TestQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<Result<string>>>(_ => throw thrown);
+
+        var logger = new CapturingLogger<QueryDispatcher>();
+        var sp = new ServiceCollection()
+            .AddSingleton(handler)
+            .AddSingleton<ILogger<QueryDispatcher>>(logger)
+            .BuildServiceProvider();
+        var dispatcher = new QueryDispatcher(sp);
+
+        // Act
+        var result = await dispatcher.DispatchAsync<TestQuery, string>(
+            new TestQuery(),
+            CancellationToken.None);
+
+        // Assert — the Result contract is preserved (P0-02: never rethrow)
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Query.ExecutionFailed");
+
+        // Assert — the exception was logged with its stack trace, not silently swallowed
+        var errorEntry = logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Error).Subject;
+        errorEntry.Exception.Should().BeSameAs(thrown);
+        errorEntry.Message.Should().Contain(nameof(TestQuery));
+
+        // Assert — the exception type is preserved in the error metadata (non-breaking enrichment)
+        result.Error.Metadata.Should().ContainKey("exceptionType");
+        result.Error.Metadata["exceptionType"].Should().Be(typeof(InvalidOperationException).FullName);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenNoLoggerRegistered_StillReturnsFailureWithoutThrowing()
+    {
+        // Arrange — no ILogger registered; dispatcher must fall back to NullLogger and not throw
+        var handler = Substitute.For<IQueryHandler<TestQuery, string>>();
+        handler.HandleAsync(Arg.Any<TestQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<Result<string>>>(_ => throw new InvalidOperationException("query bad"));
+
+        var sp = new ServiceCollection()
+            .AddSingleton(handler)
+            .BuildServiceProvider();
+        var dispatcher = new QueryDispatcher(sp);
+
+        // Act
+        var result = await dispatcher.DispatchAsync<TestQuery, string>(
+            new TestQuery(),
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Query.ExecutionFailed");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenHandlerSucceeds_DoesNotLogError()
+    {
+        // Arrange
+        var handler = Substitute.For<IQueryHandler<TestQuery, string>>();
+        handler.HandleAsync(Arg.Any<TestQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result.Success("hello")));
+
+        var logger = new CapturingLogger<QueryDispatcher>();
+        var sp = new ServiceCollection()
+            .AddSingleton(handler)
+            .AddSingleton<ILogger<QueryDispatcher>>(logger)
+            .BuildServiceProvider();
+        var dispatcher = new QueryDispatcher(sp);
+
+        // Act
+        var result = await dispatcher.DispatchAsync<TestQuery, string>(
+            new TestQuery(),
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        logger.Entries.Should().NotContain(e => e.Level == LogLevel.Error);
     }
 }


### PR DESCRIPTION
## P0-02 — Dispatcher swallows handler exceptions silently

The Compendium command/query dispatchers convert **any** exception thrown inside a handler into
`Result.Failure(Error.Failure("*.ExecutionFailed", ex.Message))` **without logging the exception or
stack trace**. In production this makes debugging blind: the only trace is on OTel spans
(`exception.type` / `exception.message` activity tags), which are not always sampled or retained.

Refs:
- Nexus bug inventory **P0-02**
- Memory note `project_compendium_dispatcher_silent`
- Nexus PR #86 added an HTTP-layer `ProblemDetailsLoggingFilter` that only **partially** mitigated this (REST surface only — MCP, SDK, background/process-manager dispatch paths still went dark).

## What changed

Three swallow points fixed (`CommandDispatcher.DispatchAsync<TCommand>`,
`CommandDispatcher.DispatchAsync<TCommand,TResult>`, `QueryDispatcher.DispatchAsync<TQuery,TResult>`):

1. **Structured error logging before wrapping.** Each catch block now calls
   `_logger.LogError(ex, "...", commandOrQueryType, ...)` — logging the full exception (with stack
   trace) at `Error` level **before** building the failure `Result`.
2. **No public API break.** Both dispatchers already receive `IServiceProvider` only. Rather than
   change the public single-argument constructor (which downstream consumers call directly — see the
   existing unit tests), the logger is **resolved from the service provider** with a
   `NullLogger<T>` fallback when no logging is configured. Binary- and source-compatible.
3. **Non-breaking error enrichment.** `Error.Failure(...)` already supports an optional `metadata`
   dictionary, so the failure error now carries `{ exceptionType }` — letting consumers discriminate
   the underlying cause without string-parsing `Error.Message`.
4. **Result contract preserved.** Still returns `Result.Failure`, never rethrows.

The pre-existing `LoggingBehavior<TRequest,TResponse>` only logs when registered as a pipeline
behavior and rethrows; the dispatcher catch sits outside the behavior pipeline and is the final,
unconditional swallow point — which is exactly what this fixes.

## Tests

Added to `CommandDispatcherTests` / `QueryDispatcherTests` (+ a tiny `CapturingLogger<T>` helper to
avoid a new `Microsoft.Extensions.Diagnostics.Testing` dependency):

- handler throws → `Result.Failure` returned **AND** logger received the exception at `Error` level
  **AND** `exceptionType` metadata present (command no-result, command-with-result, and query paths)
- no `ILogger` registered → falls back to `NullLogger`, still returns failure, does not throw
- success path → no `Error`-level log emitted

`dotnet test Compendium.Application.Tests` → **232 passed**. Architecture tests → **37 passed**.

## Notes
- The legacy `[Obsolete]` `SagaOrchestrator` (slated for removal in v1.0) has similar catch-and-wrap
  blocks but is deprecated dead-path; intentionally **out of scope** for this focused P0 fix. The live
  choreography path (`ChoreographyRouter`) already aggregates handler errors with messages.